### PR TITLE
allow storm topologies to use the heron state interface

### DIFF
--- a/storm-compatibility/src/java/org/apache/storm/topology/TopologyBuilder.java
+++ b/storm-compatibility/src/java/org/apache/storm/topology/TopologyBuilder.java
@@ -25,6 +25,7 @@ import org.apache.storm.generated.StormTopology;
 
 import com.twitter.heron.api.HeronTopology;
 import com.twitter.heron.api.bolt.WindowedBoltExecutor;
+import com.twitter.heron.api.topology.IStatefulComponent;
 
 public class TopologyBuilder {
   private com.twitter.heron.api.topology.TopologyBuilder delegate =
@@ -40,9 +41,14 @@ public class TopologyBuilder {
   }
 
   public BoltDeclarer setBolt(String id, IRichBolt bolt, Number parallelismHint) {
-    IRichBoltDelegate boltImpl = new IRichBoltDelegate(bolt);
-    com.twitter.heron.api.topology.BoltDeclarer declarer =
-        delegate.setBolt(id, boltImpl, parallelismHint);
+    com.twitter.heron.api.bolt.IRichBolt boltImpl;
+    if (bolt instanceof IStatefulComponent) {
+      boltImpl = new IRichStatefulBoltDelagate(bolt);
+    } else {
+      boltImpl = new IRichBoltDelegate(bolt);
+    }
+    com.twitter.heron.api.topology.BoltDeclarer declarer
+        = delegate.setBolt(id, boltImpl, parallelismHint);;
     return new BoltDeclarerImpl(declarer);
   }
 
@@ -72,9 +78,14 @@ public class TopologyBuilder {
   }
 
   public SpoutDeclarer setSpout(String id, IRichSpout spout, Number parallelismHint) {
-    IRichSpoutDelegate spoutImpl = new IRichSpoutDelegate(spout);
-    com.twitter.heron.api.topology.SpoutDeclarer declarer =
-        delegate.setSpout(id, spoutImpl, parallelismHint);
+    com.twitter.heron.api.spout.IRichSpout spoutImpl;
+    if (spout instanceof IStatefulComponent) {
+      spoutImpl = new IRichStatefulSpoutDelegate(spout);
+    } else {
+      spoutImpl = new IRichSpoutDelegate(spout);
+    }
+    com.twitter.heron.api.topology.SpoutDeclarer declarer
+        = delegate.setSpout(id, spoutImpl, parallelismHint);
     return new SpoutDeclarerImpl(declarer);
   }
 }

--- a/storm-compatibility/src/java/org/apache/storm/utils/ConfigUtils.java
+++ b/storm-compatibility/src/java/org/apache/storm/utils/ConfigUtils.java
@@ -174,19 +174,21 @@ public final class ConfigUtils {
    * @param heron the heron config object to receive the results.
    */
   private static void doTopologyLevelTranslation(Config heronConfig) {
-    if (heronConfig.containsKey(org.apache.storm.Config.TOPOLOGY_ACKER_EXECUTORS)) {
-      Integer nAckers =
-          Utils.getInt(heronConfig.get(org.apache.storm.Config.TOPOLOGY_ACKER_EXECUTORS));
-      if (nAckers > 0) {
-        com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
-                 com.twitter.heron.api.Config.TopologyReliabilityMode.ATLEAST_ONCE);
+    if (!heronConfig.containsKey(Config.TOPOLOGY_RELIABILITY_MODE)) {
+      if (heronConfig.containsKey(org.apache.storm.Config.TOPOLOGY_ACKER_EXECUTORS)) {
+        Integer nAckers =
+            Utils.getInt(heronConfig.get(org.apache.storm.Config.TOPOLOGY_ACKER_EXECUTORS));
+        if (nAckers > 0) {
+          com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
+              com.twitter.heron.api.Config.TopologyReliabilityMode.ATLEAST_ONCE);
+        } else {
+          com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
+              com.twitter.heron.api.Config.TopologyReliabilityMode.ATMOST_ONCE);
+        }
       } else {
         com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
-                 com.twitter.heron.api.Config.TopologyReliabilityMode.ATMOST_ONCE);
+            com.twitter.heron.api.Config.TopologyReliabilityMode.ATMOST_ONCE);
       }
-    } else {
-      com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
-               com.twitter.heron.api.Config.TopologyReliabilityMode.ATMOST_ONCE);
     }
   }
 }


### PR DESCRIPTION
To use the heron state interface uses will need to add these configs:

conf.put(com.twitter.heron.api.Config.TOPOLOGY_RELIABILITY_MODE, com.twitter.heron.api.Config.TopologyReliabilityMode.EFFECTIVELY_ONCE);
    conf.registerSerialization(com.twitter.heron.api.state.HashMapState.class);

in addition to implementing the stateful component interface:

public static class AckingTestWordSpout extends BaseRichSpout implements IStatefulComponent<String, String>{
.
.
.
}