### PR TITLE
(Ok To Merge) updating docker scripts

### DIFF
--- a/docker/dist/Dockerfile.dist.centos7
+++ b/docker/dist/Dockerfile.dist.centos7
@@ -15,9 +15,8 @@ ADD artifacts /heron
 
 WORKDIR /heron
 
-# run heron installers
-RUN /heron/heron-client-install.sh
-RUN /heron/heron-tools-install.sh
+# run heron installer
+RUN /heron/heron-install.sh
 
 RUN mkdir -p /opt/heron && \
     tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron

--- a/docker/dist/Dockerfile.dist.debian8
+++ b/docker/dist/Dockerfile.dist.debian8
@@ -14,8 +14,9 @@ ADD artifacts /heron
 
 WORKDIR /heron
 
-# run heron tools install
-RUN /heron/heron-tools-install.sh && \
+
+# run heron installer
+RUN /heron/heron-install.sh && \
     tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron && \
     rm -rf /heron/heron-core.tar.gz && \
     rm -rf /heron/heron-tools-install.sh && \

--- a/docker/dist/Dockerfile.dist.ubuntu14.04
+++ b/docker/dist/Dockerfile.dist.ubuntu14.04
@@ -18,8 +18,8 @@ ADD artifacts /heron
 
 WORKDIR /heron
 
-# run heron installers
-RUN /heron/heron-client-install.sh && /heron/heron-tools-install.sh
+# run heron installer
+RUN /heron/heron-install.sh
 
 RUN tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
 

--- a/docker/dist/Dockerfile.dist.ubuntu14.04
+++ b/docker/dist/Dockerfile.dist.ubuntu14.04
@@ -23,10 +23,6 @@ RUN /heron/heron-install.sh
 
 RUN tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
 
-RUN rm -f /heron/heron-tools-install.sh && \
-    rm -f /heron/heron-client-install.sh && \
-    rm -f /heron/heron-core.tar.gz
-
 ENV HERON_HOME /heron/heron-core/
 
 # install zookeeper

--- a/docker/dist/Dockerfile.dist.ubuntu15.10
+++ b/docker/dist/Dockerfile.dist.ubuntu15.10
@@ -16,9 +16,8 @@ ADD artifacts /heron
 
 WORKDIR /heron
 
-# run heron installers
-RUN /heron/heron-client-install.sh
-RUN /heron/heron-tools-install.sh
+# run heron installer
+RUN /heron/heron-install.sh
 
 RUN tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
 

--- a/docker/dist/Dockerfile.dist.ubuntu16.04
+++ b/docker/dist/Dockerfile.dist.ubuntu16.04
@@ -16,9 +16,8 @@ ADD artifacts /heron
 
 WORKDIR /heron
 
-# run heron installers
-RUN /heron/heron-client-install.sh
-RUN /heron/heron-tools-install.sh
+# run heron installer
+RUN /heron/heron-install.sh
 
 RUN tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
 

--- a/docker/scripts/build-docker.sh
+++ b/docker/scripts/build-docker.sh
@@ -23,7 +23,6 @@ setup_scratch_dir() {
 
     mkdir $1
     mkdir $1/artifacts
-    echo "success: $1/artifacts"
   fi
 
   cp -R $DOCKER_DIR/dist $1/

--- a/docker/scripts/build-docker.sh
+++ b/docker/scripts/build-docker.sh
@@ -20,8 +20,10 @@ trap cleanup EXIT
 
 setup_scratch_dir() {
   if [ ! -f "$1" ]; then
+
     mkdir $1
     mkdir $1/artifacts
+    echo "success: $1/artifacts"
   fi
 
   cp -R $DOCKER_DIR/dist $1/
@@ -38,23 +40,18 @@ run_build() {
   setup_scratch_dir $SCRATCH_DIR
 
   # need to copy artifacts locally
-  TOOLS_FILE="$OUTPUT_DIRECTORY/heron-tools-install-$HERON_VERSION-$TARGET_PLATFORM.sh"
-  TOOLS_OUT_FILE="$SCRATCH_DIR/artifacts/heron-tools-install.sh"
-
-  CLIENT_FILE="$OUTPUT_DIRECTORY/heron-client-install-$HERON_VERSION-$TARGET_PLATFORM.sh"
-  CLIENT_OUT_FILE="$SCRATCH_DIR/artifacts/heron-client-install.sh"
-
   CORE_FILE="$OUTPUT_DIRECTORY/heron-core-$HERON_VERSION-$TARGET_PLATFORM.tar.gz"
   CORE_OUT_FILE="$SCRATCH_DIR/artifacts/heron-core.tar.gz"
 
-  cp $TOOLS_FILE $TOOLS_OUT_FILE
-  cp $CORE_FILE $CORE_OUT_FILE
+  ALL_FILE="$OUTPUT_DIRECTORY/heron-install.sh"
+  ALL_OUT_FILE="$SCRATCH_DIR/artifacts/heron-install.sh"
 
+  cp $CORE_FILE $CORE_OUT_FILE
+  cp $ALL_FILE $ALL_OUT_FILE
   export HERON_VERSION
 
   echo "Building docker image with tag:$DOCKER_TAG"
   docker build --squash -t "$DOCKER_TAG" -t "$DOCKER_LATEST_TAG" -f "$DOCKER_FILE" "$SCRATCH_DIR"
-
   # save the image as a tar file
   DOCKER_IMAGE_FILE="$OUTPUT_DIRECTORY/heron-docker-$HERON_VERSION-$TARGET_PLATFORM.tar"
 

--- a/docker/scripts/build-docker.sh
+++ b/docker/scripts/build-docker.sh
@@ -57,7 +57,7 @@ run_build() {
   echo "Saving docker image to $DOCKER_IMAGE_FILE"
   docker save -o $DOCKER_IMAGE_FILE $DOCKER_TAG
   gzip $DOCKER_IMAGE_FILE
-}
+} 
 
 case $# in
   3)


### PR DESCRIPTION
This PR is only for feedback in updating the Heron Docker build scripts.

@kramasamy In the process of trying to diagnose other issues, I noticed the docker build scripts are not working as of today.  I made a few changes and was able to successfully build a Heron Ubuntu 14.04 image and place it in a zip file.  I think that I could easily make these changes to the other image types if you think these changes are ok to put in.  

Let me know your thoughts.