### PR TITLE
check checkpoint file exists before deleting it

### DIFF
--- a/heron/statefulstorages/src/java/org/apache/heron/statefulstorage/localfs/LocalFileSystemStorage.java
+++ b/heron/statefulstorages/src/java/org/apache/heron/statefulstorage/localfs/LocalFileSystemStorage.java
@@ -109,17 +109,21 @@ public class LocalFileSystemStorage implements IStatefulStorage {
       }
     } else {
       String[] names = new File(topologyCheckpointRoot).list();
-      for (String name : names) {
-        if (name.compareTo(oldestCheckpointPreserved) < 0) {
-          FileUtils.deleteDir(new File(topologyCheckpointRoot, name), true);
+      if (names.length == 0) {
+        LOG.warning("No checkpoint files under root path: " + topologyCheckpointRoot);
+      } else {
+        for (String name : names) {
+          if (name.compareTo(oldestCheckpointPreserved) < 0) {
+            FileUtils.deleteDir(new File(topologyCheckpointRoot, name), true);
+          }
         }
-      }
 
-      // Do a double check. Now all checkpoints with smaller checkpoint id should be cleaned
-      names = new File(topologyCheckpointRoot).list();
-      for (String name : names) {
-        if (name.compareTo(oldestCheckpointPreserved) < 0) {
-          throw new StatefulStorageException("Failed to delete " + name);
+        // Do a double check. Now all checkpoints with smaller checkpoint id should be cleaned
+        names = new File(topologyCheckpointRoot).list();
+        for (String name : names) {
+          if (name.compareTo(oldestCheckpointPreserved) < 0) {
+            throw new StatefulStorageException("Failed to delete " + name);
+          }
         }
       }
     }


### PR DESCRIPTION
Currently, if there's no checkpoint file under the root dir, the LocalFileSystemStorage will raise an NPE directly and cause the process to stop when handling the clean checkpoint request.

This PR avoids the NPE and log a warning if there're no files to be deleted under the root directory.