### PR TITLE
[healthmgr] Enable runtime toggle for AutoRestartBackpressureContainerPolicy

### DIFF
--- a/heron/config/src/yaml/conf/local/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/local/healthmgr.yaml
@@ -18,19 +18,19 @@
 # Topology health manager mode:
 # disabled = do not launch the health manager
 # cluster = launch the health manager on container-0
-heron.topology.healthmgr.mode: cluster
+heron.topology.healthmgr.mode: disabled
 
 # Default class and url for providing metrics
-heron.healthmgr.metricsource.type: org.apache.heron.healthmgr.sensors.MetricsCacheMetricsProvider
+heron.healthmgr.metricsource.type: org.apache.heron.healthmgr.sensors.TrackerMetricsProvider
 heron.healthmgr.metricsource.url: http://localhost:8888
 
 # Enable MetricsCache if MetricsCache is chosen as metrics provider
-heron.topology.metricscachemgr.mode: cluster
+#heron.topology.metricscachemgr.mode: cluster
 
 ## list of policies to be executed for self regulation
-heron.class.health.policies:
+#heron.class.health.policies:
 #  - dynamic-resource-allocation
-  - auto-restart-backpressure-container
+#  - auto-restart-backpressure-container
 #
 ## configuration specific to individual policies listed above
 #dynamic-resource-allocation:
@@ -38,7 +38,7 @@ heron.class.health.policies:
 #  health.policy.interval.ms: 120000
 #  BackPressureDetector.noiseFilterMillis: 20
 #  GrowingWaitQueueDetector.limit: 5
-auto-restart-backpressure-container:
-  health.policy.class: org.apache.heron.healthmgr.policy.AutoRestartBackpressureContainerPolicy
-  health.policy.interval.ms: 120000
-  BackPressureDetector.noiseFilterMillis: 20
+#auto-restart-backpressure-container:
+#  health.policy.class: org.apache.heron.healthmgr.policy.AutoRestartBackpressureContainerPolicy
+#  health.policy.interval.ms: 120000
+#  BackPressureDetector.noiseFilterMillis: 20

--- a/heron/config/src/yaml/conf/local/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/local/healthmgr.yaml
@@ -35,12 +35,14 @@ heron.class.health.policies:
   - auto-restart-backpressure-container
 
 ## configuration specific to individual policies listed above
+
 #dynamic-resource-allocation:
 #  health.policy.mode: deactivated
 #  health.policy.class: org.apache.heron.healthmgr.policy.DynamicResourceAllocationPolicy
 #  health.policy.interval.ms: 120000
 #  BackPressureDetector.noiseFilterMillis: 20
 #  GrowingWaitQueueDetector.limit: 5
+
 auto-restart-backpressure-container:
   # policy toggle value:
   # deactivated = freeze this policy

--- a/heron/config/src/yaml/conf/local/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/local/healthmgr.yaml
@@ -18,27 +18,32 @@
 # Topology health manager mode:
 # disabled = do not launch the health manager
 # cluster = launch the health manager on container-0
-heron.topology.healthmgr.mode: disabled
+heron.topology.healthmgr.mode: cluster
 
 # Default class and url for providing metrics
-heron.healthmgr.metricsource.type: org.apache.heron.healthmgr.sensors.TrackerMetricsProvider
+heron.healthmgr.metricsource.type: org.apache.heron.healthmgr.sensors.MetricsCacheMetricsProvider
 heron.healthmgr.metricsource.url: http://localhost:8888
 
 # Enable MetricsCache if MetricsCache is chosen as metrics provider
-#heron.topology.metricscachemgr.mode: cluster
+heron.topology.metricscachemgr.mode: cluster
 
 ## list of policies to be executed for self regulation
-#heron.class.health.policies:
+heron.class.health.policies:
 #  - dynamic-resource-allocation
-#  - auto-restart-backpressure-container
-#
+  - auto-restart-backpressure-container
+
 ## configuration specific to individual policies listed above
 #dynamic-resource-allocation:
+#  health.policy.mode: deactivated
 #  health.policy.class: org.apache.heron.healthmgr.policy.DynamicResourceAllocationPolicy
 #  health.policy.interval.ms: 120000
 #  BackPressureDetector.noiseFilterMillis: 20
 #  GrowingWaitQueueDetector.limit: 5
-#auto-restart-backpressure-container:
-#  health.policy.class: org.apache.heron.healthmgr.policy.AutoRestartBackpressureContainerPolicy
-#  health.policy.interval.ms: 120000
-#  BackPressureDetector.noiseFilterMillis: 20
+auto-restart-backpressure-container:
+  # policy toggle value:
+  # deactivated = freeze this policy
+  # activated = turn on this policy
+  health.policy.mode: deactivated
+  health.policy.class: org.apache.heron.healthmgr.policy.AutoRestartBackpressureContainerPolicy
+  health.policy.interval.ms: 20000
+  BackPressureDetector.noiseFilterMillis: 20

