### PR TITLE
Nwang/fix negative index caused by hash mod

### DIFF
--- a/heron/api/src/java/org/apache/heron/api/utils/Utils.java
+++ b/heron/api/src/java/org/apache/heron/api/utils/Utils.java
@@ -155,4 +155,11 @@ public final class Utils {
   public static double zeroIfNaNOrInf(double x) {
     return (Double.isNaN(x) || Double.isInfinite(x)) ? 0.0 : x;
   }
+
+  public static Integer assignKeyToTask(int key, List<Integer> taskIds) {
+    int index = key % taskIds.size();
+    // Make sure index is not negative
+    index = index >= 0 ? index : index + taskIds.size();
+    return taskIds.get(index);
+  }
 }

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/groupings/JoinCustomGrouping.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/groupings/JoinCustomGrouping.java
@@ -53,6 +53,8 @@ public class JoinCustomGrouping<K, V> implements CustomStreamGrouping {
     List<Integer> ret = new ArrayList<>();
     V obj = (V) values.get(0);
     int index = keyExtractor.apply(obj).hashCode() % taskIds.size();
+    // Make sure index is not negative
+    index = index >= 0 ? index : index + taskIds.size();
     ret.add(taskIds.get(index));
     return ret;
   }

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/groupings/JoinCustomGrouping.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/groupings/JoinCustomGrouping.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.heron.api.grouping.CustomStreamGrouping;
 import org.apache.heron.api.topology.TopologyContext;
