### PR TITLE
Revert the latest version number change of scala rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -957,17 +957,15 @@ new_http_archive(
 )
 
 # scala integration
-rules_scala_version="669ed8750b77fd99b758298f6467aaa5e6a9dabb" # update this as needed
+rules_scala_version="5cdae2f034581a05e23c3473613b409de5978833" # update this as needed
 
 http_archive(
     name = "io_bazel_rules_scala",
     url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip" % rules_scala_version,
     type = "zip",
     strip_prefix= "rules_scala-%s" % rules_scala_version,
-    sha256 = "1b0f0d7d0cb815116216b0349de0a7d12187dd0d1f4a538f1e7b657d1033a298",
+    sha256 = "bd66b178da5b9b6845f677bdfb2594de8f1050f831a8d69527c6737969376065",
 )
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
-scala_register_toolchains()


### PR DESCRIPTION
It seems the latest version number change of Scala rules doesn't work (fail to compile). Reverting the rules to the previous version which seems to be working for me.

The error seems to be related to "JavaInfo" in scala.bzl, which was updated in this PR in the bazelbuild/rules_scala project: https://github.com/bazelbuild/rules_scala/commit/afa64035b8c371888d06d524159d75611f078969

The issue can be walked around by upgrading to newer version of bazel (tested with 0.14.1, which is the right version used by heron project).  But since bazel version is not verified before compiling, it might be better to merge this PR to give developers some headroom to upgrade.