### PR TITLE
[DO NOT MERGE] - K8S Conversion to using Replica Sets

### DIFF
--- a/heron/config/src/yaml/conf/kubernetes/packing.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/packing.yaml
@@ -1,2 +1,3 @@
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    com.twitter.heron.packing.roundrobin.RoundRobinPacking
+heron.class.repacking.algorithm:  com.twitter.heron.packing.binpacking.FirstFitDecreasingPacking

--- a/heron/config/src/yaml/conf/kubernetes/packing.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/packing.yaml
@@ -1,3 +1,2 @@
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    com.twitter.heron.packing.roundrobin.RoundRobinPacking
-heron.class.repacking.algorithm:  com.twitter.heron.packing.binpacking.FirstFitDecreasingPacking

--- a/heron/config/src/yaml/conf/kubernetes/scheduler.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/scheduler.yaml
@@ -37,4 +37,4 @@ heron.scheduler.tunnel.retry.interval.ms:        1000
 heron.scheduler.tunnel.verify.count:             10
 
 # SSH tunnel host
-heron.scheduler.tunnel.host:              john@35.202.157.213
+heron.scheduler.tunnel.host:              <user>@<k8s_host>

--- a/heron/config/src/yaml/conf/kubernetes/scheduler.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/scheduler.yaml
@@ -14,10 +14,27 @@ heron.directory.conf:                       "./heron-conf/"
 heron.directory.home:                       $HERON_HOME
 
 # The URI of kubernetes API
-heron.kubernetes.scheduler.uri:             <kubernetes_api_addr>
+heron.kubernetes.scheduler.uri:             http://localhost:8001
 
 # Invoke the IScheduler as a library directly
 heron.scheduler.is.service:                  False
 
 # docker repo for executor
-heron.executor.docker.image:                'ndustrialio/heron-core:latest'
+heron.executor.docker.image:                'streamlio/heron:latest'
+
+heron.scheduler.is.tunnel.needed: True
+
+# The connection timeout in ms when trying to connect to zk server
+heron.scheduler.tunnel.connection.timeout.ms:    1000
+
+# The count of retry to check whether has direct access on zk server
+heron.scheduler.tunnel.connection.retry.count:   2
+
+# The interval in ms between two retry checking whether has direct access on zk server
+heron.scheduler.tunnel.retry.interval.ms:        1000
+
+# The count of retry to verify whether seting up a tunnel process
+heron.scheduler.tunnel.verify.count:             10
+
+# SSH tunnel host
+heron.scheduler.tunnel.host:              john@35.202.157.213

--- a/heron/config/src/yaml/conf/kubernetes/statemgr.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/statemgr.yaml
@@ -2,7 +2,7 @@
 heron.class.state.manager: com.twitter.heron.statemgr.zookeeper.curator.CuratorStateManager
 
 # local state manager connection string
-heron.statemgr.connection.string:  10.23.251.30:2181
+heron.statemgr.connection.string:  <zk_host>:2181
 
 # path of the root address to store the state in a local file system
 heron.statemgr.root.path: "/heron"
@@ -36,4 +36,4 @@ heron.statemgr.tunnel.retry.interval.ms:        1000
 heron.statemgr.tunnel.verify.count:             10
 
 # SSH tunnel host
-heron.statemgr.tunnel.host:              john@35.202.157.213
+heron.statemgr.tunnel.host:              <user>@<k8s_host>

--- a/heron/config/src/yaml/conf/kubernetes/statemgr.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/statemgr.yaml
@@ -2,7 +2,7 @@
 heron.class.state.manager: com.twitter.heron.statemgr.zookeeper.curator.CuratorStateManager
 
 # local state manager connection string
-heron.statemgr.connection.string:  <zookeeper_host:zookeeper_port>
+heron.statemgr.connection.string:  10.23.251.30:2181
 
 # path of the root address to store the state in a local file system
 heron.statemgr.root.path: "/heron"
@@ -21,3 +21,19 @@ heron.statemgr.zookeeper.retry.count: 10
 
 # duration of time to wait until the next retry
 heron.statemgr.zookeeper.retry.interval.ms: 10000
