### PR TITLE
Fix kryo factor config

### DIFF
--- a/heron/common/src/cpp/config/topology-config-helper.h
+++ b/heron/common/src/cpp/config/topology-config-helper.h
@@ -144,23 +144,23 @@ class TopologyConfigHelper {
                                       std::map<std::string, std::string>& _retval);
 
   // Return topology level config
-  static void GetTopologyConfig(const proto::api::Topology& _topology,
-                                std::map<std::string, std::string>& retval);
+  static void GetTopologyRuntimeConfig(const proto::api::Topology& _topology,
+                                       std::map<std::string, std::string>& retval);
 
   // Update topology level config
-  static void SetTopologyConfig(proto::api::Topology* _topology,
-                                const std::map<std::string, std::string>& retval);
+  static void SetTopologyRuntimeConfig(proto::api::Topology* _topology,
+                                       const std::map<std::string, std::string>& retval);
 
 
   // Return component level config
-  static void GetComponentConfig(const proto::api::Topology& _topology,
-                                 const std::string& _component_name,
-                                 std::map<std::string, std::string>& config);
+  static void GetComponentRuntimeConfig(const proto::api::Topology& _topology,
+                                        const std::string& _component_name,
+                                        std::map<std::string, std::string>& config);
 
   // Update component level config
