### PR TITLE
Align MetricsCacheMgr location discovery in Stmgr

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -725,7 +725,8 @@ class HeronExecutor(object):
         '--config_file=%s' % self.heron_internals_config_file,
         '--override_config_file=%s' % self.override_config_file,
         '--ckptmgr_port=%s' % str(self.checkpoint_manager_port),
-        '--ckptmgr_id=%s' % self.ckptmgr_ids[self.shard]]
+        '--ckptmgr_id=%s' % self.ckptmgr_ids[self.shard],
+        '--metricscachemgr_mode=%s' % self.metricscache_manager_mode.lower()]
     retval[self.stmgr_ids[self.shard]] = stmgr_cmd
 
     # metricsmgr_metrics_sink_config_file = 'metrics_sinks.yaml'

--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -175,7 +175,8 @@ class HeronExecutorTest(unittest.TestCase):
                   '--myhost=%s --data_port=master_port '
                   '--local_data_port=tmaster_controller_port --metricsmgr_port=metricsmgr_port '
                   '--shell_port=shell-port --config_file=%s --override_config_file=%s '
-                  '--ckptmgr_port=ckptmgr-port --ckptmgr_id=ckptmgr-1'
+                  '--ckptmgr_port=ckptmgr-port --ckptmgr_id=ckptmgr-1 '
+                  '--metricscachemgr_mode=cluster'
                   % (HOSTNAME, INTERNAL_CONF_PATH, OVERRIDE_PATH)),
       ProcessInfo(MockPOpen(), 'container_1_word_3', get_expected_instance_command('word', 3, 1)),
       ProcessInfo(MockPOpen(), 'container_1_exclaim1_1',
@@ -199,7 +200,8 @@ class HeronExecutorTest(unittest.TestCase):
                   '--data_port=master_port '
                   '--local_data_port=tmaster_controller_port --metricsmgr_port=metricsmgr_port '
                   '--shell_port=shell-port --config_file=%s --override_config_file=%s '
-                  '--ckptmgr_port=ckptmgr-port --ckptmgr_id=ckptmgr-7'
+                  '--ckptmgr_port=ckptmgr-port --ckptmgr_id=ckptmgr-7 '
+                  '--metricscachemgr_mode=cluster'
                   % (HOSTNAME, INTERNAL_CONF_PATH, OVERRIDE_PATH)),
       ProcessInfo(MockPOpen(), 'metricsmgr-7', get_expected_metricsmgr_command(7)),
       ProcessInfo(MockPOpen(), 'heron-shell-7', get_expected_shell_command(7)),
@@ -268,9 +270,9 @@ class HeronExecutorTest(unittest.TestCase):
       ("--checkpoint-manager-classpath", "ckptmgr_classpath"),
       ("--checkpoint-manager-port", "ckptmgr-port"),
       ("--stateful-config-file", "stateful_config_file"),
-      ("--health-manager-mode", "healthmgr_mode"),
+      ("--health-manager-mode", "cluster"),
       ("--health-manager-classpath", "healthmgr_classpath"),
-      ("--metricscache-manager-mode", "metricscache_mode")
+      ("--metricscache-manager-mode", "cluster")
     ]
 
     args = ("%s=%s" % (arg[0], (str(arg[1]))) for arg in executor_args)

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -70,7 +70,8 @@ StMgr::StMgr(EventLoop* eventLoop, const sp_string& _myhost, sp_int32 _data_port
              const std::vector<sp_string>& _instances, const sp_string& _zkhostport,
              const sp_string& _zkroot, sp_int32 _metricsmgr_port, sp_int32 _shell_port,
              sp_int32 _ckptmgr_port, const sp_string& _ckptmgr_id,
-             sp_int64 _high_watermark, sp_int64 _low_watermark, sp_string& _metricscachemgr_mode)
+             sp_int64 _high_watermark, sp_int64 _low_watermark,
+             const sp_string& _metricscachemgr_mode)
 
     : pplan_(NULL),
       topology_name_(_topology_name),

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -70,7 +70,7 @@ StMgr::StMgr(EventLoop* eventLoop, const sp_string& _myhost, sp_int32 _data_port
              const std::vector<sp_string>& _instances, const sp_string& _zkhostport,
              const sp_string& _zkroot, sp_int32 _metricsmgr_port, sp_int32 _shell_port,
              sp_int32 _ckptmgr_port, const sp_string& _ckptmgr_id,
-             sp_int64 _high_watermark, sp_int64 _low_watermark)
+             sp_int64 _high_watermark, sp_int64 _low_watermark, sp_string& _metricscachemgr_mode)
 
     : pplan_(NULL),
       topology_name_(_topology_name),
