### PR TITLE
Make checkpoint manager's ram configurable

### DIFF
--- a/heron/api/src/java/org/apache/heron/api/Config.java
+++ b/heron/api/src/java/org/apache/heron/api/Config.java
@@ -218,6 +218,19 @@ public class Config extends HashMap<String, Object> {
   public static final String TOPOLOGY_STATEFUL_START_CLEAN =
                              "topology.stateful.start.clean";
   /**
+   * Checkpoint Manager RAM requirement.
+   */
+  public static final String TOPOLOGY_STATEFUL_CKPTMGR_RAM =
+                            "topology.stateful.checkpointmanager.ram";
+  /**
+   * Stream Manager RAM requirement
+   */
+  public static final String TOPOLOGY_STMGR_RAM =  "topology.stmgr.ram";
+  /**
+   * Metrics Manager RAM requirement
+   */
+  public static final String TOPOLOGY_METRICSMGR_RAM = "topology.metricsmgr.ram";
+  /**
    * Name of the topology. This config is automatically set by Heron when the topology is submitted.
    */
   public static final String TOPOLOGY_NAME = "topology.name";
@@ -319,6 +332,9 @@ public class Config extends HashMap<String, Object> {
     apiVars.add(TOPOLOGY_COMPONENT_DISKMAP);
     apiVars.add(TOPOLOGY_STATEFUL_START_CLEAN);
     apiVars.add(TOPOLOGY_STATEFUL_CHECKPOINT_INTERVAL_SECONDS);
+    apiVars.add(TOPOLOGY_STATEFUL_CKPTMGR_RAM);
+    apiVars.add(TOPOLOGY_STMGR_RAM);
+    apiVars.add(TOPOLOGY_METRICSMGR_RAM);
     apiVars.add(TOPOLOGY_RELIABILITY_MODE);
     apiVars.add(TOPOLOGY_NAME);
     apiVars.add(TOPOLOGY_TEAM_NAME);
@@ -572,6 +588,21 @@ public class Config extends HashMap<String, Object> {
     conf.put(Config.TOPOLOGY_STATEFUL_START_CLEAN, String.valueOf(clean));
   }
 
+  public static void setCheckpointManagerRam(Map<String, Object> conf,
+                                             ByteAmount ramInBytes) {
+    conf.put(Config.TOPOLOGY_STATEFUL_CKPTMGR_RAM, ramInBytes.asBytes());
+  }
+
+  public static void setStreamManagerRam(Map<String, Object> conf,
+                                         ByteAmount ramInBytes) {
+    conf.put(Config.TOPOLOGY_STMGR_RAM, ramInBytes.asBytes());
+  }
+
+  public static void setMetricsmgrRam(Map<String, Object> conf,
+                                      ByteAmount ramInBytes) {
+    conf.put(Config.TOPOLOGY_METRICSMGR_RAM, ramInBytes.asBytes());
+  }
+
   @SuppressWarnings("rawtypes")
   public static void setEnvironment(Map<String, Object> conf, Map env) {
     conf.put(Config.TOPOLOGY_ENVIRONMENT, env);
@@ -736,6 +767,18 @@ public class Config extends HashMap<String, Object> {
 
   public void setTopologyStatefulStartClean(boolean clean) {
     setTopologyStatefulStartClean(this, clean);
+  }
+
+  public void setCheckpointManagerRam(ByteAmount ramInBytes) {
+    setCheckpointManagerRam(this, ramInBytes);
+  }
+
+  public void setStreamManagerRam(ByteAmount ramInBytes) {
+    setStreamManagerRam(this, ramInBytes);
+  }
+
+  public void setMetricsmgrRam(ByteAmount ramInBytes) {
+    setMetricsmgrRam(this, ramInBytes);
   }
 
   /**

--- a/heron/api/src/java/org/apache/heron/api/utils/TopologyUtils.java
+++ b/heron/api/src/java/org/apache/heron/api/utils/TopologyUtils.java
@@ -157,6 +157,13 @@ public final class TopologyUtils {
     }
   }
 
+  public static ByteAmount getCheckpointManagerRam(TopologyAPI.Topology topology) {
+    List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
+    return TopologyUtils.getConfigWithDefault(topologyConfig,
+        org.apache.heron.api.Config.TOPOLOGY_STATEFUL_CKPTMGR_RAM,
+       ByteAmount.fromGigabytes(1));
+  }
+
   /**
    * Throw a IllegalArgumentException if verifyTopology returns false
    * @param topology to validate

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -77,7 +77,8 @@ def print_usage():
       " --metricscache-manager-master-port=<metricscachemgr_masterport>"
       " --metricscache-manager-stats-port=<metricscachemgr_statsport>"
       " --is-stateful=<is_stateful> --checkpoint-manager-classpath=<ckptmgr_classpath>"
-      " --checkpoint-manager-port=<ckptmgr_port> --stateful-config-file=<stateful_config_file>"
+      " --checkpoint-manager-port=<ckptmgr_port> --checkpoint-manager-ram=<checkpoint_manager_ram>"
+      " --stateful-config-file=<stateful_config_file>"
       " --health-manager-mode=<healthmgr_mode> --health-manager-classpath=<healthmgr_classpath>"
       " --cpp-instance-binary=<cpp_instance_binary>"
       " --jvm-remote-debugger-ports=<comma_seperated_port_list>")
@@ -251,6 +252,7 @@ class HeronExecutor(object):
     self.is_stateful_topology = (parsed_args.is_stateful.lower() == 'true')
     self.checkpoint_manager_classpath = parsed_args.checkpoint_manager_classpath
     self.checkpoint_manager_port = parsed_args.checkpoint_manager_port
+    self.checkpoint_manager_ram = parsed_args.checkpoint_manager_ram
     self.stateful_config_file = parsed_args.stateful_config_file
     self.metricscache_manager_mode = parsed_args.metricscache_manager_mode \
         if parsed_args.metricscache_manager_mode else "disabled"
@@ -332,6 +334,7 @@ class HeronExecutor(object):
     parser.add_argument("--is-stateful", required=True)
     parser.add_argument("--checkpoint-manager-classpath", required=True)
     parser.add_argument("--checkpoint-manager-port", required=True)
+    parser.add_argument("--checkpoint-manager-ram", type=long, required=True)
     parser.add_argument("--stateful-config-file", required=True)
     parser.add_argument("--health-manager-mode", required=True)
     parser.add_argument("--health-manager-classpath", required=True)
@@ -763,8 +766,10 @@ class HeronExecutor(object):
 
     ckptmgr_main_class = 'org.apache.heron.ckptmgr.CheckpointManager'
 
+    ckptmgr_ram_mb = self.checkpoint_manager_ram / (1024 * 1024)
     ckptmgr_cmd = [os.path.join(self.heron_java_home, "bin/java"),
-                   '-Xmx1024M',
+                   '-Xms%dM' % ckptmgr_ram_mb,
+                   '-Xmx%dM' % ckptmgr_ram_mb,
                    '-XX:+PrintCommandLineFlags',
                    '-verbosegc',
                    '-XX:+PrintGCDetails',

--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
@@ -203,11 +203,6 @@ public class RoundRobinPacking implements IPacking, IRepacking {
         org.apache.heron.api.Config.TOPOLOGY_STATEFUL_CKPTMGR_RAM,
         isStateful ? DEFAULT_DAEMON_PROCESS_RAM_PADDING : ByteAmount.ZERO);
 
-    // TODO(nlu): remove there logging line
-    ByteAmount totalBytes = stmgrRam.plus(metricsmgrRam).plus(ckptmgrRam);
-    LOG.info("discover the topology isStateful: " + isStateful);
-    LOG.info("total container padding bytes: " + totalBytes.toString());
-
     return stmgrRam.plus(metricsmgrRam).plus(ckptmgrRam);
   }
 

--- a/heron/scheduler-core/src/java/org/apache/heron/scheduler/ExecutorFlag.java
+++ b/heron/scheduler-core/src/java/org/apache/heron/scheduler/ExecutorFlag.java
@@ -62,6 +62,7 @@ public enum ExecutorFlag {
   IsStateful("is-stateful"),
   CheckpointManagerClasspath("checkpoint-manager-classpath"),
   CheckpointManagerPort("checkpoint-manager-port"),
+  CheckpointManagerRam("checkpoint-manager-ram"),
   StatefulConfigFile("stateful-config-file"),
   HealthManagerMode("health-manager-mode"),
   HealthManagerClasspath("health-manager-classpath"),

--- a/heron/scheduler-core/src/java/org/apache/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/org/apache/heron/scheduler/utils/SchedulerUtils.java
@@ -311,8 +311,11 @@ public final class SchedulerUtils {
     args.add(createCommandArg(ExecutorFlag.CheckpointManagerClasspath,
         completeCkptmgrProcessClassPath));
     args.add(createCommandArg(ExecutorFlag.StatefulConfigFile, Context.statefulConfigFile(config)));
+
     args.add(createCommandArg(
-        ExecutorFlag.CheckpointManagerRam, Long.toString(Context.ckptmgrRam(config).asBytes())));
+        ExecutorFlag.CheckpointManagerRam,
+        Long.toString(TopologyUtils.getCheckpointManagerRam(topology).asBytes())));
+
     String healthMgrMode = Context.healthMgrMode(config)
         == null ? "disabled" : Context.healthMgrMode(config);
     args.add(createCommandArg(ExecutorFlag.HealthManagerMode, healthMgrMode));

--- a/heron/scheduler-core/src/java/org/apache/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/org/apache/heron/scheduler/utils/SchedulerUtils.java
@@ -311,7 +311,8 @@ public final class SchedulerUtils {
     args.add(createCommandArg(ExecutorFlag.CheckpointManagerClasspath,
         completeCkptmgrProcessClassPath));
     args.add(createCommandArg(ExecutorFlag.StatefulConfigFile, Context.statefulConfigFile(config)));
-
+    args.add(createCommandArg(
+        ExecutorFlag.CheckpointManagerRam, Long.toString(Context.ckptmgrRam(config).asBytes())));
     String healthMgrMode = Context.healthMgrMode(config)
         == null ? "disabled" : Context.healthMgrMode(config);
     args.add(createCommandArg(ExecutorFlag.HealthManagerMode, healthMgrMode));

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/aurora/AuroraScheduler.java
@@ -216,7 +216,7 @@ public class AuroraScheduler implements IScheduler, IScalable {
         controller.addContainers(containersToAdd.size()));
     if (newAddedContainerIds.size() != containersToAdd.size()) {
       throw new RuntimeException(
-          "Aurora returned differnt countainer count " + newAddedContainerIds.size()
+          "Aurora returned different container count " + newAddedContainerIds.size()
           + "; input count was " + containersToAdd.size());
     }
     // Do the remapping:

--- a/heron/spi/src/java/org/apache/heron/spi/common/Context.java
+++ b/heron/spi/src/java/org/apache/heron/spi/common/Context.java
@@ -218,6 +218,14 @@ public class Context {
     return cfg.getByteAmountValue(Key.STMGR_RAM);
   }
 
+  public static ByteAmount ckptmgrRam(Config cfg) {
+    return cfg.getByteAmountValue(Key.CKPTMGR_RAM);
+  }
+
+  public static ByteAmount metricsmgrRam(Config cfg) {
+    return cfg.getByteAmountValue(Key.METRICSMGR_RAM);
+  }
+
   public static ByteAmount instanceRam(Config cfg) {
     return cfg.getByteAmountValue(Key.INSTANCE_RAM);
   }

--- a/heron/spi/src/java/org/apache/heron/spi/common/Key.java
+++ b/heron/spi/src/java/org/apache/heron/spi/common/Key.java
@@ -118,10 +118,12 @@ public enum Key {
   STATEMGR_ROOT_PATH        ("heron.statemgr.root.path",         Type.STRING),
 
   //keys for config provided default values for resources
-  STMGR_RAM                 ("heron.resources.stmgr.ram",     ByteAmount.fromBytes(1073741824)),
-  INSTANCE_RAM              ("heron.resources.instance.ram",  ByteAmount.fromBytes(1073741824)),
-  INSTANCE_CPU              ("heron.resources.instance.cpu",  1.0),
-  INSTANCE_DISK             ("heron.resources.instance.disk", ByteAmount.fromBytes(1073741824)),
+  STMGR_RAM                 ("heron.resources.stmgr.ram",      ByteAmount.fromBytes(1073741824)),
+  CKPTMGR_RAM               ("heron.resources.ckptmgr.ram",    ByteAmount.fromBytes(1073741824)),
+  METRICSMGR_RAM            ("heron.resources.metricsmgr.ram", ByteAmount.fromBytes(1073741824)),
+  INSTANCE_RAM              ("heron.resources.instance.ram",   ByteAmount.fromBytes(1073741824)),
+  INSTANCE_CPU              ("heron.resources.instance.cpu",   1.0),
+  INSTANCE_DISK             ("heron.resources.instance.disk",  ByteAmount.fromBytes(1073741824)),
 
   //keys for checkpoint management
   STATEFUL_STORAGE_CLASSNAME               ("heron.statefulstorage.classname", Type.STRING),

--- a/heron/spi/tests/java/org/apache/heron/spi/common/ContextTest.java
+++ b/heron/spi/tests/java/org/apache/heron/spi/common/ContextTest.java
@@ -61,6 +61,8 @@ public class ContextTest {
     Config defaultResources = props;
 
     assertEquals(Key.STMGR_RAM.getDefault(), Context.stmgrRam(defaultResources));
+    assertEquals(Key.CKPTMGR_RAM.getDefault(), Context.ckptmgrRam(defaultResources));
+    assertEquals(Key.METRICSMGR_RAM.getDefault(), Context.metricsmgrRam(defaultResources));
     assertEquals(
         (Double) Key.INSTANCE_CPU.getDefault(), Context.instanceCpu(defaultResources), 0.001);
     assertEquals(Key.INSTANCE_RAM.getDefault(), Context.instanceRam(defaultResources));


### PR DESCRIPTION
Originally checkpoint manager ram is hardcoded to 1GB. If a state is very large, the checkpoint manager will be crashed due to OOM error.

This PR makes the following changes:
1. Checkpoint manager ram is configurable with `Config` and passed to `heron_executor` via aurora. 
2. Container memory padding is calculated based on the stmgr, metricsmgr and ckptmgr ram request. Previously it's a hardcoded value -- 2GB.

Tested with `RoundRobingPacking` algorithm and `Aurora` Scheduler. Test case include non-stateful topology, stateful topology with ckptmgr ram set, stateful topology with ckptmgr ram not set.