### PR TITLE
add config for apiserver overrides

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/nomad/NomadScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/nomad/NomadScheduler.java
@@ -70,7 +70,8 @@ public class NomadScheduler implements IScheduler {
         .putAll(config)
         .putAll(ConfigLoader.loadConfig(
             Context.heronHome(config), Context.heronConf(config),
-            null, Context.overrideFile(config)))
+            null, Context.apiserverOverrideFile(config) != null
+                ? Context.apiserverOverrideFile(config) : Context.overrideFile(config)))
         .build());
     this.runtimeConfig = runtime;
     this.updateTopologyManager =

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
@@ -297,6 +297,10 @@ public class Context {
     return cfg.getStringValue(Key.OVERRIDE_YAML);
   }
 
+  public static String apiserverOverrideFile(Config cfg) {
+    return cfg.getStringValue(Key.APISERVER_OVERRIDE_YAML);
+  }
+
   public static String executorBinary(Config cfg) {
     return cfg.getStringValue(Key.EXECUTOR_BINARY);
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
@@ -165,6 +165,10 @@ public enum Key {
   //keys for heron configuration files on the cluster
   OVERRIDE_YAML("heron.config.file.override.yaml",  "${HERON_CONF}/override.yaml"),
 
+  // Path to the config overrides passed into the apiserver. Only applicable to submitting
+  // topologies via apiserver
+  APISERVER_OVERRIDE_YAML("heron.apiserver.file.override.yaml", Type.STRING),
+
   //keys for config provided user binaries
   EXECUTOR_BINARY       ("heron.binaries.executor",        "${HERON_BIN}/heron-executor"),
   STMGR_BINARY          ("heron.binaries.stmgr",           "${HERON_BIN}/heron-stmgr"),

--- a/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/utils/ConfigUtils.java
+++ b/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/utils/ConfigUtils.java
@@ -32,6 +32,7 @@ import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.scheduler.utils.SubmitterUtils;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.ConfigLoader;
+import com.twitter.heron.spi.common.Key;
 
 public final class ConfigUtils {
 
@@ -62,10 +63,17 @@ public final class ConfigUtils {
         String releaseFile,
         String overrideConfigurationFile) {
     // TODO add release file
-    return ConfigLoader.loadConfig(heronDirectory,
+    Config config = ConfigLoader.loadConfig(heronDirectory,
         heronConfigDirectory,
         releaseFile,
         overrideConfigurationFile);
+    // Put location of the override file in the config so that schedulers invoked by
+    // the apiserver can load the override configs if needed. OVERRIDE_YAML cannot be used
+    // to set this because then the location will get passed on to the heron executors
+    return Config.newBuilder()
+        .putAll(config)
+        .put(Key.APISERVER_OVERRIDE_YAML, overrideConfigurationFile)
+        .build();
   }
 
   public static Config getTopologyConfig(String topologyPackage, String topologyBinaryFile,


### PR DESCRIPTION
currently a scheduler invoked by the apiserver has no way of getting the set of config overrides set when launching the apiserver.  Adding a config so that a scheduler can read in the override yaml file created by the apiserver for the config overrides specified in the apiserver launch command.