--- a/heron/config/src/yaml/conf/local/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/local/healthmgr.yaml
@@ -25,6 +25,8 @@ heron.healthmgr.metricsource.type: org.apache.heron.healthmgr.sensors.MetricsCac
 heron.healthmgr.metricsource.url: http://localhost:8888
 
 # Enable MetricsCache if MetricsCache is chosen as metrics provider
+# disabled = do not launch the metricscache manager
+# cluster = launch the metricscache manager on container-0
 heron.topology.metricscachemgr.mode: cluster
 
 ## list of policies to be executed for self regulation

--- a/heron/config/src/yaml/conf/local/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/local/healthmgr.yaml
@@ -18,19 +18,19 @@
 # Topology health manager mode:
 # disabled = do not launch the health manager
 # cluster = launch the health manager on container-0
-heron.topology.healthmgr.mode: disabled
+heron.topology.healthmgr.mode: cluster
 
 # Default class and url for providing metrics
-heron.healthmgr.metricsource.type: org.apache.heron.healthmgr.sensors.TrackerMetricsProvider
+heron.healthmgr.metricsource.type: org.apache.heron.healthmgr.sensors.MetricsCacheMetricsProvider
 heron.healthmgr.metricsource.url: http://localhost:8888
 
 # Enable MetricsCache if MetricsCache is chosen as metrics provider
-#heron.topology.metricscachemgr.mode: cluster
+heron.topology.metricscachemgr.mode: cluster
 
 ## list of policies to be executed for self regulation
-#heron.class.health.policies:
+heron.class.health.policies:
 #  - dynamic-resource-allocation
-#  - auto-restart-backpressure-container
+  - auto-restart-backpressure-container
 #
 ## configuration specific to individual policies listed above
 #dynamic-resource-allocation:
@@ -38,7 +38,7 @@ heron.healthmgr.metricsource.url: http://localhost:8888
 #  health.policy.interval.ms: 120000
 #  BackPressureDetector.noiseFilterMillis: 20
 #  GrowingWaitQueueDetector.limit: 5
-#auto-restart-backpressure-container:
-#  health.policy.class: org.apache.heron.healthmgr.policy.AutoRestartBackpressureContainerPolicy
-#  health.policy.interval.ms: 120000
-#  BackPressureDetector.noiseFilterMillis: 20
+auto-restart-backpressure-container:
+  health.policy.class: org.apache.heron.healthmgr.policy.AutoRestartBackpressureContainerPolicy
+  health.policy.interval.ms: 120000
+  BackPressureDetector.noiseFilterMillis: 20

--- a/heron/config/src/yaml/conf/sandbox/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/sandbox/healthmgr.yaml
@@ -35,12 +35,14 @@ heron.class.health.policies:
   - auto-restart-backpressure-container
 
 ## configuration specific to individual policies listed above
+
 #dynamic-resource-allocation:
 #  health.policy.mode: deactivated
 #  health.policy.class: org.apache.heron.healthmgr.policy.DynamicResourceAllocationPolicy
 #  health.policy.interval.ms: 120000
 #  BackPressureDetector.noiseFilterMillis: 20
 #  GrowingWaitQueueDetector.limit: 5
+
 auto-restart-backpressure-container:
   # policy toggle value:
   # deactivated = freeze this policy

--- a/heron/config/src/yaml/conf/sandbox/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/sandbox/healthmgr.yaml
@@ -18,27 +18,34 @@
 # Topology health manager mode:
 # disabled = do not launch the health manager
 # cluster = launch the health manager on container-0
-heron.topology.healthmgr.mode: disabled
+heron.topology.healthmgr.mode: cluster
 
 # Default class and url for providing metrics
-heron.healthmgr.metricsource.type: org.apache.heron.healthmgr.sensors.TrackerMetricsProvider
+heron.healthmgr.metricsource.type: org.apache.heron.healthmgr.sensors.MetricsCacheMetricsProvider
 heron.healthmgr.metricsource.url: http://localhost:8888
 
 # Enable MetricsCache if MetricsCache is chosen as metrics provider
-#heron.topology.metricscachemgr.mode: cluster
+# disabled = do not launch the metricscache manager
+# cluster = launch the metricscache manager on container-0
+heron.topology.metricscachemgr.mode: cluster
 
 ## list of policies to be executed for self regulation
-#heron.class.health.policies:
+heron.class.health.policies:
 #  - dynamic-resource-allocation
-#  - auto-restart-backpressure-container
-#
+  - auto-restart-backpressure-container
+
 ## configuration specific to individual policies listed above
 #dynamic-resource-allocation:
+#  health.policy.mode: deactivated
 #  health.policy.class: org.apache.heron.healthmgr.policy.DynamicResourceAllocationPolicy
 #  health.policy.interval.ms: 120000
 #  BackPressureDetector.noiseFilterMillis: 20
 #  GrowingWaitQueueDetector.limit: 5
-#auto-restart-backpressure-container:
-#  health.policy.class: org.apache.heron.healthmgr.policy.AutoRestartBackpressureContainerPolicy
-#  health.policy.interval.ms: 120000
-#  BackPressureDetector.noiseFilterMillis: 20
+auto-restart-backpressure-container:
+  # policy toggle value:
+  # deactivated = freeze this policy
+  # activated = turn on this policy
+  health.policy.mode: deactivated
+  health.policy.class: org.apache.heron.healthmgr.policy.AutoRestartBackpressureContainerPolicy
+  health.policy.interval.ms: 20000
+  BackPressureDetector.noiseFilterMillis: 20

