### PR TITLE
S3Uploader improvements

### DIFF
--- a/heron/uploaders/src/java/BUILD
+++ b/heron/uploaders/src/java/BUILD
@@ -10,6 +10,7 @@ uploader_spi_files = [
 
 s3_deps_files = \
     uploader_spi_files + [
+        "@org_apache_commons_commons_lang3//jar",
         "//third_party/java:aws-java-sdk",
         "//third_party/java:guava",
     ]
@@ -25,43 +26,43 @@ dlog_deps_files = \
         "@org_apache_distributedlog_core//jar",
         "//heron/io/dlog/src/java:dlog-lib",
     ]
-    
+
 http_uploader_deps_files = \
     uploader_spi_files + [
         "@org_apache_httpcomponents_httpmime//jar",
         "@org_apache_httpcomponents_http_client//jar",
         "@org_apache_httpcomponents_http_core//jar",
         "@org_apache_commons_commons_lang3//jar",
-        "//third_party/java:guava"
+        "//third_party/java:guava",
     ]
 
 java_library(
-    name = 'null-uploader-java',
+    name = "null-uploader-java",
     srcs = glob(["**/NullUploader.java"]),
     deps = uploader_spi_files,
 )
 
 java_binary(
-    name = 'null-uploader-unshaded',
+    name = "null-uploader-unshaded",
     srcs = glob(["**/NullUploader.java"]),
     deps = uploader_spi_files,
 )
 
 genrule(
-    name = 'heron-null-uploader',
+    name = "heron-null-uploader",
     srcs = [":null-uploader-unshaded_deploy.jar"],
     outs = ["heron-null-uploader.jar"],
-    cmd  = "cp $< $@",
+    cmd = "cp $< $@",
 )
 
 java_library(
-    name = 'localfs-uploader-java',
+    name = "localfs-uploader-java",
     srcs = glob(["**/localfs/**/*.java"]),
     deps = uploader_spi_files,
 )
 
 java_binary(
-    name = 'localfs-uploader-unshaded',
+    name = "localfs-uploader-unshaded",
     srcs = glob(["**/localfs/**/*.java"]),
     deps = uploader_spi_files,
 )
@@ -70,17 +71,17 @@ genrule(
     name = "heron-localfs-uploader",
     srcs = [":localfs-uploader-unshaded_deploy.jar"],
     outs = ["heron-localfs-uploader.jar"],
-    cmd  = "cp $< $@",
+    cmd = "cp $< $@",
 )
 
 java_library(
-    name = 'hdfs-uploader-java',
+    name = "hdfs-uploader-java",
     srcs = glob(["**/hdfs/**/*.java"]),
     deps = uploader_spi_files,
 )
 
 java_binary(
-    name = 'hdfs-uploader-unshaded',
+    name = "hdfs-uploader-unshaded",
     srcs = glob(["**/hdfs/**/*.java"]),
     deps = uploader_spi_files,
 )
@@ -89,17 +90,17 @@ genrule(
     name = "heron-hdfs-uploader",
     srcs = [":hdfs-uploader-unshaded_deploy.jar"],
     outs = ["heron-hdfs-uploader.jar"],
-    cmd  = "cp $< $@",
+    cmd = "cp $< $@",
 )
 
 java_library(
-    name = 'dlog-uploader-java',
+    name = "dlog-uploader-java",
     srcs = glob(["**/dlog/**/*.java"]),
     deps = dlog_deps_files,
 )
 
 java_binary(
-    name = 'dlog-uploader-unshaded',
+    name = "dlog-uploader-unshaded",
     srcs = glob(["**/dlog/**/*.java"]),
     deps = dlog_deps_files,
 )
@@ -108,77 +109,81 @@ genrule(
     name = "heron-dlog-uploader",
     srcs = [":dlog-uploader-unshaded_deploy.jar"],
     outs = ["heron-dlog-uploader.jar"],
-    cmd  = "cp $< $@",
+    cmd = "cp $< $@",
 )
 
 java_library(
-    name = 's3-uploader-java',
+    name = "s3-uploader-java",
     srcs = glob(["**/s3/**/*.java"]),
     deps = s3_deps_files,
 )
 
 java_binary(
-    name = 's3-uploader-unshaded',
+    name = "s3-uploader-unshaded",
     srcs = glob(["**/s3/**/*.java"]),
-    deps = s3_deps_files)
+    deps = s3_deps_files,
+)
 
 genrule(
     name = "heron-s3-uploader",
     srcs = [":s3-uploader-unshaded_deploy.jar"],
     outs = ["heron-s3-uploader.jar"],
-    cmd  = "cp $< $@",
+    cmd = "cp $< $@",
 )
 
 java_library(
-    name = 'scp-uploader-java',
+    name = "scp-uploader-java",
     srcs = glob(["**/scp/**/*.java"]),
     deps = uploader_spi_files,
 )
 
 java_binary(
-    name = 'scp-uploader-unshaded',
+    name = "scp-uploader-unshaded",
     srcs = glob(["**/scp/**/*.java"]),
-    deps = uploader_spi_files)
+    deps = uploader_spi_files,
+)
 
 genrule(
     name = "heron-scp-uploader",
     srcs = [":scp-uploader-unshaded_deploy.jar"],
     outs = ["heron-scp-uploader.jar"],
-    cmd  = "cp $< $@",
+    cmd = "cp $< $@",
 )
 
 java_library(
-    name = 'gcs-uploader-java',
+    name = "gcs-uploader-java",
     srcs = glob(["**/gcs/**/*.java"]),
     deps = gcs_deps_files,
 )
 
 java_binary(
-    name = 'gcs-uploader-unshaded',
+    name = "gcs-uploader-unshaded",
     srcs = glob(["**/gcs/**/*.java"]),
-    deps = gcs_deps_files)
+    deps = gcs_deps_files,
+)
 
 genrule(
     name = "heron-gcs-uploader",
     srcs = [":gcs-uploader-unshaded_deploy.jar"],
     outs = ["heron-gcs-uploader.jar"],
-    cmd  = "cp $< $@",
+    cmd = "cp $< $@",
 )
 
 java_library(
-    name = 'http-uploader-java',
+    name = "http-uploader-java",
     srcs = glob(["**/http/**/*.java"]),
     deps = http_uploader_deps_files,
 )
 
 java_binary(
-    name = 'http-uploader-unshaded',
+    name = "http-uploader-unshaded",
     srcs = glob(["**/http/**/*.java"]),
-    deps = http_uploader_deps_files)
+    deps = http_uploader_deps_files,
+)
 
 genrule(
     name = "heron-http-uploader",
     srcs = [":http-uploader-unshaded_deploy.jar"],
     outs = ["heron-http-uploader.jar"],
-    cmd  = "cp $< $@",
+    cmd = "cp $< $@",
 )