@@ -96,7 +96,8 @@ StMgr::StMgr(EventLoop* eventLoop, const sp_string& _myhost, sp_int32 _data_port
       ckptmgr_port_(_ckptmgr_port),
       ckptmgr_id_(_ckptmgr_id),
       high_watermark_(_high_watermark),
-      low_watermark_(_low_watermark) {}
+      low_watermark_(_low_watermark),
+      metricscachemgr_mode_(_metricscachemgr_mode) {}
 
 void StMgr::Init() {
   LOG(INFO) << "Init Stmgr" << std::endl;
@@ -119,8 +120,10 @@ void StMgr::Init() {
   metrics_manager_client_->register_metric(METRIC_TIME_SPENT_BACK_PRESSURE_INIT,
                                            back_pressure_metric_initiated_);
   state_mgr_->SetTMasterLocationWatch(topology_name_, [this]() { this->FetchTMasterLocation(); });
-  state_mgr_->SetMetricsCacheLocationWatch(
+  if (0 != metricscachemgr_mode_.compare()) {
+    state_mgr_->SetMetricsCacheLocationWatch(
                        topology_name_, [this]() { this->FetchMetricsCacheLocation(); });
+  }
 
   reliability_mode_ = heron::config::TopologyConfigHelper::GetReliabilityMode(*hydrated_topology_);
   if (reliability_mode_ == config::TopologyConfigVars::EFFECTIVELY_ONCE) {
@@ -156,7 +159,9 @@ void StMgr::Init() {
   // constructor needs actual stmgr ports, thus put FetchTMasterLocation()
   // has to be after after StartStmgrServer and StartInstanceServer()
   FetchTMasterLocation();
-  FetchMetricsCacheLocation();
+  if (0 != metricscachemgr_mode_.compare()) {
+    FetchMetricsCacheLocation();
+  }
 
   if (reliability_mode_ == config::TopologyConfigVars::EFFECTIVELY_ONCE) {
     // Now start the stateful restorer

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -120,7 +120,7 @@ void StMgr::Init() {
   metrics_manager_client_->register_metric(METRIC_TIME_SPENT_BACK_PRESSURE_INIT,
                                            back_pressure_metric_initiated_);
   state_mgr_->SetTMasterLocationWatch(topology_name_, [this]() { this->FetchTMasterLocation(); });
-  if (0 != metricscachemgr_mode_.compare()) {
+  if (0 != metricscachemgr_mode_.compare("disabled")) {
     state_mgr_->SetMetricsCacheLocationWatch(
                        topology_name_, [this]() { this->FetchMetricsCacheLocation(); });
   }
@@ -159,7 +159,7 @@ void StMgr::Init() {
   // constructor needs actual stmgr ports, thus put FetchTMasterLocation()
   // has to be after after StartStmgrServer and StartInstanceServer()
   FetchTMasterLocation();
-  if (0 != metricscachemgr_mode_.compare()) {
+  if (0 != metricscachemgr_mode_.compare("disabled")) {
     FetchMetricsCacheLocation();
   }
 

--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -255,6 +255,7 @@ class StMgr {
   sp_int64 high_watermark_;
   sp_int64 low_watermark_;
 
+  // whether MetricsCacheMgr is running
   sp_string metricscachemgr_mode_;
 };
 

--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -64,7 +64,7 @@ class StMgr {
         const std::vector<sp_string>& _instances, const sp_string& _zkhostport,
         const sp_string& _zkroot, sp_int32 _metricsmgr_port, sp_int32 _shell_port,
         sp_int32 _ckptmgr_port, const sp_string& _ckptmgr_id,
-        sp_int64 _high_watermark, sp_int64 _low_watermark);
+        sp_int64 _high_watermark, sp_int64 _low_watermark, sp_string& _metricscachemgr_mode);
   virtual ~StMgr();
 
   // All kinds of initialization like starting servers and clients

--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -253,6 +253,8 @@ class StMgr {
 
   sp_int64 high_watermark_;
   sp_int64 low_watermark_;
+
+  sp_string metricscachemgr_mode_;
 };
 
 }  // namespace stmgr

--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -64,7 +64,8 @@ class StMgr {
         const std::vector<sp_string>& _instances, const sp_string& _zkhostport,
         const sp_string& _zkroot, sp_int32 _metricsmgr_port, sp_int32 _shell_port,
         sp_int32 _ckptmgr_port, const sp_string& _ckptmgr_id,
-        sp_int64 _high_watermark, sp_int64 _low_watermark, sp_string& _metricscachemgr_mode);
+        sp_int64 _high_watermark, sp_int64 _low_watermark,
+        const sp_string& _metricscachemgr_mode);
   virtual ~StMgr();
 
   // All kinds of initialization like starting servers and clients

--- a/heron/stmgr/src/cpp/server/stmgr-main.cpp
+++ b/heron/stmgr/src/cpp/server/stmgr-main.cpp
@@ -80,7 +80,7 @@ int main(int argc, char* argv[]) {
                           FLAGS_topology_name, FLAGS_topology_id, topology, FLAGS_stmgr_id,
                           instances, FLAGS_zkhostportlist, FLAGS_zkroot, FLAGS_metricsmgr_port,
                           FLAGS_shell_port, FLAGS_ckptmgr_port, FLAGS_ckptmgr_id,
-                          high_watermark, low_watermark, metricscachemgr_mode);
+                          high_watermark, low_watermark, FLAGS_metricscachemgr_mode);
   mgr.Init();
   ss.loop();
   return 0;

--- a/heron/stmgr/src/cpp/server/stmgr-main.cpp
+++ b/heron/stmgr/src/cpp/server/stmgr-main.cpp
@@ -43,6 +43,7 @@ DEFINE_string(config_file, "", "The heron internals config file");
 DEFINE_string(override_config_file, "", "The override heron internals config file");
 DEFINE_string(ckptmgr_id, "", "The id of the local ckptmgr");
 DEFINE_int32(ckptmgr_port, 0, "The port of the local ckptmgr");
+DEFINE_string(metricscachemgr_mode, "disabled", "MetricsCacheMgr mode, default `disabled`");
 
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
@@ -79,7 +80,7 @@ int main(int argc, char* argv[]) {
                           FLAGS_topology_name, FLAGS_topology_id, topology, FLAGS_stmgr_id,
                           instances, FLAGS_zkhostportlist, FLAGS_zkroot, FLAGS_metricsmgr_port,
                           FLAGS_shell_port, FLAGS_ckptmgr_port, FLAGS_ckptmgr_id,
-                          high_watermark, low_watermark);
+                          high_watermark, low_watermark, metricscachemgr_mode);
   mgr.Init();
   ss.loop();
   return 0;

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -283,7 +283,7 @@ void StartStMgr(EventLoopImpl*& ss, heron::stmgr::StMgr*& mgr, std::thread*& stm
                                 topology_id,
                                 stmgr_topology, stmgr_id, workers, zkhostportlist, dpath,
                                 metricsmgr_port, shell_port, ckptmgr_port, ckptmgr_id,
-                                _high_watermark, _low_watermark);
+                                _high_watermark, _low_watermark, "disabled");
   EXPECT_EQ(0, stmgr_port);
   EXPECT_EQ(0, local_data_port);
   mgr->Init();


### PR DESCRIPTION
MetricsCacheMgr can be turned on or off by a switch config. When it is off, its location does not exist in StateMgr. The present Stmgr always tries to discover the MetricsCacheMgr location.

This PR disables the above discovery in Stmgr when MetricsCacheMgr is not running.