--- a/heron/config/src/yaml/conf/yarn/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/yarn/healthmgr.yaml
@@ -35,12 +35,14 @@ heron.class.health.policies:
   - auto-restart-backpressure-container
 
 ## configuration specific to individual policies listed above
+
 #dynamic-resource-allocation:
 #  health.policy.mode: deactivated
 #  health.policy.class: org.apache.heron.healthmgr.policy.DynamicResourceAllocationPolicy
 #  health.policy.interval.ms: 120000
 #  BackPressureDetector.noiseFilterMillis: 20
 #  GrowingWaitQueueDetector.limit: 5
+
 auto-restart-backpressure-container:
   # policy toggle value:
   # deactivated = freeze this policy

--- a/heron/config/src/yaml/conf/yarn/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/yarn/healthmgr.yaml
@@ -18,22 +18,34 @@
 # Topology health manager mode:
 # disabled = do not launch the health manager
 # cluster = launch the health manager on container-0
-heron.topology.healthmgr.mode: disabled
+heron.topology.healthmgr.mode: cluster
 
 # Default class and url for providing metrics
-heron.healthmgr.metricsource.type: org.apache.heron.healthmgr.sensors.TrackerMetricsProvider
+heron.healthmgr.metricsource.type: org.apache.heron.healthmgr.sensors.MetricsCacheMetricsProvider
 heron.healthmgr.metricsource.url: http://localhost:8888
 
 # Enable MetricsCache if MetricsCache is chosen as metrics provider
-#heron.topology.metricscachemgr.mode: cluster
+# disabled = do not launch the metricscache manager
+# cluster = launch the metricscache manager on container-0
+heron.topology.metricscachemgr.mode: cluster
 
 ## list of policies to be executed for self regulation
-#heron.class.health.policies:
+heron.class.health.policies:
 #  - dynamic-resource-allocation
-#
+  - auto-restart-backpressure-container
+
 ## configuration specific to individual policies listed above
 #dynamic-resource-allocation:
+#  health.policy.mode: deactivated
 #  health.policy.class: org.apache.heron.healthmgr.policy.DynamicResourceAllocationPolicy
 #  health.policy.interval.ms: 120000
 #  BackPressureDetector.noiseFilterMillis: 20
 #  GrowingWaitQueueDetector.limit: 5
+auto-restart-backpressure-container:
+  # policy toggle value:
+  # deactivated = freeze this policy
+  # activated = turn on this policy
+  health.policy.mode: deactivated
+  health.policy.class: org.apache.heron.healthmgr.policy.AutoRestartBackpressureContainerPolicy
+  health.policy.interval.ms: 20000
+  BackPressureDetector.noiseFilterMillis: 20

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthManager.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthManager.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
@@ -67,7 +66,10 @@ import org.apache.heron.spi.statemgr.IStateManager;
 import org.apache.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import org.apache.heron.spi.utils.ReflectionUtils;
 
