### PR TITLE
Adding average Serialization/Deserialization time per tuple

### DIFF
--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/FullBoltMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/FullBoltMetrics.java
@@ -52,8 +52,10 @@ public class FullBoltMetrics extends BoltMetrics {
   // Time in nano-seconds spending in execute() at every interval
   private final MultiCountMetric executeTimeNs;
   private final MultiCountMetric emitCount;
-  private final MultiCountMetric deserializationTimeNs;
-  private final MultiCountMetric serializationTimeNs;
+  private final MultiCountMetric totalDeserializationTimeNs;
+  private final MultiCountMetric totalSerializationTimeNs;
+  private final MultiReducedMetric<MeanReducerState, Number, Double> averageSerializationTimeNs;
+  private final MultiReducedMetric<MeanReducerState, Number, Double> averageDeserializationTimeNs;
 
   // The # of times back-pressure happens on outStreamQueue
   // so instance could not produce more tuples
@@ -71,8 +73,11 @@ public class FullBoltMetrics extends BoltMetrics {
     emitCount = new MultiCountMetric();
     outQueueFullCount = new CountMetric();
 
-    deserializationTimeNs = new MultiCountMetric();
-    serializationTimeNs = new MultiCountMetric();
+    totalDeserializationTimeNs = new MultiCountMetric();
+    totalSerializationTimeNs = new MultiCountMetric();
+
+    averageSerializationTimeNs = new MultiReducedMetric<>(new MeanReducer());
+    averageDeserializationTimeNs = new MultiReducedMetric<>(new MeanReducer());
   }
 
   public void registerMetrics(TopologyContextImpl topologyContext) {
@@ -91,8 +96,11 @@ public class FullBoltMetrics extends BoltMetrics {
     topologyContext.registerMetric("__emit-count", emitCount, interval);
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
     topologyContext.registerMetric(
-        "__tuple-deserialization-time-ns", deserializationTimeNs, interval);
-    topologyContext.registerMetric("__tuple-serialization-time-ns", serializationTimeNs, interval);
+        "__tuple-deserialization-time-ns", totalDeserializationTimeNs, interval);
+    topologyContext.registerMetric("__tuple-serialization-time-ns", totalSerializationTimeNs, interval);
+    topologyContext.registerMetric(
+        "__av-tuple-deserialization-time-ns", totalDeserializationTimeNs, interval);
+    topologyContext.registerMetric("__av-tuple-serialization-time-ns", totalSerializationTimeNs, interval);
   }
 
   // For MultiCountMetrics, we need to set the default value for all streams.
@@ -174,17 +182,20 @@ public class FullBoltMetrics extends BoltMetrics {
   }
 
   public void deserializeDataTuple(String streamId, String sourceComponent, long latency) {
-    deserializationTimeNs.scope(streamId).incrBy(latency);
+    totalDeserializationTimeNs.scope(streamId).incrBy(latency);
+    averageDeserializationTimeNs.scope(streamId).update(latency);
 
     // Consider there are cases that different streams with the same streamId,
     // but with different source component. We need to distinguish them too.
     String globalStreamId =
         new StringBuilder(sourceComponent).append("/").append(streamId).toString();
-    deserializationTimeNs.scope(globalStreamId).incrBy(latency);
+    totalDeserializationTimeNs.scope(globalStreamId).incrBy(latency);
+    averageDeserializationTimeNs.scope(globalStreamId).update(latency);
   }
 
   public void serializeDataTuple(String streamId, long latency) {
-    serializationTimeNs.scope(streamId).incrBy(latency);
+    totalSerializationTimeNs.scope(streamId).incrBy(latency);
+    averageSerializationTimeNs.scope(streamId).update(latency);
   }
 }
 

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/FullBoltMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/FullBoltMetrics.java
@@ -97,10 +97,12 @@ public class FullBoltMetrics extends BoltMetrics {
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
     topologyContext.registerMetric(
         "__tuple-deserialization-time-ns", totalDeserializationTimeNs, interval);
-    topologyContext.registerMetric("__tuple-serialization-time-ns", totalSerializationTimeNs, interval);
+    topologyContext.registerMetric(
+        "__tuple-serialization-time-ns", totalSerializationTimeNs, interval);
     topologyContext.registerMetric(
         "__av-tuple-deserialization-time-ns", totalDeserializationTimeNs, interval);
-    topologyContext.registerMetric("__av-tuple-serialization-time-ns", totalSerializationTimeNs, interval);
+    topologyContext.registerMetric(
+        "__av-tuple-serialization-time-ns", totalSerializationTimeNs, interval);
   }
 
   // For MultiCountMetrics, we need to set the default value for all streams.

--- a/heron/instance/src/java/org/apache/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/org/apache/heron/instance/bolt/BoltInstance.java
@@ -290,8 +290,8 @@ public class BoltInstance implements IInstance {
             stream.getComponentName(), stream.getId()).size();
         int sourceTaskId = tuples.getSrcTaskId();
 
+        long startTime = System.nanoTime();
         for (HeronTuples.HeronDataTuple dataTuple : tuples.getData().getTuplesList()) {
-          long startExecuteTuple = System.nanoTime();
           // Create the value list and fill the value
           List<Object> values = new ArrayList<>(nValues);
           for (int i = 0; i < nValues; i++) {
@@ -301,6 +301,12 @@ public class BoltInstance implements IInstance {
           // Decode the tuple
           TupleImpl t = new TupleImpl(topologyContext, stream, dataTuple.getKey(),
               dataTuple.getRootsList(), values, startExecuteTuple, false, sourceTaskId);
+
+          long deserializedTime = System.nanoTime();
+          boltMetrics.deserializeDataTuple(stream.getId(), stream.getComponentName(),
+              deserializedTime - startTime);
+
+          long startExecuteTuple = System.nanoTime();
 
           // Delegate to the use defined bolt
           bolt.execute(t);


### PR DESCRIPTION
Currently, the serialization metrics are reported as MultiCountMetric. This means that serialization times are reported as a sum of the serialization times for all tuples sent per unit time. It would be better if the metric was reported as average serialization time per tuple.