+import org.apache.heron.api.utils.Utils;
 import org.apache.heron.streamlet.SerializableFunction;
 
 /**
@@ -52,10 +53,8 @@ public class JoinCustomGrouping<K, V> implements CustomStreamGrouping {
   public List<Integer> chooseTasks(List<Object> values) {
     List<Integer> ret = new ArrayList<>();
     V obj = (V) values.get(0);
-    int index = keyExtractor.apply(obj).hashCode() % taskIds.size();
-    // Make sure index is not negative
-    index = index >= 0 ? index : index + taskIds.size();
-    ret.add(taskIds.get(index));
+    int key = keyExtractor.apply(obj).hashCode();
+    ret.add(Utils.assignKeyToTask(key, taskIds));
     return ret;
   }
 }

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/groupings/ReduceByKeyAndWindowCustomGrouping.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/groupings/ReduceByKeyAndWindowCustomGrouping.java
@@ -25,7 +25,9 @@ import java.util.List;
 
 import org.apache.heron.api.grouping.CustomStreamGrouping;
 import org.apache.heron.api.topology.TopologyContext;
+import org.apache.heron.api.utils.Utils;
 import org.apache.heron.streamlet.SerializableFunction;
+
 
 /**
  * ReduceByKeyAndWindowCustomGrouping is the class that routes the incoming tuples
@@ -54,10 +56,8 @@ public class ReduceByKeyAndWindowCustomGrouping<K, V> implements CustomStreamGro
   public List<Integer> chooseTasks(List<Object> values) {
     List<Integer> ret = new ArrayList<>();
     V obj = (V) values.get(0);
-    int index = keyExtractor.apply(obj).hashCode() % taskIds.size();
-    // Make sure index is not negative
-    index = index >= 0 ? index : index + taskIds.size();
-    ret.add(taskIds.get(index));
+    int key = keyExtractor.apply(obj).hashCode();
+    ret.add(Utils.assignKeyToTask(key, taskIds));
     return ret;
   }
 }

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/groupings/ReduceByKeyAndWindowCustomGrouping.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/groupings/ReduceByKeyAndWindowCustomGrouping.java
@@ -55,6 +55,8 @@ public class ReduceByKeyAndWindowCustomGrouping<K, V> implements CustomStreamGro
     List<Integer> ret = new ArrayList<>();
     V obj = (V) values.get(0);
     int index = keyExtractor.apply(obj).hashCode() % taskIds.size();
+    // Make sure index is not negative
+    index = index >= 0 ? index : index + taskIds.size();
     ret.add(taskIds.get(index));
     return ret;
   }

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/groupings/RemapCustomGrouping.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/groupings/RemapCustomGrouping.java
@@ -54,7 +54,10 @@ public class RemapCustomGrouping<R> implements CustomStreamGrouping {
     R obj = (R) values.get(0);
     List<Integer> targets = remapFn.apply(obj, ret.size());
     for (Integer target : targets) {
-      ret.add(taskIds.get(target % taskIds.size()));
+      int index = target % taskIds.size();
+      // Make sure index is not negative
+      index = index >= 0 ? index : index + taskIds.size();
+      ret.add(taskIds.get(index));
     }
     return ret;
   }

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/groupings/RemapCustomGrouping.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/groupings/RemapCustomGrouping.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.heron.api.grouping.CustomStreamGrouping;
 import org.apache.heron.api.topology.TopologyContext;
+import org.apache.heron.api.utils.Utils;
 import org.apache.heron.streamlet.SerializableBiFunction;
 
 /**
@@ -54,10 +55,7 @@ public class RemapCustomGrouping<R> implements CustomStreamGrouping {
     R obj = (R) values.get(0);
     List<Integer> targets = remapFn.apply(obj, ret.size());
     for (Integer target : targets) {
-      int index = target % taskIds.size();
-      // Make sure index is not negative
-      index = index >= 0 ? index : index + taskIds.size();
-      ret.add(taskIds.get(index));
+      ret.add(Utils.assignKeyToTask(target, taskIds));
     }
     return ret;
   }

--- a/heron/api/tests/java/BUILD
+++ b/heron/api/tests/java/BUILD
@@ -32,7 +32,8 @@ java_tests(
     "org.apache.heron.streamlet.impl.operators.ReduceByKeyAndWindowOperatorTest",
     "org.apache.heron.streamlet.impl.operators.GeneralReduceByKeyAndWindowOperatorTest",
     "org.apache.heron.api.ConfigTest",
-    "org.apache.heron.api.HeronSubmitterTest"
+    "org.apache.heron.api.HeronSubmitterTest",
+    "org.apache.heron.api.utils.UtilsTest"
   ],
   runtime_deps = [ ":api-tests" ],
   size = "small",

--- a/heron/api/tests/java/org/apache/heron/api/utils/UtilsTest.java
+++ b/heron/api/tests/java/org/apache/heron/api/utils/UtilsTest.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.api.utils;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import junit.framework.TestCase;
+
+public class UtilsTest extends TestCase {
+
+  @Test
+  public void testAssignKeyToTask() {
+    ArrayList<Integer> taskIds = new ArrayList<Integer>();
+    taskIds.add(1);
+    taskIds.add(2);
+    assertEquals(taskIds.size(), 2);
+    assertEquals(Utils.assignKeyToTask(0, taskIds), Integer.valueOf(1));
+    assertEquals(Utils.assignKeyToTask(100, taskIds), Integer.valueOf(1));
+    assertEquals(Utils.assignKeyToTask(101, taskIds), Integer.valueOf(2));
+    assertEquals(Utils.assignKeyToTask(-100, taskIds), Integer.valueOf(1));
+    assertEquals(Utils.assignKeyToTask(-101, taskIds), Integer.valueOf(2));
+  }
+}

--- a/heron/simulator/src/java/org/apache/heron/simulator/grouping/FieldsGrouping.java
+++ b/heron/simulator/src/java/org/apache/heron/simulator/grouping/FieldsGrouping.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.heron.api.generated.TopologyAPI;
+import org.apache.heron.api.utils.Utils;
 import org.apache.heron.proto.system.HeronTuples;
 
 public class FieldsGrouping extends Grouping {
@@ -55,10 +56,7 @@ public class FieldsGrouping extends Grouping {
       taskIndex += getHashCode(tuple.getValues(indices)) % primeNumber;
     }
 
-    taskIndex = taskIndex % taskIds.size();
-    // Make sure taskIndex is not negative
-    taskIndex = taskIndex >= 0 ? taskIndex : taskIndex + taskIds.size();
-    res.add(taskIds.get(taskIndex));
+    res.add(Utils.assignKeyToTask(taskIndex, taskIds));
 
     return res;
   }

--- a/heron/simulator/src/java/org/apache/heron/simulator/grouping/FieldsGrouping.java
+++ b/heron/simulator/src/java/org/apache/heron/simulator/grouping/FieldsGrouping.java
@@ -56,7 +56,7 @@ public class FieldsGrouping extends Grouping {
     }
 
     taskIndex = taskIndex % taskIds.size();
-    // Make sure taskIndex is greater than 0
+    // Make sure taskIndex is not negative
     taskIndex = taskIndex >= 0 ? taskIndex : taskIndex + taskIds.size();
     res.add(taskIds.get(taskIndex));
 


### PR DESCRIPTION
"hashCode() % taskIds.size()" can be negative which could cause "out of boundary" error. This has been handled in simulator/grouping/FieldsGrouping.java but a few others need the fix as well.