-import static org.apache.heron.healthmgr.HealthPolicyConfig.*;
+import static org.apache.heron.healthmgr.HealthPolicyConfig.CONF_METRICS_SOURCE_TYPE;
+import static org.apache.heron.healthmgr.HealthPolicyConfig.CONF_METRICS_SOURCE_URL;
+import static org.apache.heron.healthmgr.HealthPolicyConfig.CONF_POLICY_ID;
+import static org.apache.heron.healthmgr.HealthPolicyConfig.CONF_TOPOLOGY_NAME;
 
 /**
  * {@link HealthManager} makes a topology dynamic and self-regulating. This is implemented using

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthManager.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthManager.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
@@ -66,9 +67,7 @@ import org.apache.heron.spi.statemgr.IStateManager;
 import org.apache.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import org.apache.heron.spi.utils.ReflectionUtils;
 
-import static org.apache.heron.healthmgr.HealthPolicyConfig.CONF_METRICS_SOURCE_TYPE;
-import static org.apache.heron.healthmgr.HealthPolicyConfig.CONF_METRICS_SOURCE_URL;
-import static org.apache.heron.healthmgr.HealthPolicyConfig.CONF_TOPOLOGY_NAME;
+import static org.apache.heron.healthmgr.HealthPolicyConfig.*;
 
 /**
  * {@link HealthManager} makes a topology dynamic and self-regulating. This is implemented using
@@ -314,7 +313,7 @@ public class HealthManager {
       Class<IHealthPolicy> policyClass
           = (Class<IHealthPolicy>) this.getClass().getClassLoader().loadClass(policyClassName);
 
-      AbstractModule module = constructPolicySpecificModule(policyConfig);
+      AbstractModule module = constructPolicySpecificModule(policyId, policyConfig);
       IHealthPolicy policy = injector.createChildInjector(module).getInstance(policyClass);
 
       healthPolicies.add(policy);
@@ -378,10 +377,14 @@ public class HealthManager {
     };
   }
 
-  private AbstractModule constructPolicySpecificModule(final HealthPolicyConfig policyConfig) {
+  private AbstractModule constructPolicySpecificModule(
+      final String policyId, final HealthPolicyConfig policyConfig) {
     return new AbstractModule() {
       @Override
       protected void configure() {
+        bind(String.class)
+            .annotatedWith(Names.named(CONF_POLICY_ID))
+            .toInstance(policyId);
         bind(HealthPolicyConfig.class).toInstance(policyConfig);
       }
     };

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthPolicyConfig.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthPolicyConfig.java
@@ -33,6 +33,7 @@ public class HealthPolicyConfig {
   public static final String CONF_POLICY_ID = "POLICY_ID";
 
   public static final String CONF_POLICY_MODE_DEACTIVATED = "deactivated";
+  public static final String CONF_POLICY_MODE_ACTIVATED = "activated";
 
   private static final Logger LOG = Logger.getLogger(HealthPolicyConfig.class.getName());
   private final Map<String, Object> configs;
@@ -48,10 +49,15 @@ public class HealthPolicyConfig {
 
   public ToggleablePolicy.PolicyMode getPolicyMode() {
     String configKey = PolicyConfigKey.HEALTH_POLICY_MODE.key();
-    if (configs.containsKey(configKey)
-        && CONF_POLICY_MODE_DEACTIVATED.equals(
-            (String) configs.get(PolicyConfigKey.HEALTH_POLICY_MODE.key()))) {
-      return ToggleablePolicy.PolicyMode.deactivated;
+    if (configs.containsKey(configKey)) {
+      String val = (String) configs.get(PolicyConfigKey.HEALTH_POLICY_MODE.key());
+      if (CONF_POLICY_MODE_DEACTIVATED.equals(val)) {
+        return ToggleablePolicy.PolicyMode.deactivated;
+      } else if (CONF_POLICY_MODE_ACTIVATED.equals(val)) {
+        return ToggleablePolicy.PolicyMode.activated;
+      } else {
+        LOG.warning("unknown policy mode config " + val);
+      }
     }
     return ToggleablePolicy.PolicyMode.activated;
   }

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthPolicyConfig.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthPolicyConfig.java
@@ -32,6 +32,8 @@ public class HealthPolicyConfig {
   public static final String CONF_METRICS_SOURCE_TYPE = "METRICS_SOURCE_TYPE";
   public static final String CONF_POLICY_ID = "POLICY_ID";
 
+  public static final String CONF_POLICY_MODE_DEACTIVATED = "deactivated";
+
   private static final Logger LOG = Logger.getLogger(HealthPolicyConfig.class.getName());
   private final Map<String, Object> configs;
 
@@ -47,14 +49,15 @@ public class HealthPolicyConfig {
   public ToggleablePolicy.PolicyMode getPolicyMode() {
     String configKey = PolicyConfigKey.HEALTH_POLICY_MODE.key();
     if (configs.containsKey(configKey)
-        && "deactivated".equals((String) configs.get(PolicyConfigKey.HEALTH_POLICY_MODE.key()))) {
+        && CONF_POLICY_MODE_DEACTIVATED.equals(
+            (String) configs.get(PolicyConfigKey.HEALTH_POLICY_MODE.key()))) {
       return ToggleablePolicy.PolicyMode.deactivated;
     }
     return ToggleablePolicy.PolicyMode.activated;
   }
 
   public Duration getInterval() {
-    return Duration.ofMillis((int) configs.get(PolicyConfigKey.HEALTH_POLICY_INTERVAL.key()));
+    return Duration.ofMillis((int) configs.get(PolicyConfigKey.HEALTH_POLICY_INTERVAL_MS.key()));
   }
 
   public Object getConfig(String configName) {

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthPolicyConfig.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthPolicyConfig.java
@@ -42,6 +42,15 @@ public class HealthPolicyConfig {
     return (String) configs.get(PolicyConfigKey.HEALTH_POLICY_CLASS.key());
   }
 
+  String getPolicyMode() {
+    String configKey = PolicyConfigKey.HEALTH_POLICY_MODE.key();
+    if (configs.containsKey(configKey)
+        && "deactivated".equals((String) configs.get(PolicyConfigKey.HEALTH_POLICY_MODE.key()))) {
+      return "deactivated";
+    }
+    return "activated";
+  }
+
   public Duration getInterval() {
     return Duration.ofMillis((int) configs.get(PolicyConfigKey.HEALTH_POLICY_INTERVAL.key()));
   }

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthPolicyConfig.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthPolicyConfig.java
@@ -24,11 +24,13 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 import org.apache.heron.healthmgr.HealthPolicyConfigReader.PolicyConfigKey;
+import org.apache.heron.healthmgr.policy.ToggleablePolicy;
 
 public class HealthPolicyConfig {
   public static final String CONF_TOPOLOGY_NAME = "TOPOLOGY_NAME";
   public static final String CONF_METRICS_SOURCE_URL = "METRICS_SOURCE_URL";
   public static final String CONF_METRICS_SOURCE_TYPE = "METRICS_SOURCE_TYPE";
+  public static final String CONF_POLICY_ID = "POLICY_ID";
 
   private static final Logger LOG = Logger.getLogger(HealthPolicyConfig.class.getName());
   private final Map<String, Object> configs;
@@ -42,13 +44,13 @@ public class HealthPolicyConfig {
     return (String) configs.get(PolicyConfigKey.HEALTH_POLICY_CLASS.key());
   }
 
-  String getPolicyMode() {
+  public ToggleablePolicy.PolicyMode getPolicyMode() {
     String configKey = PolicyConfigKey.HEALTH_POLICY_MODE.key();
     if (configs.containsKey(configKey)
         && "deactivated".equals((String) configs.get(PolicyConfigKey.HEALTH_POLICY_MODE.key()))) {
-      return "deactivated";
+      return ToggleablePolicy.PolicyMode.deactivated;
     }
-    return "activated";
+    return ToggleablePolicy.PolicyMode.activated;
   }
 
   public Duration getInterval() {

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthPolicyConfigReader.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthPolicyConfigReader.java
@@ -49,6 +49,7 @@ public class HealthPolicyConfigReader {
   public enum PolicyConfigKey {
     CONF_FILE_NAME("healthmgr.yaml"),
     HEALTH_POLICIES("heron.class.health.policies"),
+    HEALTH_POLICY_MODE("health.policy.mode"),
     HEALTH_POLICY_CLASS("health.policy.class"),
     HEALTH_POLICY_INTERVAL("health.policy.interval.ms"),
     CONF_SENSOR_DURATION_SUFFIX(".duration"),

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthPolicyConfigReader.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/HealthPolicyConfigReader.java
@@ -51,7 +51,7 @@ public class HealthPolicyConfigReader {
     HEALTH_POLICIES("heron.class.health.policies"),
     HEALTH_POLICY_MODE("health.policy.mode"),
     HEALTH_POLICY_CLASS("health.policy.class"),
-    HEALTH_POLICY_INTERVAL("health.policy.interval.ms"),
+    HEALTH_POLICY_INTERVAL_MS("health.policy.interval.ms"),
     CONF_SENSOR_DURATION_SUFFIX(".duration"),
     METRIC_SOURCE_TYPE("heron.healthmgr.metricsource.type"),
     METRIC_SOURCE_URL("heron.healthmgr.metricsource.url");

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/common/PhysicalPlanProvider.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/common/PhysicalPlanProvider.java
@@ -78,12 +78,10 @@ public class PhysicalPlanProvider implements Provider<PhysicalPlan> {
 
   @Override
   public synchronized PhysicalPlan get() {
-//    if (physicalPlan == null) {
     physicalPlan = stateManagerAdaptor.getPhysicalPlan(topologyName);
     if (physicalPlan == null) {
       throw new InvalidStateException(topologyName, "Failed to fetch the physical plan");
     }
-//    }
     return physicalPlan;
   }
 

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/common/PhysicalPlanProvider.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/common/PhysicalPlanProvider.java
@@ -78,12 +78,12 @@ public class PhysicalPlanProvider implements Provider<PhysicalPlan> {
 
   @Override
   public synchronized PhysicalPlan get() {
+//    if (physicalPlan == null) {
+    physicalPlan = stateManagerAdaptor.getPhysicalPlan(topologyName);
     if (physicalPlan == null) {
-      physicalPlan = stateManagerAdaptor.getPhysicalPlan(topologyName);
-      if (physicalPlan == null) {
-        throw new InvalidStateException(topologyName, "Failed to fetch the physical plan");
-      }
+      throw new InvalidStateException(topologyName, "Failed to fetch the physical plan");
     }
+//    }
     return physicalPlan;
   }
 

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/AutoRestartBackpressureContainerPolicy.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/AutoRestartBackpressureContainerPolicy.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 
 import com.microsoft.dhalion.events.EventHandler;
 import com.microsoft.dhalion.events.EventManager;
-import com.microsoft.dhalion.policy.HealthPolicyImpl;
 
 import org.apache.heron.healthmgr.HealthPolicyConfig;
 import org.apache.heron.healthmgr.common.HealthManagerEvents.ContainerRestart;
@@ -42,7 +41,7 @@ import static org.apache.heron.healthmgr.HealthPolicyConfigReader.PolicyConfigKe
  * state for long time, which we believe the container cannot recover.
  * 2. resolver: try to restart the backpressure container so as to be rescheduled.
  */
