### PR TITLE
Making emit, ack, and fail thread safe

### DIFF
--- a/heron/instance/src/java/org/apache/heron/instance/AbstractOutputCollector.java
+++ b/heron/instance/src/java/org/apache/heron/instance/AbstractOutputCollector.java
@@ -17,6 +17,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
@@ -40,6 +41,7 @@ public class AbstractOutputCollector {
   private long totalTuplesEmitted;
   private long totalBytesEmitted;
   private PhysicalPlanHelper helper;
+  public final ReentrantLock lock = new ReentrantLock();
 
   /**
    * The SuppressWarnings is only until TOPOLOGY_ENABLE_ACKING exists.
@@ -73,7 +75,7 @@ public class AbstractOutputCollector {
       }
     }
 
-    this.outputter = new OutgoingTupleCollection(helper, streamOutQueue);
+    this.outputter = new OutgoingTupleCollection(helper, streamOutQueue, lock);
   }
 
   public void updatePhysicalPlanHelper(PhysicalPlanHelper physicalPlanHelper) {

--- a/heron/instance/src/java/org/apache/heron/instance/OutgoingTupleCollection.java
+++ b/heron/instance/src/java/org/apache/heron/instance/OutgoingTupleCollection.java
@@ -136,7 +136,8 @@ public class OutgoingTupleCollection {
     totalDataEmittedInBytes.getAndAdd(tupleSizeInBytes);
   }
 
-  public synchronized void addAckTuple(HeronTuples.AckTuple.Builder newTuple, long tupleSizeInBytes) {
+  public synchronized void addAckTuple(
+      HeronTuples.AckTuple.Builder newTuple, long tupleSizeInBytes) {
     if (currentControlTuple == null
         || currentControlTuple.getFailsCount() > 0
         || currentControlTuple.getAcksCount() >= controlTupleSetCapacity) {
@@ -148,7 +149,8 @@ public class OutgoingTupleCollection {
     totalDataEmittedInBytes.getAndAdd(tupleSizeInBytes);
   }
 
-  public synchronized void addFailTuple(HeronTuples.AckTuple.Builder newTuple, long tupleSizeInBytes) {
+  public synchronized void addFailTuple(
+      HeronTuples.AckTuple.Builder newTuple, long tupleSizeInBytes) {
     if (currentControlTuple == null
         || currentControlTuple.getAcksCount() > 0
         || currentControlTuple.getFailsCount() >= controlTupleSetCapacity) {


### PR DESCRIPTION
We have some use cases in which users will want to emit and ack or fail in different threads.  I have done some performance comparisons and there seems to not be a performance difference but perhaps others can chime in.