### PR TITLE
[WIP] Use six to make heronpy tests pass in python3

### DIFF
--- a/heronpy/api/tests/python/serializer_unittest.py
+++ b/heronpy/api/tests/python/serializer_unittest.py
@@ -23,6 +23,7 @@
 
 import unittest
 
+import six
 from heronpy.api.serializer import PythonSerializer
 
 prim_list = [1000, -234, 0.00023, "string",
@@ -39,6 +40,6 @@ class SerializerTest(unittest.TestCase):
     # Test with a list of primitive types
     for obj in prim_list:
       serialized = serializer.serialize(obj)
-      self.assertIsInstance(serialized, str)
+      self.assertIsInstance(serialized, six.binary_type)
       deserialized = serializer.deserialize(serialized)
       self.assertEqual(deserialized, obj)

--- a/heronpy/api/topology.py
+++ b/heronpy/api/topology.py
@@ -26,10 +26,11 @@ import os
 import uuid
 
 import heronpy.api.api_constants as api_constants
+import six
+from heronpy.api.component.component_spec import HeronComponentSpec
 from heronpy.api.serializer import default_serializer
 from heronpy.proto import topology_pb2
 
-from heronpy.api.component.component_spec import HeronComponentSpec
 
 class TopologyType(type):
   """Metaclass to define a Heron topology in Python"""
@@ -255,6 +256,7 @@ class TopologyType(type):
 
     return sanitized
 
+@six.add_metaclass(TopologyType)
 class Topology(object):
   """Topology is an abstract class for defining a topology
 
@@ -285,7 +287,6 @@ class Topology(object):
                                     inputs={word_spout: Grouping.fields('word')},
                                     config={"count_bolt.specific.config": "another value"})
   """
-  __metaclass__ = TopologyType
 
   # pylint: disable=no-member
   @classmethod

--- a/scripts/packages/heronpy/requirements.txt
+++ b/scripts/packages/heronpy/requirements.txt
@@ -1,1 +1,2 @@
 protobuf==3.4.0
+six


### PR DESCRIPTION
I don't know if it is this simple, so throwing this at Travis to see if it sticks. I will work on getting py3 PEXs deployable in the week after next, that is if this doesn't magically do the trick - I have yet to get set up for testing.

`six` could also be used to clean up `try/except` imports in heronpy and possibly the other python code.