### PR TITLE
spill state to local disk when configured

### DIFF
--- a/examples/src/java/org/apache/heron/examples/api/StatefulTumblingWindowTopology.java
+++ b/examples/src/java/org/apache/heron/examples/api/StatefulTumblingWindowTopology.java
@@ -155,7 +155,8 @@ public final class StatefulTumblingWindowTopology {
     TopologyBuilder builder = new TopologyBuilder();
     builder.setSpout("integer", new IntegerSpout(), 1);
     WindowSumBolt windowSumBolt = new WindowSumBolt();
-    windowSumBolt.withTumblingWindow(Duration.ofSeconds(10));
+    windowSumBolt.withTumblingWindow(Duration.ofMinutes(10));
+
     builder.setBolt("sumbolt", windowSumBolt, 1).shuffleGrouping("integer");
     builder.setBolt("printer", new PrinterBolt()).shuffleGrouping("sumbolt");
     Config conf = new Config();
@@ -172,6 +173,7 @@ public final class StatefulTumblingWindowTopology {
     conf.setTopologyReliabilityMode(Config.TopologyReliabilityMode.EFFECTIVELY_ONCE);
     conf.setTopologyStatefulCheckpointIntervalSecs(20);
     conf.setMaxSpoutPending(1000);
+    conf.setMessageTimeoutSecs(1500);
 
     if (args != null && args.length > 0) {
       topoName = args[0];

--- a/heron/api/src/java/org/apache/heron/api/Config.java
+++ b/heron/api/src/java/org/apache/heron/api/Config.java
@@ -223,6 +223,16 @@ public class Config extends HashMap<String, Object> {
   public static final String TOPOLOGY_STATEFUL_CKPTMGR_RAM =
                             "topology.stateful.checkpointmanager.ram";
   /**
+   * Whether spill the state to disk for transferring
+   */
+  public static final String TOPOLOGY_STATEFUL_SPILL_STATE =
+                            "topology.stateful.spill.state";
+  /**
+   * The local disk location where the state is spilled
+   */
+  public static final String TOPOLOGY_STATEFUL_SPILL_STATE_LOCATION =
+                            "topology.stateful.spill.state.location";
+  /**
    * Stream Manager RAM requirement
    */
   public static final String TOPOLOGY_STMGR_RAM =  "topology.stmgr.ram";
@@ -333,6 +343,8 @@ public class Config extends HashMap<String, Object> {
     apiVars.add(TOPOLOGY_STATEFUL_START_CLEAN);
     apiVars.add(TOPOLOGY_STATEFUL_CHECKPOINT_INTERVAL_SECONDS);
     apiVars.add(TOPOLOGY_STATEFUL_CKPTMGR_RAM);
+    apiVars.add(TOPOLOGY_STATEFUL_SPILL_STATE);
+    apiVars.add(TOPOLOGY_STATEFUL_SPILL_STATE_LOCATION);
     apiVars.add(TOPOLOGY_STMGR_RAM);
     apiVars.add(TOPOLOGY_METRICSMGR_RAM);
     apiVars.add(TOPOLOGY_RELIABILITY_MODE);
@@ -593,6 +605,16 @@ public class Config extends HashMap<String, Object> {
     conf.put(Config.TOPOLOGY_STATEFUL_CKPTMGR_RAM, ramInBytes.asBytes());
   }
 
+  public static void setTopologyStatefulSpillState(Map<String, Object> conf,
+                                   String spillState) {
+    conf.put(Config.TOPOLOGY_STATEFUL_SPILL_STATE, spillState);
+  }
+
+  public static void setTopologyStatefulSpillStateLocation(Map<String, Object> conf,
+                                                           String location) {
+    conf.put(Config.TOPOLOGY_STATEFUL_SPILL_STATE_LOCATION, location);
+  }
+
   public static void setStreamManagerRam(Map<String, Object> conf,
                                          ByteAmount ramInBytes) {
     conf.put(Config.TOPOLOGY_STMGR_RAM, ramInBytes.asBytes());
@@ -771,6 +793,14 @@ public class Config extends HashMap<String, Object> {
 
   public void setCheckpointManagerRam(ByteAmount ramInBytes) {
     setCheckpointManagerRam(this, ramInBytes);
+  }
+
+  public void setTopologyStatefulSpillState(String spillState) {
+    setTopologyStatefulSpillState(this, spillState);
+  }
+
+  public void setTopologyStatefulSpillStateLocation(String location) {
+    setTopologyStatefulSpillStateLocation(this, location);
   }
 
   public void setStreamManagerRam(ByteAmount ramInBytes) {

--- a/heron/api/src/java/org/apache/heron/api/HeronTopology.java
+++ b/heron/api/src/java/org/apache/heron/api/HeronTopology.java
@@ -62,6 +62,12 @@ public class HeronTopology {
     if (!userConfig.containsKey(Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS)) {
       userConfig.put(Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS, "true");
     }
+    if (!userConfig.containsKey(Config.TOPOLOGY_STATEFUL_SPILL_STATE)) {
+      userConfig.put(Config.TOPOLOGY_STATEFUL_SPILL_STATE, "false");
+      if (!userConfig.containsKey(Config.TOPOLOGY_STATEFUL_SPILL_STATE_LOCATION)) {
+        userConfig.put(Config.TOPOLOGY_STATEFUL_SPILL_STATE_LOCATION, "./spilled-state/");
+      }
+    }
   }
 
   public TopologyAPI.Topology getTopology() {

--- a/heron/ckptmgr/src/java/BUILD
+++ b/heron/ckptmgr/src/java/BUILD
@@ -9,13 +9,17 @@ java_library(
         exclude = ["**/CheckpointManager.java"],
     ),
     deps = [
-        "//heron/spi/src/java:statefulstorage-spi-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:network-java",
         "//heron/common/src/java:utils-java",
         "//heron/proto:proto_common_java",
         "//heron/proto:proto_ckptmgr_java",
+        "//heron/proto:proto_physical_plan_java",
+        "//heron/proto:proto_stmgr_java",
+        "//heron/proto:proto_topology_java",
+        "//heron/spi/src/java:statefulstorage-spi-java",
         "@com_google_protobuf//:protobuf_java",
     ],
 )
@@ -25,13 +29,13 @@ java_binary(
     srcs = glob(["**/CheckpointManager.java"]),
     deps = [
         ":ckptmgr-java",
-        "//heron/spi/src/java:statefulstorage-spi-java",
         "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:network-java",
         "//heron/common/src/java:utils-java",
         "//heron/proto:proto_ckptmgr_java",
+        "//heron/spi/src/java:statefulstorage-spi-java",
         "@commons_cli_commons_cli//jar",
     ],
 )

--- a/heron/ckptmgr/src/java/org/apache/heron/ckptmgr/CheckpointManagerServer.java
+++ b/heron/ckptmgr/src/java/org/apache/heron/ckptmgr/CheckpointManagerServer.java
@@ -359,8 +359,15 @@ public class CheckpointManagerServer extends HeronServer {
     TopologyAPI.Config config = pplan.getTopology().getTopologyConfig();
     this.spillState = Boolean.parseBoolean(TopologyUtils.getConfigWithDefault(config.getKvsList(),
         Config.TOPOLOGY_STATEFUL_SPILL_STATE, "false"));
-    this.spillStateLocation = String.valueOf(TopologyUtils.getConfigWithDefault(config.getKvsList(),
-        Config.TOPOLOGY_STATEFUL_SPILL_STATE_LOCATION, ""));
+    this.spillStateLocation = String.format("%s/%s/",
+        String.valueOf(TopologyUtils.getConfigWithDefault(config.getKvsList(),
+                       Config.TOPOLOGY_STATEFUL_SPILL_STATE_LOCATION, "")),
+        "ckptmgr");
+    if (FileUtils.isDirectoryExists(spillStateLocation)) {
+      FileUtils.cleanDir(spillStateLocation);
+    } else {
+      FileUtils.createDirectory(spillStateLocation);
+    }
     LOG.info("spill state: " + spillState
         + ". set spilled state location: " + spillStateLocation);
   }

--- a/heron/ckptmgr/src/java/org/apache/heron/ckptmgr/CheckpointManagerServer.java
+++ b/heron/ckptmgr/src/java/org/apache/heron/ckptmgr/CheckpointManagerServer.java
@@ -326,7 +326,7 @@ public class CheckpointManagerServer extends HeronServer {
 
           // spill state to local disk
           String stateLocation = spillStateLocation + checkpointId + "-" + UUID.randomUUID();
-          if (FileUtils.writeToFile(stateLocation, ckpt.getState().toByteArray(), true)) {
+          if (!FileUtils.writeToFile(stateLocation, ckpt.getState().toByteArray(), true)) {
             throw new RuntimeException("failed to spill state. Bailing out...");
           }
           LOG.info("spilled state to: " + stateLocation);

--- a/heron/ckptmgr/src/java/org/apache/heron/ckptmgr/CheckpointManagerServer.java
+++ b/heron/ckptmgr/src/java/org/apache/heron/ckptmgr/CheckpointManagerServer.java
@@ -326,7 +326,9 @@ public class CheckpointManagerServer extends HeronServer {
 
           // spill state to local disk
           String stateLocation = spillStateLocation + checkpointId + "-" + UUID.randomUUID();
-          FileUtils.writeToFile(stateLocation, ckpt.getState().toByteArray(), true);
+          if (FileUtils.writeToFile(stateLocation, ckpt.getState().toByteArray(), true)) {
+            throw new RuntimeException("failed to spill state. Bailing out...");
+          }
           LOG.info("spilled state to: " + stateLocation);
           ckpt = CheckpointManager.InstanceStateCheckpoint.newBuilder()
                   .setStateLocation(stateLocation)

--- a/heron/ckptmgr/src/java/org/apache/heron/ckptmgr/CheckpointManagerServer.java
+++ b/heron/ckptmgr/src/java/org/apache/heron/ckptmgr/CheckpointManagerServer.java
@@ -277,10 +277,6 @@ public class CheckpointManagerServer extends HeronServer {
             .setState(ByteString.copyFrom(FileUtils.readFromFile(localStateLocation)))
             .build();
 
-    if (!FileUtils.deleteFile(localStateLocation)) {
-      LOG.info("failed to delete state tmp file: " + localStateLocation);
-    }
-
     return new Checkpoint(checkpoint);
   }
 
@@ -324,6 +320,9 @@ public class CheckpointManagerServer extends HeronServer {
         if (spillState) {
           CheckpointManager.InstanceStateCheckpoint ckpt = checkpoint.getCheckpoint();
           String checkpointId = ckpt.getCheckpointId();
+
+          // clean any possible existing states
+          FileUtils.cleanDir(spillStateLocation);
 
           // spill state to local disk
           String stateLocation = spillStateLocation + checkpointId + "-" + UUID.randomUUID();

--- a/heron/ckptmgr/tests/java/org/apache/heron/ckptmgr/CheckpointManagerServerTest.java
+++ b/heron/ckptmgr/tests/java/org/apache/heron/ckptmgr/CheckpointManagerServerTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.heron.api.generated.TopologyAPI;
 import org.apache.heron.common.basics.NIOLooper;
 import org.apache.heron.common.basics.SysUtils;
 import org.apache.heron.common.network.HeronClient;
@@ -79,11 +80,23 @@ public class CheckpointManagerServerTest {
     final int COMPONENT_INDEX = 1;
     final String COMPONENT_NAME = "component_name";
     final byte[] BYTES = "checkpoint manager server test bytes".getBytes();
+    final String TOPO_ID = "topo_id";
+    final String TOPO_NAME = "topo_name";
 
     PhysicalPlans.InstanceInfo info = PhysicalPlans.InstanceInfo.newBuilder()
         .setTaskId(TASK_ID)
         .setComponentIndex(COMPONENT_INDEX)
         .setComponentName(COMPONENT_NAME)
+        .build();
+
+    TopologyAPI.Topology topology = TopologyAPI.Topology.newBuilder()
+        .setId(TOPO_ID)
+        .setName(TOPO_NAME)
+        .setState(TopologyAPI.TopologyState.RUNNING)
+        .build();
+
+    PhysicalPlans.PhysicalPlan pplan = PhysicalPlans.PhysicalPlan.newBuilder()
+        .setTopology(topology)
         .build();
 
     instance = PhysicalPlans.Instance.newBuilder()
@@ -121,6 +134,7 @@ public class CheckpointManagerServerTest {
         .setTopologyId(TOPOLOGY_ID)
         .setStmgrId(STMGR_ID)
         .setTopologyName(TOPOLOGY_NAME)
+        .setPhysicalPlan(pplan)
         .build();
 
     registerTMasterRequest = CheckpointManager.RegisterTMasterRequest.newBuilder()

--- a/heron/instance/src/java/org/apache/heron/instance/AbstractOutputCollector.java
+++ b/heron/instance/src/java/org/apache/heron/instance/AbstractOutputCollector.java
@@ -114,8 +114,10 @@ public class AbstractOutputCollector {
 
   // Flush the states
   public void sendOutState(State<Serializable, Serializable> state,
-                           String checkpointId) {
-    outputter.sendOutState(state, checkpointId);
+                           String checkpointId,
+                           boolean spillState,
+                           String location) {
+    outputter.sendOutState(state, checkpointId, spillState, location);
   }
 
   // Clean the internal state of BoltOutputCollectorImpl

--- a/heron/instance/src/java/org/apache/heron/instance/OutgoingTupleCollection.java
+++ b/heron/instance/src/java/org/apache/heron/instance/OutgoingTupleCollection.java
@@ -128,6 +128,8 @@ public class OutgoingTupleCollection {
       instanceStateBuilder.setCheckpointId(checkpointId);
 
       if (spillState) {
+        FileUtils.cleanDir(location);
+
         String stateLocation = location + checkpointId + "-" + UUID.randomUUID();
         FileUtils.writeToFile(stateLocation, serializedState, true);
         instanceStateBuilder.setStateLocation(stateLocation);

--- a/heron/instance/src/java/org/apache/heron/instance/OutgoingTupleCollection.java
+++ b/heron/instance/src/java/org/apache/heron/instance/OutgoingTupleCollection.java
@@ -131,7 +131,9 @@ public class OutgoingTupleCollection {
         FileUtils.cleanDir(location);
 
         String stateLocation = location + checkpointId + "-" + UUID.randomUUID();
-        FileUtils.writeToFile(stateLocation, serializedState, true);
+        if (!FileUtils.writeToFile(stateLocation, serializedState, true)) {
+          throw new RuntimeException("failed to spill state. Bailing out...");
+        }
         instanceStateBuilder.setStateLocation(stateLocation);
       } else {
         instanceStateBuilder.setState(ByteString.copyFrom(serializedState));

--- a/heron/instance/src/java/org/apache/heron/instance/Slave.java
+++ b/heron/instance/src/java/org/apache/heron/instance/Slave.java
@@ -317,10 +317,6 @@ public class Slave implements Runnable, AutoCloseable {
       String stateLocation = request.getState().getStateLocation();
       byte[] rawState = FileUtils.readFromFile(stateLocation);
 
-      if (!FileUtils.deleteFile(stateLocation)) {
-        LOG.info("failed to delete the state tmp file: " + stateLocation);
-      }
-
       @SuppressWarnings("unchecked")
       State<Serializable, Serializable> stateToRestore =
           (State<Serializable, Serializable>) serializer.deserialize(rawState);

--- a/heron/instance/src/java/org/apache/heron/instance/Slave.java
+++ b/heron/instance/src/java/org/apache/heron/instance/Slave.java
@@ -32,6 +32,7 @@ import org.apache.heron.api.serializer.IPluggableSerializer;
 import org.apache.heron.api.state.HashMapState;
 import org.apache.heron.api.state.State;
 import org.apache.heron.common.basics.Communicator;
+import org.apache.heron.common.basics.FileUtils;
 import org.apache.heron.common.basics.SingletonRegistry;
 import org.apache.heron.common.basics.SlaveLooper;
 import org.apache.heron.common.config.SystemConfig;
@@ -304,12 +305,25 @@ public class Slave implements Runnable, AutoCloseable {
       instanceState.clear();
       instanceState = null;
     }
+
     if (request.getState().hasState() && !request.getState().getState().isEmpty()) {
       @SuppressWarnings("unchecked")
       State<Serializable, Serializable> stateToRestore =
           (State<Serializable, Serializable>) serializer.deserialize(
               request.getState().getState().toByteArray());
 
+      instanceState = stateToRestore;
+    } else if (request.getState().hasStateLocation()) {
+      String stateLocation = request.getState().getStateLocation();
+      byte[] rawState = FileUtils.readFromFile(stateLocation);
+
+      if (!FileUtils.deleteFile(stateLocation)) {
+        LOG.info("failed to delete the state tmp file: " + stateLocation);
+      }
+
+      @SuppressWarnings("unchecked")
+      State<Serializable, Serializable> stateToRestore =
+          (State<Serializable, Serializable>) serializer.deserialize(rawState);
       instanceState = stateToRestore;
     } else {
       LOG.info("The restore request does not have an actual state");

--- a/heron/instance/src/java/org/apache/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/org/apache/heron/instance/bolt/BoltInstance.java
@@ -106,8 +106,9 @@ public class BoltInstance implements IInstance {
     this.spillState =
         Boolean.parseBoolean((String) config.get(Config.TOPOLOGY_STATEFUL_SPILL_STATE));
 
-    this.spillStateLocation =
-        String.valueOf(config.get(Config.TOPOLOGY_STATEFUL_SPILL_STATE_LOCATION));
+    this.spillStateLocation = String.format("%s/%s/",
+            String.valueOf(config.get(Config.TOPOLOGY_STATEFUL_SPILL_STATE_LOCATION)),
+            helper.getMyInstanceId());
 
     if (helper.getMyBolt() == null) {
       throw new RuntimeException("HeronBoltInstance has no bolt in physical plan.");

--- a/heron/instance/src/java/org/apache/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/org/apache/heron/instance/spout/SpoutInstance.java
@@ -106,8 +106,9 @@ public class SpoutInstance implements IInstance {
     this.spillState =
         Boolean.parseBoolean((String) config.get(Config.TOPOLOGY_STATEFUL_SPILL_STATE));
 
-    this.spillStateLocation =
-        String.valueOf(config.get(Config.TOPOLOGY_STATEFUL_SPILL_STATE_LOCATION));
+    this.spillStateLocation = String.format("%s/%s/",
+        String.valueOf(config.get(Config.TOPOLOGY_STATEFUL_SPILL_STATE_LOCATION)),
+        helper.getMyInstanceId());
 
     LOG.info("Is this topology stateful: " + isTopologyStateful);
 

--- a/heron/proto/ckptmgr.proto
+++ b/heron/proto/ckptmgr.proto
@@ -202,6 +202,7 @@ message RegisterStMgrRequest {
   required string topology_name = 1;
   required string topology_id = 2;
   required string stmgr_id = 3;
+  required heron.proto.system.PhysicalPlan physical_plan = 4;
 }
 
 // This is the message that checkpoint manager

--- a/heron/proto/ckptmgr.proto
+++ b/heron/proto/ckptmgr.proto
@@ -180,10 +180,12 @@ message CleanStatefulCheckpointResponse {
  */
 
 // This message encapsulates the info associated with
-// state of an instance/partition
+// state of an instance/partition. only one of the state_location
+// and state should be set
 message InstanceStateCheckpoint {
   required string checkpoint_id = 1;
-  required bytes state = 2;
+  optional bytes state = 2;
+  optional string state_location = 3;
 }
 
 // This message encapsulates the info associated with

--- a/heron/proto/stmgr.proto
+++ b/heron/proto/stmgr.proto
@@ -67,4 +67,6 @@ message TupleStreamMessage {
   required int32 task_id = 1;
   // serialized data
   required bytes set = 2;
+  // number of tuples in serialized data tuples only
+  required int32 num_tuples = 4;
 }

--- a/heron/stmgr/src/cpp/manager/ckptmgr-client.cpp
+++ b/heron/stmgr/src/cpp/manager/ckptmgr-client.cpp
@@ -42,6 +42,7 @@ CkptMgrClient::CkptMgrClient(EventLoop* eventloop, const NetworkOptions& _option
       ckptmgr_id_(_ckptmgr_id),
       stmgr_id_(_stmgr_id),
       quit_(false),
+      pplan_(nullptr),
       ckpt_saved_watcher_(_ckpt_saved_watcher),
       ckpt_get_watcher_(_ckpt_get_watcher),
       register_watcher_(_register_watcher) {
@@ -144,6 +145,7 @@ void CkptMgrClient::SendRegisterRequest() {
   request->set_topology_name(topology_name_);
   request->set_topology_id(topology_id_);
   request->set_stmgr_id(stmgr_id_);
+  request->mutable_physical_plan()->CopyFrom(*pplan_);
   SendRequest(request, NULL);
 }
 
@@ -152,11 +154,8 @@ void CkptMgrClient::SaveInstanceState(proto::ckptmgr::SaveInstanceStateRequest* 
   SendRequest(_request, NULL);
 }
 
-void CkptMgrClient::SendNewPhysicalPlan(const proto::system::PhysicalPlan& _pplan) {
-  LOG(INFO) << "Sending new physical plan to ckpgmgr" << std::endl;
-  proto::stmgr::NewInstanceAssignmentMessage new_assignment;
-  new_assignment.mutable_pplan()->CopyFrom(_pplan);
-  SendMessage(new_assignment);
+void CkptMgrClient::SetPhysicalPlan(proto::system::PhysicalPlan& _pplan) {
+  pplan_ = &_pplan;
 }
 
 void CkptMgrClient::GetInstanceState(const proto::system::Instance& _instance,

--- a/heron/stmgr/src/cpp/manager/ckptmgr-client.cpp
+++ b/heron/stmgr/src/cpp/manager/ckptmgr-client.cpp
@@ -152,6 +152,13 @@ void CkptMgrClient::SaveInstanceState(proto::ckptmgr::SaveInstanceStateRequest* 
   SendRequest(_request, NULL);
 }
 
+void CkptMgrClient::SendNewPhysicalPlan(const proto::system::PhysicalPlan& _pplan) {
+  LOG(INFO) << "Sending new physical plan to ckpgmgr" << std::endl;
+  proto::stmgr::NewInstanceAssignmentMessage new_assignment;
+  new_assignment.mutable_pplan()->CopyFrom(_pplan);
+  SendMessage(new_assignment);
+}
+
 void CkptMgrClient::GetInstanceState(const proto::system::Instance& _instance,
                                      const std::string& _checkpoint_id) {
   LOG(INFO) << "Sending GetInstanceState to ckptmgr for task_id " << _instance.info().task_id()

--- a/heron/stmgr/src/cpp/manager/ckptmgr-client.h
+++ b/heron/stmgr/src/cpp/manager/ckptmgr-client.h
@@ -44,10 +44,10 @@ class CkptMgrClient : public Client {
 
   void Quit();
 
-  // TODO(nlu): add requests methods
   virtual void SaveInstanceState(proto::ckptmgr::SaveInstanceStateRequest* _request);
   virtual void GetInstanceState(const proto::system::Instance& _instance,
                                 const std::string& _checkpoint_id);
+  virtual void SendNewPhysicalPlan(const proto::system::PhysicalPlan& _pplan);
 
  protected:
   void GetInstanceState(const proto::system::Instance& _instance,
@@ -67,8 +67,6 @@ class CkptMgrClient : public Client {
   void SendRegisterRequest();
 
   void OnReconnectTimer();
-
-  // TODO(nlu): add response handler methods
 
   sp_string topology_name_;
   sp_string topology_id_;

--- a/heron/stmgr/src/cpp/manager/ckptmgr-client.h
+++ b/heron/stmgr/src/cpp/manager/ckptmgr-client.h
@@ -47,7 +47,7 @@ class CkptMgrClient : public Client {
   virtual void SaveInstanceState(proto::ckptmgr::SaveInstanceStateRequest* _request);
   virtual void GetInstanceState(const proto::system::Instance& _instance,
                                 const std::string& _checkpoint_id);
-  virtual void SendNewPhysicalPlan(const proto::system::PhysicalPlan& _pplan);
+  virtual void SetPhysicalPlan(proto::system::PhysicalPlan& _pplan);
 
  protected:
   void GetInstanceState(const proto::system::Instance& _instance,
@@ -81,6 +81,8 @@ class CkptMgrClient : public Client {
 
   // Config
   sp_int32 reconnect_cpktmgr_interval_sec_;
+
+  proto::system::PhysicalPlan* pplan_;
 };
 
 }  // namespace stmgr

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
@@ -141,6 +141,11 @@ bool StMgrClientMgr::SendTupleStreamMessage(sp_int32 _task_id, const sp_string& 
   out = __global_protobuf_pool_acquire__(out);
   out->set_task_id(_task_id);
   out->set_src_task_id(_msg.src_task_id());
+  sp_int32 length = 0;
+  if (_msg.has_data()) {
+    length = _msg.data().tuples_size();
+  }
+  out->set_num_tuples(length);
   _msg.SerializePartialToString(out->mutable_set());
 
   bool retval = clients_[_stmgr_id]->SendTupleStreamMessage(*out);

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -600,6 +600,10 @@ void StMgr::NewPhysicalPlan(proto::system::PhysicalPlan* _pplan) {
     clientmgr_->StartConnections(pplan_);
   }
   instance_server_->BroadcastNewPhysicalPlan(*pplan_);
+  // for stateful topologies we need to send the pplan to ckptmgr
+  if (ckptmgr_client_) {
+    ckptmgr_client_->SendNewPhysicalPlan(*pplan_);
+  }
 }
 
 void StMgr::CleanupStreamConsumers() {
@@ -1003,7 +1007,7 @@ void StMgr::InitiateStatefulCheckpoint(sp_string _checkpoint_id) {
   instance_server_->InitiateStatefulCheckpoint(_checkpoint_id);
 }
 
-// We just recieved a InstanceStateCheckpoint message from one of our instances
+// We just received a InstanceStateCheckpoint message from one of our instances
 // We need to propagate it to all downstream tasks
 // We also need to send the checkpoint to ckptmgr
 void StMgr::HandleStoreInstanceStateCheckpoint(


### PR DESCRIPTION
During our test, we found that if a state is too large (>~64MB), the original checkpointing mechanism fails. The actual state will be packed in the protobuf message and transmitted through the network. Once it's large enough, the receiver will have problems parsing the IncomingPacket, which causes the connection to be closed. And it fails the whole checkpointing process.

This PR solves this problem by introducing the state spilling feature. With the feature turned on, the actual state will be spilled to local disk and only the state location information is transmitted through the network. This ensures the checkpointing works for even very large states.

Tested with internal topologies. A previous related PR is #2962 