--- a/heron/uploaders/src/java/org/apache/heron/uploader/s3/S3Uploader.java
+++ b/heron/uploaders/src/java/org/apache/heron/uploader/s3/S3Uploader.java
@@ -143,11 +143,14 @@ public class S3Uploader implements IUploader {
       builder.setClientConfiguration(clientCfg);
     }
 
-    s3Client = builder.withRegion(customRegion)
-            .withPathStyleAccessEnabled(true)
-            .withChunkedEncodingDisabled(true)
-            .withPayloadSigningEnabled(true)
-            .build();
+    if (customRegion != null && !customRegion.equals("")) {
+      builder.setRegion(customRegion);
+    }
+
+    s3Client = builder.withPathStyleAccessEnabled(true)
+        .withChunkedEncodingDisabled(true)
+        .withPayloadSigningEnabled(true)
+        .build();
 
     if (!Strings.isNullOrEmpty(endpoint)) {
       s3Client.setEndpoint(endpoint);
@@ -237,7 +240,8 @@ public class S3Uploader implements IUploader {
   public void close() {
     // Cleanup the backup file if it exists as its not needed anymore.
     // This will succeed whether the file exists or not.
-    if (!Strings.isNullOrEmpty(previousVersionFilePath)) {
+    if (!Strings.isNullOrEmpty(previousVersionFilePath)
+        && s3Client.doesObjectExist(bucket, previousVersionFilePath)) {
       s3Client.deleteObject(bucket, previousVersionFilePath);
     }
   }

--- a/heron/uploaders/src/java/org/apache/heron/uploader/s3/S3Uploader.java
+++ b/heron/uploaders/src/java/org/apache/heron/uploader/s3/S3Uploader.java
@@ -34,6 +34,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.google.common.base.Strings;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.heron.spi.common.Config;
 import org.apache.heron.spi.common.Context;
 import org.apache.heron.spi.uploader.IUploader;
@@ -143,7 +144,7 @@ public class S3Uploader implements IUploader {
       builder.setClientConfiguration(clientCfg);
     }
 
-    if (customRegion != null && !customRegion.equals("")) {
+    if(StringUtils.isNotBlank(customRegion)) {
       builder.setRegion(customRegion);
     }
 

--- a/heron/uploaders/tests/java/org/apache/heron/uploader/s3/S3UploaderTest.java
+++ b/heron/uploaders/tests/java/org/apache/heron/uploader/s3/S3UploaderTest.java
@@ -173,10 +173,28 @@ public class S3UploaderTest {
     String expectedPreviousVersionPath = "test-topology/previous_topology.tar.gz";
     String expectedBucket = "bucket";
 
+    when(mockS3Client.doesObjectExist(expectedBucket, expectedPreviousVersionPath))
+        .thenReturn(true);
+
     uploader.close();
+
+    verify(mockS3Client).doesObjectExist(expectedBucket, expectedPreviousVersionPath);
     verify(mockS3Client).deleteObject(expectedBucket, expectedPreviousVersionPath);
   }
 
+  @Test
+  public void close_DoNotDeleteFileIfItDoesNotExist() {
+    String expectedPreviousVersionPath = "test-topology/previous_topology.tar.gz";
+    String expectedBucket = "bucket";
+
+    when(mockS3Client.doesObjectExist(expectedBucket, expectedPreviousVersionPath))
+        .thenReturn(false);
+
+    uploader.close();
+
+    verify(mockS3Client).doesObjectExist(expectedBucket, expectedPreviousVersionPath);
+    verify(mockS3Client, never()).deleteObject(expectedBucket, expectedPreviousVersionPath);
+  }
 
   @Test
   public void PrefixUploadPathWithSpecifiedPrefix() throws Exception {


### PR DESCRIPTION
This fixes 2 bugs in the S3Uploader.

The first is when setting the region it is not checked before-hand if
the region is set or not. In the event that the end user does not
explicitly set the region in the config it will automatically be set to
`null`. Since `null` is not a valid s3 region the uploader will fail
with a 301 on any command which can be confusing. It is not required
that the s3 client sets a region and in the event that one is not set
explicitly it will default to us-east-1.

The second is the `close` method does not check to see if the file
exists before it deletes it. In the event that there is a failure
earlier in the uploading process the `previousVersionFilePath` will
exist but was never uploaded to s3 and the `close` method will throw
an exception.