### PR TITLE
log the object when it cannot be serialized when emitting tuples

### DIFF
--- a/heron/api/src/java/org/apache/heron/api/serializer/JavaSerializer.java
+++ b/heron/api/src/java/org/apache/heron/api/serializer/JavaSerializer.java
@@ -40,7 +40,7 @@ public class JavaSerializer implements IPluggableSerializer {
       oos.writeObject(object);
       oos.flush();
     } catch (IOException e) {
-      throw new RuntimeException("NotSerializable object is: " + object.toString(), e);
+      throw new RuntimeException("Failed to serialize object: " + object.toString(), e);
     }
     return bos.toByteArray();
   }

--- a/heron/api/src/java/org/apache/heron/api/serializer/JavaSerializer.java
+++ b/heron/api/src/java/org/apache/heron/api/serializer/JavaSerializer.java
@@ -40,7 +40,7 @@ public class JavaSerializer implements IPluggableSerializer {
       oos.writeObject(object);
       oos.flush();
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException("NotSerializable object is: " + object.toString(), e);
     }
     return bos.toByteArray();
   }


### PR DESCRIPTION
We saw some topology may encounter the NotSerializableException and the heron-instance crashes. But the user may not be able to analyze why his tuple has NotSerializableException. This PR logs the tuple content to make the diagnosis easy.

