### PR TITLE
Fix code when submitting a toplogy file without an known extension

### DIFF
--- a/heron/tools/cli/src/python/submit.py
+++ b/heron/tools/cli/src/python/submit.py
@@ -424,8 +424,8 @@ def run(command, parser, cl_args, unknown_args):
   tar_type = topology_file.endswith(".tar") or topology_file.endswith(".tar.gz")
   pex_type = topology_file.endswith(".pex")
   cpp_type = topology_file.endswith(".dylib") or topology_file.endswith(".so")
-  if not jar_type and not tar_type and not pex_type and not cpp_type:
-    ext_name = os.path.splitext(topology_file)
+  if not (jar_type or tar_type or pex_type or cpp_type):
+    _, ext_name = os.path.splitext(topology_file)
     err_context = "Unknown file type '%s'. Please use .tar "\
                   "or .tar.gz or .jar or .pex or .dylib or .so file"\
                   % ext_name


### PR DESCRIPTION
Without this you get:
```
$ heron submit local my-mysterious-topology -
[2018-06-21 20:04:51 +0000] [INFO]: Using cluster definition in /opt/heron/heron/conf/local
Traceback (most recent call last):
  File "/opt/heron/bin/heron/.bootstrap/_pex/pex.py", line 365, in execute
  File "/opt/heron/bin/heron/.bootstrap/_pex/pex.py", line 293, in _wrap_coverage
  File "/opt/heron/bin/heron/.bootstrap/_pex/pex.py", line 325, in _wrap_profiling
  File "/opt/heron/bin/heron/.bootstrap/_pex/pex.py", line 408, in _execute
  File "/opt/heron/bin/heron/.bootstrap/_pex/pex.py", line 466, in execute_entry
  File "/opt/heron/bin/heron/.bootstrap/_pex/pex.py", line 471, in execute_module
  File "/usr/lib/python2.7/runpy.py", line 192, in run_module
    fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/opt/heron/bin/heron/heron/tools/cli/src/python/main.py", line 387, in <module>
  File "/opt/heron/bin/heron/heron/tools/cli/src/python/main.py", line 383, in main
  File "/opt/heron/bin/heron/heron/tools/cli/src/python/main.py", line 367, in execute
  File "/opt/heron/bin/heron/heron/tools/cli/src/python/main.py", line 125, in run
  File "/opt/heron/bin/heron/heron/tools/cli/src/python/submit.py", line 404, in run
TypeError: not all arguments converted during string formatting
```