-  static void SetComponentConfig(proto::api::Topology* _topology,
-                                 const std::string& _component_name,
-                                 const std::map<std::string, std::string>& config);
+  static void SetComponentRuntimeConfig(proto::api::Topology* _topology,
+                                        const std::string& _component_name,
+                                        const std::map<std::string, std::string>& config);
 
   // Get the topology config value given the config key
   static const std::string GetTopologyConfigValue(const proto::api::Topology& _topology,
@@ -190,11 +190,11 @@ class TopologyConfigHelper {
                                     const std::string& _config_name,
                                     bool _default_value);
   // Convert topology config to a key value map
-  static void ConvertConfigToKVMap(const proto::api::Config& _config,
-                                   std::map<std::string, std::string>& retval);
+  static void ConvertRuntimeConfigToKVMap(const proto::api::Config& _config,
+                                          std::map<std::string, std::string>& retval);
   // Update topology config from a key value map
-  static void UpdateConfigFromKVMap(proto::api::Config* _config,
-                                    const std::map<std::string, std::string>& _kv_map);
+  static void UpdateRuntimeConfigFromKVMap(proto::api::Config* _config,
+                                           const std::map<std::string, std::string>& _kv_map);
 };
 }  // namespace config
 }  // namespace heron

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -1126,14 +1126,14 @@ void StMgr::PatchPhysicalPlanWithHydratedTopology(proto::system::PhysicalPlan* _
   proto::api::TopologyState st = _pplan->topology().state();
 
   std::map<std::string, std::string> topology_config;
-  config::TopologyConfigHelper::GetTopologyConfig(_pplan->topology(), topology_config);
+  config::TopologyConfigHelper::GetTopologyRuntimeConfig(_pplan->topology(), topology_config);
 
   std::unordered_set<std::string> components;
   std::map<std::string, std::map<std::string, std::string>> component_config;
   config::TopologyConfigHelper::GetAllComponentNames(_pplan->topology(), components);
   for (auto iter = components.begin(); iter != components.end(); ++iter) {
     std::map<std::string, std::string> config;
-    config::TopologyConfigHelper::GetComponentConfig(_pplan->topology(), *iter, topology_config);
+    config::TopologyConfigHelper::GetComponentRuntimeConfig(_pplan->topology(), *iter, config);
     component_config[*iter] = config;
   }
 
@@ -1143,9 +1143,10 @@ void StMgr::PatchPhysicalPlanWithHydratedTopology(proto::system::PhysicalPlan* _
 
   // Restore new topology data
   _pplan->mutable_topology()->set_state(st);
-  config::TopologyConfigHelper::SetTopologyConfig(_pplan->mutable_topology(), topology_config);
+  config::TopologyConfigHelper::SetTopologyRuntimeConfig(_pplan->mutable_topology(),
+                                                         topology_config);
   for (auto iter = components.begin(); iter != components.end(); ++iter) {
-    config::TopologyConfigHelper::SetComponentConfig(_pplan->mutable_topology(), *iter,
+    config::TopologyConfigHelper::SetComponentRuntimeConfig(_pplan->mutable_topology(), *iter,
         component_config[*iter]);
   }
 }

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -1899,7 +1899,7 @@ TEST(StMgr, test_PatchPhysicalPlanWithHydratedTopology) {
   std::map<std::string, std::string> update;
   update["conf.new"] = "test";
   update[heron::config::TopologyConfigVars::TOPOLOGY_MESSAGE_TIMEOUT_SECS] = "10";
-  heron::config::TopologyConfigHelper::SetTopologyConfig(pplan->mutable_topology(), update);
+  heron::config::TopologyConfigHelper::SetTopologyRuntimeConfig(pplan->mutable_topology(), update);
 
   // Verify updated runtime data is still in the patched physical plan
   // The topology in the physical plan should have the old name

--- a/heron/tmaster/src/cpp/manager/tmaster.cpp
+++ b/heron/tmaster/src/cpp/manager/tmaster.cpp
@@ -637,12 +637,12 @@ bool TMaster::UpdateRuntimeConfigInTopology(proto::api::Topology* _topology,
   const char* topology_key = config::TopologyConfigHelper::GetReservedTopologyConfigKey();
   for (iter = _config.begin(); iter != _config.end(); ++iter) {
     // Get config for topology or component.
-    std::map<std::string, std::string> runtime_config;
-    config::TopologyConfigHelper::ConvertToRuntimeConfigs(iter->second, runtime_config);
+    std::map<std::string, std::string> config;
+    config::TopologyConfigHelper::ConvertToRuntimeConfigs(iter->second, config);
     if (iter->first == topology_key) {
-      config::TopologyConfigHelper::SetTopologyConfig(_topology, runtime_config);
+      config::TopologyConfigHelper::SetTopologyRuntimeConfig(_topology, config);
     } else {
-      config::TopologyConfigHelper::SetComponentConfig(_topology, iter->first, runtime_config);
+      config::TopologyConfigHelper::SetComponentRuntimeConfig(_topology, iter->first, config);
     }
   }
 

--- a/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
+++ b/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
@@ -50,10 +50,10 @@ const sp_string heron_internals_config_filename =
 const sp_string metrics_sinks_config_filename =
     "../../../../../../../../heron/config/metrics_sinks.yaml";
 
-const sp_string topology_runtime_config_1 = "topology.runtime.test_config";
-const sp_string topology_runtime_config_2 = "topology.runtime.test_config2";
-const sp_string spout_runtime_config = "topology.runtime.spout.test_config";
-const sp_string bolt_runtime_config = "topology.runtime.bolt.test_config";
+const sp_string topology_init_config_1 = "topology.runtime.test_config";
+const sp_string topology_init_config_2 = "topology.runtime.test_config2";
+const sp_string spout_init_config = "topology.runtime.spout.test_config";
+const sp_string bolt_init_config = "topology.runtime.bolt.test_config";
 
 // Generate a dummy topology
 static heron::proto::api::Topology* GenerateDummyTopology(
@@ -93,7 +93,7 @@ static heron::proto::api::Topology* GenerateDummyTopology(
     kv->set_value(std::to_string(num_spout_instances));
     // Add runtime config
     heron::proto::api::Config::KeyValue* kv1 = config->add_kvs();
-    kv1->set_key(spout_runtime_config);
+    kv1->set_key(spout_init_config);
     kv1->set_value("-1");
   }
   // Set bolts
@@ -123,7 +123,7 @@ static heron::proto::api::Topology* GenerateDummyTopology(
     kv->set_value(std::to_string(num_bolt_instances));
     // Add runtime config
     heron::proto::api::Config::KeyValue* kv1 = config->add_kvs();
-    kv1->set_key(bolt_runtime_config);
+    kv1->set_key(bolt_init_config);
     kv1->set_value("-1");
   }
   // Set message timeout
@@ -133,10 +133,10 @@ static heron::proto::api::Topology* GenerateDummyTopology(
   kv->set_value(MESSAGE_TIMEOUT);
   // Add runtime config
   heron::proto::api::Config::KeyValue* kv1 = topology_config->add_kvs();
-  kv1->set_key(topology_runtime_config_1);
+  kv1->set_key(topology_init_config_1);
   kv1->set_value("-1");
   heron::proto::api::Config::KeyValue* kv2 = topology_config->add_kvs();
-  kv2->set_key(topology_runtime_config_2);
+  kv2->set_key(topology_init_config_2);
   kv2->set_value("-1");
 
   // Set state
@@ -706,35 +706,13 @@ TEST(StMgr, test_runtime_config) {
   // auto c = t.topology_config();
   for (size_t i = 0; i < common.stmgrs_list_.size(); ++i) {
     while (!common.stmgrs_list_[i]->GetPhysicalPlan()) sleep(1);
-    std::map<std::string, std::string> init_config, init_spout_config, init_bolt_config;
-    const heron::proto::system::PhysicalPlan* pplan = common.stmgrs_list_[i]->GetPhysicalPlan();
-    heron::config::TopologyConfigHelper::GetTopologyConfig(pplan->topology(), init_config);
-    EXPECT_EQ(init_config[topology_runtime_config_1], "-1");
-    EXPECT_EQ(init_config[topology_runtime_config_2], "-1");
-    heron::config::TopologyConfigHelper::GetComponentConfig(pplan->topology(),
-        runtime_test_spout, init_spout_config);
-    EXPECT_EQ(init_spout_config[spout_runtime_config], "-1");
-    heron::config::TopologyConfigHelper::GetComponentConfig(pplan->topology(),
-        runtime_test_bolt, init_bolt_config);
-    EXPECT_EQ(init_bolt_config[bolt_runtime_config], "-1");
   }
-  std::map<std::string, std::string> init_config, init_spout_config, init_bolt_config;
-  const heron::proto::system::PhysicalPlan* init_pplan = common.tmaster_->getPhysicalPlan();
-  heron::config::TopologyConfigHelper::GetTopologyConfig(init_pplan->topology(), init_config);
-  EXPECT_EQ(init_config[topology_runtime_config_1], "-1");
-  EXPECT_EQ(init_config[topology_runtime_config_2], "-1");
-  heron::config::TopologyConfigHelper::GetComponentConfig(init_pplan->topology(),
-      runtime_test_spout, init_spout_config);
-  EXPECT_EQ(init_spout_config[spout_runtime_config], "-1");
-  heron::config::TopologyConfigHelper::GetComponentConfig(init_pplan->topology(),
-      runtime_test_bolt, init_bolt_config);
-  EXPECT_EQ(init_bolt_config[bolt_runtime_config], "-1");
 
   // Test ValidateRuntimeConfig()
   heron::tmaster::ComponentConfigMap validate_good_config_map;
   std::map<std::string, std::string> validate_good_config;
-  validate_good_config[topology_runtime_config_1] = "1";
-  validate_good_config[topology_runtime_config_2] = "2";
+  validate_good_config[topology_init_config_1] = "1";
+  validate_good_config[topology_init_config_2] = "2";
   const char* topology_key = heron::config::TopologyConfigHelper::GetReservedTopologyConfigKey();
   validate_good_config_map[topology_key] = validate_good_config;
   validate_good_config_map["spout1"] = validate_good_config;
@@ -742,7 +720,7 @@ TEST(StMgr, test_runtime_config) {
 
   heron::tmaster::ComponentConfigMap validate_bad_config_map;
   std::map<std::string, std::string> validate_bad_config;
-  validate_good_config[topology_runtime_config_1] = "1";
+  validate_good_config[topology_init_config_1] = "1";
   validate_bad_config_map["unknown_component"] = validate_good_config;
   EXPECT_EQ(common.tmaster_->ValidateRuntimeConfig(validate_bad_config_map), false);
 
@@ -772,10 +750,10 @@ TEST(StMgr, test_runtime_config) {
 
   // Post runtime config request with good configs and expect 200 response.
   std::vector<std::string> good_config;
-  good_config.push_back(topology_runtime_config_1 + ":1");
-  good_config.push_back(topology_runtime_config_2 + ":2");
-  good_config.push_back(runtime_test_spout + ":" + spout_runtime_config + ":3");
-  good_config.push_back(runtime_test_bolt + ":" + bolt_runtime_config + ":4");
+  good_config.push_back(topology_init_config_1 + ":1");
+  good_config.push_back(topology_init_config_2 + ":2");
+  good_config.push_back(runtime_test_spout + ":" + spout_init_config + ":3");
+  good_config.push_back(runtime_test_bolt + ":" + bolt_init_config + ":4");
   std::thread* good_config_update_thread = new std::thread(UpdateRuntimeConfig,
       common.topology_id_, common.tmaster_controller_port_, good_config, 200, "good_config");
   good_config_update_thread->join();
@@ -787,35 +765,28 @@ TEST(StMgr, test_runtime_config) {
   for (size_t i = 0; i < common.stmgrs_list_.size(); ++i) {
     std::map<std::string, std::string> updated_config, updated_spout_config, updated_bolt_config;
     const heron::proto::system::PhysicalPlan* pplan = common.stmgrs_list_[i]->GetPhysicalPlan();
-    heron::config::TopologyConfigHelper::GetTopologyConfig(pplan->topology(), updated_config);
-    EXPECT_EQ(updated_config[topology_runtime_config_1], "-1");
-    EXPECT_EQ(updated_config[topology_runtime_config_1 + ":runtime"], "1");
-    EXPECT_EQ(updated_config[topology_runtime_config_2], "-1");
-    EXPECT_EQ(updated_config[topology_runtime_config_2 + ":runtime"], "2");
-    heron::config::TopologyConfigHelper::GetComponentConfig(pplan->topology(),
+    heron::config::TopologyConfigHelper::GetTopologyRuntimeConfig(pplan->topology(),
+        updated_config);
+    EXPECT_EQ(updated_config[topology_init_config_1 + ":runtime"], "1");
+    EXPECT_EQ(updated_config[topology_init_config_2 + ":runtime"], "2");
+    heron::config::TopologyConfigHelper::GetComponentRuntimeConfig(pplan->topology(),
         runtime_test_spout, updated_spout_config);
-    EXPECT_EQ(updated_spout_config[spout_runtime_config], "-1");
-    EXPECT_EQ(updated_spout_config[spout_runtime_config + ":runtime"], "3");
-    heron::config::TopologyConfigHelper::GetComponentConfig(pplan->topology(),
+    EXPECT_EQ(updated_spout_config[spout_init_config + ":runtime"], "3");
+    heron::config::TopologyConfigHelper::GetComponentRuntimeConfig(pplan->topology(),
         runtime_test_bolt, updated_bolt_config);
-    EXPECT_EQ(updated_bolt_config[bolt_runtime_config], "-1");
-    EXPECT_EQ(updated_bolt_config[bolt_runtime_config + ":runtime"], "4");
+    EXPECT_EQ(updated_bolt_config[bolt_init_config + ":runtime"], "4");
   }
   std::map<std::string, std::string> updated_config, updated_spout_config, updated_bolt_config;
   const heron::proto::system::PhysicalPlan* pplan = common.tmaster_->getPhysicalPlan();
-  heron::config::TopologyConfigHelper::GetTopologyConfig(pplan->topology(), updated_config);
-  EXPECT_EQ(updated_config[topology_runtime_config_1], "-1");
-  EXPECT_EQ(updated_config[topology_runtime_config_1 + ":runtime"], "1");
-  EXPECT_EQ(updated_config[topology_runtime_config_2], "-1");
-  EXPECT_EQ(updated_config[topology_runtime_config_2 + ":runtime"], "2");
-  heron::config::TopologyConfigHelper::GetComponentConfig(pplan->topology(),
+  heron::config::TopologyConfigHelper::GetTopologyRuntimeConfig(pplan->topology(), updated_config);
+  EXPECT_EQ(updated_config[topology_init_config_1 + ":runtime"], "1");
+  EXPECT_EQ(updated_config[topology_init_config_2 + ":runtime"], "2");
+  heron::config::TopologyConfigHelper::GetComponentRuntimeConfig(pplan->topology(),
       runtime_test_spout, updated_spout_config);
-  EXPECT_EQ(updated_spout_config[spout_runtime_config], "-1");
-  EXPECT_EQ(updated_spout_config[spout_runtime_config + ":runtime"], "3");
-  heron::config::TopologyConfigHelper::GetComponentConfig(pplan->topology(),
+  EXPECT_EQ(updated_spout_config[spout_init_config + ":runtime"], "3");
+  heron::config::TopologyConfigHelper::GetComponentRuntimeConfig(pplan->topology(),
       runtime_test_bolt, updated_bolt_config);
-  EXPECT_EQ(updated_bolt_config[bolt_runtime_config], "-1");
-  EXPECT_EQ(updated_bolt_config[bolt_runtime_config + ":runtime"], "4");
+  EXPECT_EQ(updated_bolt_config[bolt_init_config + ":runtime"], "4");
 
   // Stop the schedulers
   for (size_t i = 0; i < common.ss_list_.size(); ++i) {


### PR DESCRIPTION
Fix runtime config patching in stmgr.
    
    The old logic store and restore all the configs. However it doesn't work
    for non-string configs because they have empty value field and the real
    data is in the serialized_value field which is not covered.