### PR TITLE
Fix Potential Double Delete Bug

### DIFF
--- a/heron/common/src/cpp/network/client.h
+++ b/heron/common/src/cpp/network/client.h
@@ -199,7 +199,7 @@ class Client : public BaseClient {
 
   void InternalSendRequest(google::protobuf::Message* _request, void* _ctx, sp_int64 _msecs);
   void InternalSendMessage(const google::protobuf::Message& _message);
-  void InternalSendResponse(OutgoingPacket* _packet);
+  void InternalSendResponse(OutgoingPacket& _packet);
 
   // Internal method to be called by the Connection class
   // when a new packet arrives

--- a/heron/common/src/cpp/network/connection.cpp
+++ b/heron/common/src/cpp/network/connection.cpp
@@ -62,7 +62,7 @@ sp_int32 Connection::sendPacket(OutgoingPacket& packet) {
   if (hasCausedBackPressure()) {
     return 0;
   }
-  
+
   // Are we above the threshold?
   if (getOutstandingBytes() >= mOptions->high_watermark_) {
     // Have we been above the threshold enough number of times?

--- a/heron/common/src/cpp/network/connection.h
+++ b/heron/common/src/cpp/network/connection.h
@@ -82,7 +82,7 @@ class Connection : public BaseConnection {
    * A negative value of sendPacket indicates an error. The most likely error is improperly
    * formatted packet.
    */
-  sp_int32 sendPacket(OutgoingPacket* packet);
+  sp_int32 sendPacket(OutgoingPacket& packet);
 
   /**
    * Invoke the callback cb when a new packet arrives. A pointer to the packet is passed


### PR DESCRIPTION
This fixes a double free bug that periodically causes the stream manager to crash if other stream managers or are killed at the right time. 

In this case opkt has the potential to be freed twice in the event of a failed packet sent in both `InternalSendResponse` and `conn->sendPacket(opkt)`

