### PR TITLE
cleaning setup scripts for removed directories

### DIFF
--- a/scripts/get_all_heron_paths.sh
+++ b/scripts/get_all_heron_paths.sh
@@ -67,7 +67,7 @@ function get_package_of() {
 }
 
 function get_heron_java_paths() {
-  local java_paths=$(find {heron,heron/tools,tools,integration_test,storm-compatibility,contrib,eco,eco-storm-examples,eco-heron-examples} -name "*.java" | sed "s|/src/java/.*$|/src/java|"| sed "s|/java/src/.*$|/java/src|" |  sed "s|/tests/java/.*$|/tests/java|" | sort -u | fgrep -v "heron/scheduler/" | fgrep -v "heron/scheduler/" )
+  local java_paths=$(find {heron,heron/tools,tools,integration_test,storm-compatibility,eco,eco-storm-examples,eco-heron-examples} -name "*.java" | sed "s|/src/java/.*$|/src/java|"| sed "s|/java/src/.*$|/java/src|" |  sed "s|/tests/java/.*$|/tests/java|" | sort -u | fgrep -v "heron/scheduler/" | fgrep -v "heron/scheduler/" )
   if [ "$(uname -s | tr 'A-Z' 'a-z')" != "darwin" ]; then
     java_paths=$(echo "${java_paths}" | fgrep -v "/objc_tools/")
   fi
@@ -105,8 +105,7 @@ function get_containing_library() {
 
 function collect_generated_binary_deps() {
   local proto_deps=$(find bazel-bin/heron/proto -type f | grep "jar$");
-  local thrift_deps=$(find bazel-bin/heron/metricsmgr/src/thrift -type f | grep "jar$");
-  echo "${proto_deps} ${thrift_deps}" | sort | uniq
+  echo "${proto_deps}" | sort | uniq
 }
 
 function collect_generated_paths() {


### PR DESCRIPTION
Two directories are removed from the project but the paths are not updated accordingly in the setup scripts. And causing the following warning:

```
find: contrib: No such file or directory
find: bazel-bin/heron/metricsmgr/src/thrift: No such file or directory
```

This PR is to fix the issue. After the cleaning, the building result is:

```
INFO: Build completed successfully, 4754 total actions
Bazel build successful!!
Path is /Users/nlu/workspace/heron
Generating IDEA project...
Done. IDEA module file: heron.iml
Opening Heron project in IDEA...
Done.
```