### PR TITLE
Fix bug in dry-run argument for update command

### DIFF
--- a/heron/tools/cli/src/python/update.py
+++ b/heron/tools/cli/src/python/update.py
@@ -102,7 +102,7 @@ def build_extra_args_dict(cl_args):
   if cl_args['dry_run']:
     dict_extra_args.update({'dry_run': True})
     if 'dry_run_format' in cl_args:
-      dict_extra_args.update({'dry_run_format', cl_args["dry_run_format"]})
+      dict_extra_args.update({'dry_run_format': cl_args["dry_run_format"]})
 
   return dict_extra_args
 
@@ -117,7 +117,7 @@ def convert_args_dict_to_list(dict_extra_args):
     list_extra_args += ["--runtime_config",
                         ','.join(dict_extra_args['runtime_config'])]
   if 'dry_run' in dict_extra_args and dict_extra_args['dry_run']:
-    list_extra_args += '--dry_run'
+    list_extra_args += ['--dry_run']
   if 'dry_run_format' in dict_extra_args:
     list_extra_args += ['--dry_run_format', dict_extra_args['dry_run_format']]
 


### PR DESCRIPTION
Since `list_extra_args` is an array, the `+=` operator deconstructs a
string and add each character as an individual array element. This made
it so when the update command it would not detect if it was in dry-run
mode and always run the update command. By encapsulating the `--dry-run`
string in an list it is properly added as an argument and runs with the
expected behavior.