### PR TITLE
add src export target for downloader

### DIFF
--- a/heron/downloaders/src/java/BUILD
+++ b/heron/downloaders/src/java/BUILD
@@ -21,3 +21,8 @@ genrule(
   outs = ["heron-downloader.jar"],
   cmd  = "cp $< $@",
 )
+
+filegroup(
+  name = "exported-downloader-java-src",
+  srcs = glob(["**/*.java"]),
+)


### PR DESCRIPTION
In some environment, the developers would like to develop their own downloaders. This PR exports the downloader src so that they can be included into the customized downloader.

This PR does not change existing behavior.