+
+heron.statemgr.is.tunnel.needed: True
+
+heron.statemgr.tunnel.connection.timeout.ms:    1000
+
+# The count of retry to check whether has direct access on zk server
+heron.statemgr.tunnel.connection.retry.count:   2
+
+# The interval in ms between two retry checking whether has direct access on zk server
+heron.statemgr.tunnel.retry.interval.ms:        1000
+
+# The count of retry to verify whether seting up a tunnel process
+heron.statemgr.tunnel.verify.count:             10
+
+# SSH tunnel host
+heron.statemgr.tunnel.host:              john@35.202.157.213

--- a/heron/config/src/yaml/conf/kubernetes/uploader.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/uploader.yaml
@@ -2,10 +2,10 @@
 heron.class.uploader:                            com.twitter.heron.uploader.s3.S3Uploader
 
 # S3 bucket to put the jar file into
-heron.uploader.s3.bucket: <bucket_name>
+heron.uploader.s3.bucket: <s3_bucket>
 
 # AWS access key
-heron.uploader.s3.access_key: <access_key>
+heron.uploader.s3.access_key: <aws_access_key>
 
 # AWS secret access key
-heron.uploader.s3.secret_key: <secret_key>
+heron.uploader.s3.secret_key: <aws_secret_key>

--- a/heron/config/src/yaml/conf/kubernetes/uploader.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/uploader.yaml
@@ -2,10 +2,10 @@
 heron.class.uploader:                            com.twitter.heron.uploader.s3.S3Uploader
 
 # S3 bucket to put the jar file into
-heron.uploader.s3.bucket: heron-topologies-public
+heron.uploader.s3.bucket: <bucket_name>
 
 # AWS access key
-heron.uploader.s3.access_key: AKIAIYOB7YJA27HCBM7Q
+heron.uploader.s3.access_key: <access_key>
 
 # AWS secret access key
-heron.uploader.s3.secret_key: 6gRjeWDRvMDBAyxhDsgIkYAE+moVngvCoMsOPgQF
+heron.uploader.s3.secret_key: <secret_key>

--- a/heron/config/src/yaml/conf/kubernetes/uploader.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/uploader.yaml
@@ -2,10 +2,10 @@
 heron.class.uploader:                            com.twitter.heron.uploader.s3.S3Uploader
 
 # S3 bucket to put the jar file into
-heron.uploader.s3.bucket: <s3_bucket>
+heron.uploader.s3.bucket: heron-topologies-public
 
 # AWS access key
-heron.uploader.s3.access_key: <aws_access_key>
+heron.uploader.s3.access_key: AKIAIYOB7YJA27HCBM7Q
 
 # AWS secret access key