-public class AutoRestartBackpressureContainerPolicy extends HealthPolicyImpl
+public class AutoRestartBackpressureContainerPolicy extends ToggleablePolicy
     implements EventHandler<ContainerRestart> {
 
   private static final String CONF_WAIT_INTERVAL_MILLIS =

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/AutoRestartBackpressureContainerPolicy.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/AutoRestartBackpressureContainerPolicy.java
@@ -23,16 +23,19 @@ import java.time.Duration;
 import java.util.logging.Logger;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import com.microsoft.dhalion.events.EventHandler;
 import com.microsoft.dhalion.events.EventManager;
 
 import org.apache.heron.healthmgr.HealthPolicyConfig;
 import org.apache.heron.healthmgr.common.HealthManagerEvents.ContainerRestart;
+import org.apache.heron.healthmgr.common.PhysicalPlanProvider;
 import org.apache.heron.healthmgr.detectors.BackPressureDetector;
 import org.apache.heron.healthmgr.resolvers.RestartContainerResolver;
 import org.apache.heron.healthmgr.sensors.BackPressureSensor;
 
+import static org.apache.heron.healthmgr.HealthPolicyConfig.CONF_POLICY_ID;
 import static org.apache.heron.healthmgr.HealthPolicyConfigReader.PolicyConfigKey.HEALTH_POLICY_INTERVAL;
 
 /**
@@ -49,15 +52,16 @@ public class AutoRestartBackpressureContainerPolicy extends ToggleablePolicy
   private static final Logger LOG =
       Logger.getLogger(AutoRestartBackpressureContainerPolicy.class.getName());
 
-  private final HealthPolicyConfig policyConfig;
 
   @Inject
-  AutoRestartBackpressureContainerPolicy(HealthPolicyConfig policyConfig,
+  AutoRestartBackpressureContainerPolicy(@Named(CONF_POLICY_ID) String policyId,
+                                         HealthPolicyConfig policyConfig,
+                                         PhysicalPlanProvider physicalPlanProvider,
                                          EventManager eventManager,
                                          BackPressureSensor backPressureSensor,
                                          BackPressureDetector backPressureDetector,
                                          RestartContainerResolver restartContainerResolver) {
-    this.policyConfig = policyConfig;
+    super(policyId, policyConfig, physicalPlanProvider);
 
     registerSensors(backPressureSensor);
     registerDetectors(backPressureDetector);

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/AutoRestartBackpressureContainerPolicy.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/AutoRestartBackpressureContainerPolicy.java
@@ -36,7 +36,7 @@ import org.apache.heron.healthmgr.resolvers.RestartContainerResolver;
 import org.apache.heron.healthmgr.sensors.BackPressureSensor;
 
 import static org.apache.heron.healthmgr.HealthPolicyConfig.CONF_POLICY_ID;
-import static org.apache.heron.healthmgr.HealthPolicyConfigReader.PolicyConfigKey.HEALTH_POLICY_INTERVAL;
+import static org.apache.heron.healthmgr.HealthPolicyConfigReader.PolicyConfigKey.HEALTH_POLICY_INTERVAL_MS;
 
 /**
  * This Policy class
@@ -68,7 +68,7 @@ public class AutoRestartBackpressureContainerPolicy extends ToggleablePolicy
     registerResolvers(restartContainerResolver);
 
     setPolicyExecutionInterval(
-        Duration.ofMillis((int) policyConfig.getConfig(HEALTH_POLICY_INTERVAL.key(), 60000)));
+        Duration.ofMillis((int) policyConfig.getConfig(HEALTH_POLICY_INTERVAL_MS.key(), 60000)));
 
     eventManager.addEventListener(ContainerRestart.class, this);
   }

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/DynamicResourceAllocationPolicy.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/DynamicResourceAllocationPolicy.java
@@ -46,7 +46,7 @@ import org.apache.heron.healthmgr.sensors.BackPressureSensor;
 import org.apache.heron.healthmgr.sensors.BufferSizeSensor;
 import org.apache.heron.healthmgr.sensors.ExecuteCountSensor;
 
-import static org.apache.heron.healthmgr.HealthPolicyConfigReader.PolicyConfigKey.HEALTH_POLICY_INTERVAL;
+import static org.apache.heron.healthmgr.HealthPolicyConfigReader.PolicyConfigKey.HEALTH_POLICY_INTERVAL_MS;
 import static org.apache.heron.healthmgr.diagnosers.BaseDiagnoser.DiagnosisType.DIAGNOSIS_DATA_SKEW;
 import static org.apache.heron.healthmgr.diagnosers.BaseDiagnoser.DiagnosisType.DIAGNOSIS_SLOW_INSTANCE;
 import static org.apache.heron.healthmgr.diagnosers.BaseDiagnoser.DiagnosisType.DIAGNOSIS_UNDER_PROVISIONING;
@@ -86,7 +86,7 @@ public class DynamicResourceAllocationPolicy extends HealthPolicyImpl
     registerResolvers(scaleUpResolver);
 
     setPolicyExecutionInterval(
-        Duration.ofMillis((int) policyConfig.getConfig(HEALTH_POLICY_INTERVAL.key(), 60000)));
+        Duration.ofMillis((int) policyConfig.getConfig(HEALTH_POLICY_INTERVAL_MS.key(), 60000)));
 
     eventManager.addEventListener(TopologyUpdate.class, this);
   }

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
@@ -49,6 +49,8 @@ public class ToggleablePolicy extends HealthPolicyImpl {
   @Inject
   protected PhysicalPlanProvider physicalPlanProvider;
   protected boolean running = true;
+  // `policyConfigKey` is the config item for this policy in the healthmgr.yaml
+  protected String policyConfigKey;
 
   @Override
   public Collection<Measurement> executeSensors() {

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
@@ -57,18 +57,12 @@ public class ToggleablePolicy extends HealthPolicyImpl {
       LOG.info("kv " + kv.getKey() + " => " + kv.getValue());
       if (kv.getKey().equals(TOGGLE_RUNTIME_CONFIG_KEY)) {
         Boolean b = Boolean.parseBoolean(kv.getValue());
-        if (Boolean.FALSE.equals(b)) {
-          if (running) {
-            running = false;
-            LOG.info("policy running status changed to False");
-          }
-        } else if (Boolean.TRUE.equals(b)) {
-          if (!running) {
-            running = true;
-            LOG.info("policy running status changed to True");
-          }
-        } else {
-          LOG.warning("unknown runtime config for `policy running status`: " + val);
+        if (Boolean.FALSE.equals(b) && running) {
+          running = false;
+          LOG.info("policy running status changed to False");
+        } else if (Boolean.TRUE.equals(b) && !running) {
+          running = true;
+          LOG.info("policy running status changed to True");
         }
       }
     }

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.healthmgr.policy;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.logging.Logger;
+
+import javax.inject.Inject;
+
+import com.microsoft.dhalion.core.Action;
+import com.microsoft.dhalion.core.Diagnosis;
+import com.microsoft.dhalion.core.Measurement;
+import com.microsoft.dhalion.core.Symptom;
+import com.microsoft.dhalion.policy.HealthPolicyImpl;
+
+import org.apache.heron.api.generated.TopologyAPI;
+import org.apache.heron.healthmgr.common.PhysicalPlanProvider;
+
+/**
+ * This Policy class
+ * 1. has a switch
+ * 2. works with runtime config
+ */
+public class ToggleablePolicy extends HealthPolicyImpl {
+  private static final Logger LOG =
+      Logger.getLogger(ToggleablePolicy.class.getName());
+
+  public static final String TOGGLE_CONFIG_KEY = "healthmgr.toggleablepolicy.running";
+  public static final String TOGGLE_RUNTIME_CONFIG_KEY = TOGGLE_CONFIG_KEY + ":runtime";
+
+  @Inject
+  protected PhysicalPlanProvider physicalPlanProvider;
+  protected boolean running = true;
+
+//  @Inject
+//  ToggleablePolicy(PhysicalPlanProvider physicalPlanProvider) {
+//    running = true;
+//    this.physicalPlanProvider = physicalPlanProvider;
+//  }
+
+  @Override
+  public Collection<Measurement> executeSensors() {
+    for (TopologyAPI.Config.KeyValue kv
+        : physicalPlanProvider.get().getTopology().getTopologyConfig().getKvsList()) {
+      LOG.info("kv " + kv.getKey() + " => " + kv.getValue());
+      if (kv.getKey().equals(TOGGLE_RUNTIME_CONFIG_KEY)) {
+        String val = kv.getValue();
+        if ("False".equals(val) || "false".equals(val)) {
+          if (running) {
+            running = false;
+            LOG.info("policy running status changed to False");
+          }
+        } else if ("True".equals(val) || "true".equals(val)) {
+          if (!running) {
+            running = true;
+            LOG.info("policy running status changed to True");
+          }
+        } else {
+          LOG.warning("unknown runtime config for `policy running status`: " + val);
+        }
+      }
+    }
+
+    if (running) {
+      return super.executeSensors();
+    } else {
+      return new ArrayList<Measurement>();
+    }
+  }
+
+  @Override
+  public Collection<Symptom> executeDetectors(Collection<Measurement> measurements) {
+    if (running) {
+      return super.executeDetectors(measurements);
+    } else {
+      return new ArrayList<Symptom>();
+    }
+  }
+
+  @Override
+  public Collection<Diagnosis> executeDiagnosers(Collection<Symptom> symptoms) {
+    if (running) {
+      return super.executeDiagnosers(symptoms);
+    } else {
+      return new ArrayList<Diagnosis>();
+    }
+  }
+
+  @Override
+  public Collection<Action> executeResolvers(Collection<Diagnosis> diagnosis) {
+    if (running) {
+      return super.executeResolvers(diagnosis);
+    } else {
+      return super.executeResolvers(new ArrayList<Diagnosis>());
+    }
+  }
+}

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
@@ -78,20 +78,20 @@ public class ToggleablePolicy extends HealthPolicyImpl {
         : physicalPlanProvider.get().getTopology().getTopologyConfig().getKvsList()) {
       LOG.fine("kv " + kv.getKey() + ":" + kv.getValue());
       if (kv.getKey().equals(policyIdRuntime)) {
-        PolicyMode val = PolicyMode.valueOf(kv.getValue());
-        if (PolicyMode.deactivated.equals(val)
-            && policyMode.equals(PolicyMode.activated)) {
-          policyMode = PolicyMode.deactivated;
-          LOG.info("policy " + policyId + " status changed to " + policyMode);
-        } else if (PolicyMode.activated.equals(val)
-            && policyMode.equals(PolicyMode.deactivated)) {
-          policyMode = PolicyMode.activated;
-          LOG.info("policy " + policyId + " status changed to " + policyMode);
-        } else {
-          LOG.info("policy " + policyId
-              + " status does not change " + policyMode + "; input " + val);
+        try {
+          PolicyMode val = PolicyMode.valueOf(kv.getValue());
+          if (!policyMode.equals(val)) {
+            policyMode = val;
+            LOG.info("policy " + policyId + " status changed to " + policyMode);
+          } else {
+            LOG.info("policy " + policyId + " status does not change " + policyMode
+                + "; unknown input " + val);
+          }
+          break;
+        } catch (IllegalArgumentException e) {
+          LOG.warning("policy " + policyId + " status does not change " + policyMode
+              + "; unknown input " + kv.getValue());
         }
-        break;
       }
     }
 

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
@@ -84,8 +84,7 @@ public class ToggleablePolicy extends HealthPolicyImpl {
             policyMode = val;
             LOG.info("policy " + policyId + " status changed to " + policyMode);
           } else {
-            LOG.info("policy " + policyId + " status does not change " + policyMode
-                + "; unknown input " + val);
+            LOG.fine("policy " + policyId + " status remains same " + policyMode);
           }
           break;
         } catch (IllegalArgumentException e) {

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
@@ -78,12 +78,12 @@ public class ToggleablePolicy extends HealthPolicyImpl {
         : physicalPlanProvider.get().getTopology().getTopologyConfig().getKvsList()) {
       LOG.fine("kv " + kv.getKey() + ":" + kv.getValue());
       if (kv.getKey().equals(policyIdRuntime)) {
-        String val = kv.getValue();
-        if (PolicyMode.deactivated.name().equals(val)
+        PolicyMode val = PolicyMode.valueOf(kv.getValue());
+        if (PolicyMode.deactivated.equals(val)
             && policyMode.equals(PolicyMode.activated)) {
           policyMode = PolicyMode.deactivated;
           LOG.info("policy " + policyId + " status changed to " + policyMode);
-        } else if (PolicyMode.activated.name().equals(val)
+        } else if (PolicyMode.activated.equals(val)
             && policyMode.equals(PolicyMode.deactivated)) {
           policyMode = PolicyMode.activated;
           LOG.info("policy " + policyId + " status changed to " + policyMode);

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
@@ -56,13 +56,13 @@ public class ToggleablePolicy extends HealthPolicyImpl {
         : physicalPlanProvider.get().getTopology().getTopologyConfig().getKvsList()) {
       LOG.info("kv " + kv.getKey() + " => " + kv.getValue());
       if (kv.getKey().equals(TOGGLE_RUNTIME_CONFIG_KEY)) {
-        String val = kv.getValue();
-        if ("False".equals(val) || "false".equals(val)) {
+        Boolean b = Boolean.parseBoolean(kv.getValue());
+        if (Boolean.FALSE.equals(b)) {
           if (running) {
             running = false;
             LOG.info("policy running status changed to False");
           }
-        } else if ("True".equals(val) || "true".equals(val)) {
+        } else if (Boolean.TRUE.equals(b)) {
           if (!running) {
             running = true;
             LOG.info("policy running status changed to True");

--- a/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
+++ b/heron/healthmgr/src/java/org/apache/heron/healthmgr/policy/ToggleablePolicy.java
@@ -36,7 +36,7 @@ import org.apache.heron.healthmgr.common.PhysicalPlanProvider;
 
 /**
  * This Policy class
- * 1. has a switch
+ * 1. has a toggle switch
  * 2. works with runtime config
  */
 public class ToggleablePolicy extends HealthPolicyImpl {
@@ -49,12 +49,6 @@ public class ToggleablePolicy extends HealthPolicyImpl {
   @Inject
   protected PhysicalPlanProvider physicalPlanProvider;
   protected boolean running = true;
-
-//  @Inject
-//  ToggleablePolicy(PhysicalPlanProvider physicalPlanProvider) {
-//    running = true;
-//    this.physicalPlanProvider = physicalPlanProvider;
-//  }
 
   @Override
   public Collection<Measurement> executeSensors() {
@@ -109,6 +103,11 @@ public class ToggleablePolicy extends HealthPolicyImpl {
     if (running) {
       return super.executeResolvers(diagnosis);
     } else {
+      /*
+       * TODO(dhalion):
+       * If sub-class could access the `lastExecutionTimestamp`
+       * and `oneTimeDelay`, avoid super method invocation.
+       */
       return super.executeResolvers(new ArrayList<Diagnosis>());
     }
   }


### PR DESCRIPTION
Heron supports config update at runtime. This PR enforces toggle config for AutoRestartBackpressureContainerPolicy. See below examples how to toggle a policy

Example commands to toggle a policy in healthmgr:
```
$ ~/bin/heron update cluster/[role]/[env] <topology-name> \
--runtime-config <policy-id>:<activated/deactivated>

$ ~/bin/heron update local ExclamationTopology \
--runtime-config auto-restart-backpressure-container:activated
$ ~/bin/heron update local ExclamationTopology \
--runtime-config auto-restart-backpressure-container:deactivated
```
