### PR TITLE
Add log in Bolt/Spout instances after persisting state

### DIFF
--- a/heron/instance/src/java/org/apache/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/org/apache/heron/instance/bolt/BoltInstance.java
@@ -157,6 +157,7 @@ public class BoltInstance implements IInstance {
     } finally {
       collector.lock.unlock();
     }
+    LOG.info("State persisted for checkpoint: " + checkpointId);
   }
 
   @SuppressWarnings("unchecked")

--- a/heron/instance/src/java/org/apache/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/org/apache/heron/instance/spout/SpoutInstance.java
@@ -165,6 +165,7 @@ public class SpoutInstance implements IInstance {
     } finally {
       collector.lock.unlock();
     }
+    LOG.info("State persisted for checkpoint: " + checkpointId);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Currently there is log at beginning only. Logging at the end could be helpful during investigation.