### PR TITLE
Add two backup urls for zookeeper

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -302,9 +302,9 @@ maven_jar(
   artifact = "com.esotericsoftware:reflectasm:1.11.3",
 )
 
-maven_jar(		
-  name = "org_objectweb_asm",		
-  artifact = "org.ow2.asm:asm:5.0.4",		
+maven_jar(
+  name = "org_objectweb_asm",
+  artifact = "org.ow2.asm:asm:5.0.4",
 )
 
 maven_jar(
@@ -827,7 +827,11 @@ new_http_archive(
 
 new_http_archive(
     name = "org_apache_zookeeper",
-    urls = ["http://apache.cs.utah.edu/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz"],
+    urls = [
+      "http://apache.cs.utah.edu/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz",
+      "http://apache.claz.org/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz",
+      "http://apache.mesi.com.ar/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz",
+    ],
     strip_prefix = "zookeeper-3.4.10",
     build_file = "third_party/zookeeper/zookeeper.BUILD",
 )


### PR DESCRIPTION
I've experiences some flakiness with a few of the zookeeper archive
urls. This adds two backup urls in the event that one of them is down or
a connection cannot be established.

Zookeeper was the only obvious candidate that had mirrors so we can start here and add other mirrors if people experience flakiness for other archives.

Closes https://github.com/apache/incubator-heron/issues/2855