-heron.uploader.s3.secret_key: <aws_secret_key>
+heron.uploader.s3.secret_key: 6gRjeWDRvMDBAyxhDsgIkYAE+moVngvCoMsOPgQF

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -38,9 +38,9 @@ public final class KubernetesConstants {
   public static final String IMAGE_PULL_POLICY = "imagePullPolicy";
   public static final String DOCKER_CONTAINER_PORT = "containerPort";
   public static final String API_VERSION = "apiVersion";
-  public static final String API_VERSION_1 = "v1";
+  public static final String API_VERSION_1 = "extensions/v1beta1";
   public static final String API_POD = "Pod";
-  public static final String API_RC = "ReplicationController";
+  public static final String API_RC = "ReplicaSet";
   public static final String API_METADATA = "metadata";
   public static final String API_KIND = "kind";
   public static final String METADATA_LABELS = "labels";

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -40,6 +40,7 @@ public final class KubernetesConstants {
   public static final String API_VERSION = "apiVersion";
   public static final String API_VERSION_1 = "v1";
   public static final String API_POD = "Pod";
+  public static final String API_RC = "ReplicationController";
   public static final String API_METADATA = "metadata";
   public static final String API_KIND = "kind";
   public static final String METADATA_LABELS = "labels";

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesController.java
@@ -35,10 +35,11 @@ public class KubernetesController {
                                String topologyName, boolean isVerbose) {
 
     if (kubernetesNamespace == null) {
-      this.baseUriPath = String.format("%s/api/v1/namespaces/default/pods", kubernetesURI);
+      this.baseUriPath = String.format("%s/api/v1/namespaces/default/replicationcontrollers",
+          kubernetesURI);
     } else {
-      this.baseUriPath = String.format("%s/api/v1/namespaces/%s/pods", kubernetesURI,
-          kubernetesNamespace);
+      this.baseUriPath = String.format("%s/api/v1/namespaces/%s/replicationcontrollers",
+          kubernetesURI, kubernetesNamespace);
     }
     this.topologyName = topologyName;
     this.isVerbose = isVerbose;
@@ -67,17 +68,17 @@ public class KubernetesController {
   }
 
   /**
-   * Get information about a pod
+   * Get information about a Replication Controller
    */
-  protected JsonNode getBasePod(String podId) throws IOException {
+  protected JsonNode getBaseRC(String rcId) throws IOException {
 
-    String podURI = String.format(
+    String rcURI = String.format(
         "%s/%s",
         this.baseUriPath,
-        podId);
+        rcId);
 
     // send the delete request to the scheduler
-    HttpJsonClient jsonAPIClient = new HttpJsonClient(podURI);
+    HttpJsonClient jsonAPIClient = new HttpJsonClient(rcURI);
     JsonNode result;
     try {
       result = jsonAPIClient.get(HttpURLConnection.HTTP_OK);
@@ -88,7 +89,7 @@ public class KubernetesController {
   }
 
   /**
-   * Deploy a single container (Pod)
+   * Deploy a single instance (Replication Controller)
    *
    * @param deployConf, the json body as a string
    */
@@ -104,17 +105,17 @@ public class KubernetesController {
   }
 
   /**
-   * Remove a single container (Pod)
+   * Remove a single container (Replication Controller)
    *
-   * @param podId, the pod id (TOPOLOGY_NAME-CONTAINER_INDEX)
+   * @param rcId, the replication controller id (TOPOLOGY_NAME-CONTAINER_INDEX)
    */
-  protected void removeContainer(String podId) throws IOException {
-    String podURI = String.format(
+  protected void removeContainer(String rcId) throws IOException {
+    String rcURI = String.format(
         "%s/%s",
         this.baseUriPath,
-        podId);
+        rcId);
 
-    HttpJsonClient jsonAPIClient = new HttpJsonClient(podURI);
+    HttpJsonClient jsonAPIClient = new HttpJsonClient(rcURI);
     jsonAPIClient.delete(HttpURLConnection.HTTP_OK);
   }
 
@@ -130,7 +131,7 @@ public class KubernetesController {
   }
 
   /**
-   * Submit a topology to kubernetes based on a set of pod configurations
+   * Submit a topology to kubernetes based on a set of replication controller configurations
    */
   protected boolean submitTopology(String[] appConfs) {
 

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesScheduler.java
@@ -197,10 +197,13 @@ public class KubernetesScheduler implements IScheduler, IScalable {
 
     instance.put("replicas", 1);
 
+    ObjectNode matchLabelsInstance = mapper.createObjectNode();
+
+    matchLabelsInstance.put("topology", Runtime.topologyName(runtimeConfiguration));
+
     ObjectNode selectorInstance = mapper.createObjectNode();
 
-    selectorInstance.put(KubernetesConstants.TOPOLOGY_LABEL,
-        Runtime.topologyName(runtimeConfiguration));
+    selectorInstance.set("matchLabels", matchLabelsInstance);
 
     instance.set("selector", selectorInstance);
 
@@ -521,7 +524,7 @@ public class KubernetesScheduler implements IScheduler, IScalable {
     String basePodName = Runtime.topologyName(runtimeConfiguration) + "-0";
     JsonNode podConfig;
     try {
-      podConfig = controller.getBaseRC(basePodName);
+      podConfig = controller.getBaseReplicaSet(basePodName);
     } catch (IOException ioe) {
       throw new TopologyRuntimeManagementException("Unable to retrieve base pod configuration from "
           + basePodName, ioe);

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/kubernetes/KubernetesControllerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/kubernetes/KubernetesControllerTest.java
@@ -94,7 +94,7 @@ public class KubernetesControllerTest {
     // Test a bad GET
     PowerMockito.doThrow(new IOException()).when(httpJsonClient).get(Mockito.anyInt());
     exception.expect(IOException.class);
-    controller.getBasePod(Mockito.anyString());
+    controller.getBaseRC(Mockito.anyString());
 
   }
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/kubernetes/KubernetesControllerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/kubernetes/KubernetesControllerTest.java
@@ -94,7 +94,7 @@ public class KubernetesControllerTest {
     // Test a bad GET
     PowerMockito.doThrow(new IOException()).when(httpJsonClient).get(Mockito.anyInt());
     exception.expect(IOException.class);
-    controller.getBaseRC(Mockito.anyString());
+    controller.getBaseReplicaSet(Mockito.anyString());
 
   }
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/kubernetes/KubernetesSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/kubernetes/KubernetesSchedulerTest.java
@@ -162,18 +162,18 @@ public class KubernetesSchedulerTest {
     Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
 
     // Fail to retrieve base pod
-    Mockito.doThrow(new IOException()).when(controller).getBaseRC(Mockito.anyString());
+    Mockito.doThrow(new IOException()).when(controller).getBaseReplicaSet(Mockito.anyString());
     expectedException.expect(TopologyRuntimeManagementException.class);
     scheduler.addContainers(containers);
 
     // Failure to deploy a container
-    Mockito.doReturn(Mockito.anyString()).when(controller).getBaseRC(Mockito.anyString());
+    Mockito.doReturn(Mockito.anyString()).when(controller).getBaseReplicaSet(Mockito.anyString());
     Mockito.doThrow(new IOException()).when(controller).deployContainer(Mockito.anyString());
     expectedException.expect(TopologyRuntimeManagementException.class);
     scheduler.addContainers(containers);
 
     // Successful deployment
-    Mockito.doReturn(Mockito.anyString()).when(controller).getBaseRC(Mockito.anyString());
+    Mockito.doReturn(Mockito.anyString()).when(controller).getBaseReplicaSet(Mockito.anyString());
     Mockito.doNothing().when(controller).deployContainer(Mockito.anyString());
     scheduler.addContainers(containers);
   }

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/kubernetes/KubernetesSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/kubernetes/KubernetesSchedulerTest.java
@@ -162,18 +162,18 @@ public class KubernetesSchedulerTest {
     Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
 
     // Fail to retrieve base pod
-    Mockito.doThrow(new IOException()).when(controller).getBasePod(Mockito.anyString());
+    Mockito.doThrow(new IOException()).when(controller).getBaseRC(Mockito.anyString());
     expectedException.expect(TopologyRuntimeManagementException.class);
     scheduler.addContainers(containers);
 
     // Failure to deploy a container
-    Mockito.doReturn(Mockito.anyString()).when(controller).getBasePod(Mockito.anyString());
+    Mockito.doReturn(Mockito.anyString()).when(controller).getBaseRC(Mockito.anyString());
     Mockito.doThrow(new IOException()).when(controller).deployContainer(Mockito.anyString());
     expectedException.expect(TopologyRuntimeManagementException.class);
     scheduler.addContainers(containers);
 
     // Successful deployment
-    Mockito.doReturn(Mockito.anyString()).when(controller).getBasePod(Mockito.anyString());
+    Mockito.doReturn(Mockito.anyString()).when(controller).getBaseRC(Mockito.anyString());
     Mockito.doNothing().when(controller).deployContainer(Mockito.anyString());
     scheduler.addContainers(containers);
   }


### PR DESCRIPTION
What?
Changes to the k8s scheduler to use replica sets as the mechanism for deployment of topology containers

Why?
Using pods (previous version) wasn't fault tolerant when k8s nodes would fail.