### PR TITLE
Extending update command to allow number of containers to be modified at runtime

### DIFF
--- a/heron/instance/src/java/org/apache/heron/metrics/GatewayMetrics.java
+++ b/heron/instance/src/java/org/apache/heron/metrics/GatewayMetrics.java
@@ -46,6 +46,7 @@ public class GatewayMetrics {
   private final CountMetric sentMetricsSize;
   private final CountMetric sentMetricsCount;
   private final CountMetric sentExceptionsCount;
+  private final CountMetric outStreamQueueSizeCumulative;
 
   // The # of items in inStreamQueue
   private final ReducedMetric<MeanReducerState, Number, Double> inStreamQueueSize;
@@ -77,6 +78,7 @@ public class GatewayMetrics {
     outStreamQueueExpectedCapacity = new ReducedMetric<>(new MeanReducer());
 
     inQueueFullCount = new CountMetric();
+    outStreamQueueSizeCumulative = new CountMetric();
   }
 
   /**
@@ -122,6 +124,9 @@ public class GatewayMetrics {
     metricsCollector.registerMetric("__gateway-out-stream-queue-size",
         outStreamQueueSize,
         interval);
+    metricsCollector.registerMetric("__gateway-out-stream-queue-size-cumulative",
+        outStreamQueueSizeCumulative,
+        interval);
     metricsCollector.registerMetric("__gateway-in-stream-queue-expected-capacity",
         inStreamQueueExpectedCapacity,
         interval);
@@ -165,6 +170,7 @@ public class GatewayMetrics {
   }
 
   public void setOutStreamQueueSize(long size) {
+    outStreamQueueSizeCumulative.incrBy(size);
     outStreamQueueSize.update(size);
   }
 

--- a/heron/instance/src/java/org/apache/heron/metrics/GatewayMetrics.java
+++ b/heron/instance/src/java/org/apache/heron/metrics/GatewayMetrics.java
@@ -46,7 +46,6 @@ public class GatewayMetrics {
   private final CountMetric sentMetricsSize;
   private final CountMetric sentMetricsCount;
   private final CountMetric sentExceptionsCount;
-  private final CountMetric outStreamQueueSizeCumulative;
 
   // The # of items in inStreamQueue
   private final ReducedMetric<MeanReducerState, Number, Double> inStreamQueueSize;
@@ -78,7 +77,6 @@ public class GatewayMetrics {
     outStreamQueueExpectedCapacity = new ReducedMetric<>(new MeanReducer());
 
     inQueueFullCount = new CountMetric();
-    outStreamQueueSizeCumulative = new CountMetric();
   }
 
   /**
@@ -124,9 +122,6 @@ public class GatewayMetrics {
     metricsCollector.registerMetric("__gateway-out-stream-queue-size",
         outStreamQueueSize,
         interval);
-    metricsCollector.registerMetric("__gateway-out-stream-queue-size-cumulative",
-        outStreamQueueSizeCumulative,
-        interval);
     metricsCollector.registerMetric("__gateway-in-stream-queue-expected-capacity",
         inStreamQueueExpectedCapacity,
         interval);
@@ -170,7 +165,6 @@ public class GatewayMetrics {
   }
 
   public void setOutStreamQueueSize(long size) {
-    outStreamQueueSizeCumulative.incrBy(size);
     outStreamQueueSize.update(size);
   }
 

--- a/heron/packing/src/java/org/apache/heron/packing/binpacking/FirstFitDecreasingPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/binpacking/FirstFitDecreasingPacking.java
@@ -201,6 +201,14 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
   }
 
   @Override
+  public PackingPlan repack(PackingPlan currentPackingPlan, int containers,
+                            Map<String, Integer> componentChanges)
+      throws PackingException, UnsupportedOperationException {
+    throw new UnsupportedOperationException("FirstFitDecreasingPacking does not currently support"
+        + " creating a new packing plan with a new number of containers.");
+  }
+
+  @Override
   public void close() {
 
   }

--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -39,6 +39,7 @@ import org.apache.heron.spi.common.Config;
 import org.apache.heron.spi.common.Context;
 import org.apache.heron.spi.packing.IPacking;
 import org.apache.heron.spi.packing.IRepacking;
+import org.apache.heron.spi.packing.PackingException;
 import org.apache.heron.spi.packing.PackingPlan;
 import org.apache.heron.spi.packing.Resource;
 
@@ -224,6 +225,14 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
             e.getMessage(), this.numContainers));
       }
     }
+  }
+
+  @Override
+  public PackingPlan repack(PackingPlan currentPackingPlan, int containers,
+                            Map<String, Integer> componentChanges)
+      throws PackingException, UnsupportedOperationException {
+    throw new UnsupportedOperationException("ResourceCompliantRRPacking does not "
+        + "currently support creating a new packing plan with a new number of containers.");
   }
 
   @Override

--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
@@ -414,4 +414,19 @@ public class RoundRobinPacking implements IPacking, IRepacking {
 
     return packInternal(newNumContainer, currentComponentParallelism);
   }
+
+  @Override
+  public PackingPlan repack(PackingPlan currentPackingPlan, int containers, Map<String, Integer>
+      componentChanges) throws PackingException {
+    if (containers == currentPackingPlan.getContainers().size()) {
+      return repack(currentPackingPlan, componentChanges);
+    }
+    Map<String, Integer> currentComponentParallelism = currentPackingPlan.getComponentCounts();
+
+    for (Map.Entry<String, Integer> e : componentChanges.entrySet()) {
+      Integer newParallelism = currentComponentParallelism.get(e.getKey()) + e.getValue();
+      currentComponentParallelism.put(e.getKey(), newParallelism);
+    }
+    return packInternal(containers, currentComponentParallelism);
+  }
 }

--- a/heron/scheduler-core/src/java/org/apache/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/org/apache/heron/scheduler/RuntimeManagerMain.java
@@ -119,6 +119,13 @@ public class RuntimeManagerMain {
         .argName("component parallelism")
         .build();
 
+    Option containerNumber = Option.builder("cn")
+        .desc("Container Number for updation: <value>")
+        .longOpt("container_number")
+        .hasArgs()
+        .argName("container number")
+        .build();
+
     Option runtimeConfig = Option.builder("rc")
         .desc("Runtime config to update: [comp:]<name>:<value>,[comp:]<name>:<value>,...")
         .longOpt("runtime_config")
@@ -193,6 +200,7 @@ public class RuntimeManagerMain {
     options.addOption(heronHome);
     options.addOption(containerId);
     options.addOption(componentParallelism);
+    options.addOption(containerNumber);
     options.addOption(runtimeConfig);
     options.addOption(dryRun);
     options.addOption(dryRunFormat);

--- a/heron/scheduler-core/src/java/org/apache/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/org/apache/heron/scheduler/RuntimeManagerMain.java
@@ -501,6 +501,13 @@ public class RuntimeManagerMain {
       config.put(
           RuntimeManagerRunner.RUNTIME_MANAGER_COMPONENT_PARALLELISM_KEY, componentParallelism);
     }
+
+    String containerNumber = cmd.getOptionValue("container_number");
+    if (containerNumber != null && !containerNumber.isEmpty()) {
+      config.put(
+          RuntimeManagerRunner.RUNTIME_MANAGER_CONTAINER_NUMBER_KEY, containerNumber);
+    }
+
     String runtimeConfigurations = cmd.getOptionValue("runtime_config");
     if (runtimeConfigurations != null && !runtimeConfigurations.isEmpty()) {
       config.put(

--- a/heron/scheduler-core/src/java/org/apache/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/org/apache/heron/scheduler/RuntimeManagerRunner.java
@@ -216,7 +216,8 @@ public class RuntimeManagerRunner {
 
       if (newParallelism != null && !newParallelism.isEmpty()) {
         changeRequests = parseNewParallelismParam(newParallelism);
-      } else if (newContainerNumber != null && !newContainerNumber.isEmpty()) {
+      }
+      if (newContainerNumber != null && !newContainerNumber.isEmpty()) {
         newContainers = Integer.parseInt(newContainerNumber);
       }
       updatePackingPlan(topologyName, newContainers, changeRequests);

--- a/heron/scheduler-core/tests/java/org/apache/heron/scheduler/RuntimeManagerRunnerTest.java
+++ b/heron/scheduler-core/tests/java/org/apache/heron/scheduler/RuntimeManagerRunnerTest.java
@@ -236,7 +236,7 @@ public class RuntimeManagerRunnerTest {
 
     when(manager.getPackingPlan(eq(TOPOLOGY_NAME))).thenReturn(currentPlan);
     doReturn(proposedPlan).when(runner).buildNewPackingPlan(
-        eq(currentPlan), eq(changeRequests), any(TopologyAPI.Topology.class));
+        eq(currentPlan), eq(changeRequests), 1, any(TopologyAPI.Topology.class));
 
     Scheduler.UpdateTopologyRequest updateTopologyRequest =
         Scheduler.UpdateTopologyRequest.newBuilder()
@@ -246,7 +246,7 @@ public class RuntimeManagerRunnerTest {
 
     when(client.updateTopology(updateTopologyRequest)).thenReturn(true);
     try {
-      runner.updateTopologyComponentParallelism(TOPOLOGY_NAME, newParallelism);
+      runner.updatePackingPlan(TOPOLOGY_NAME, 1, changeRequests);
     } finally {
       int expectedClientUpdateCalls = expectedResult ? 1 : 0;
       verify(client, times(expectedClientUpdateCalls)).updateTopology(updateTopologyRequest);

--- a/heron/spi/src/java/org/apache/heron/spi/packing/IRepacking.java
+++ b/heron/spi/src/java/org/apache/heron/spi/packing/IRepacking.java
@@ -54,6 +54,20 @@ public interface IRepacking extends AutoCloseable {
                      Map<String, Integer> componentChanges) throws PackingException;
 
   /**
+   * Generates a new packing given an existing packing and component changes
+   * Packing algorithm output generates instance id and container id.
+   * @param currentPackingPlan Existing packing plan
+   * @param componentChanges Map &lt; componentName, new component parallelism &gt;
+   * that contains the parallelism for each component whose parallelism has changed.
+   * @param containers &lt; the new number of containers for the topology
+   * specified by the user
+   * @return PackingPlan describing the new packing plan.
+   * @throws PackingException if the packing plan can not be generated
+   */
+  PackingPlan repack(PackingPlan currentPackingPlan, int containers,
+                     Map<String, Integer> componentChanges) throws PackingException;
+
+  /**
    * This is to for disposing or cleaning up any internal state.
    * Closes this stream and releases any system resources associated
    * with it. If the stream is already closed then invoking this

--- a/heron/tools/apiserver/src/java/org/apache/heron/apiserver/actions/Keys.java
+++ b/heron/tools/apiserver/src/java/org/apache/heron/apiserver/actions/Keys.java
@@ -25,6 +25,8 @@ public final class Keys {
 
   public static final String PARAM_COMPONENT_PARALLELISM =
       RuntimeManagerRunner.RUNTIME_MANAGER_COMPONENT_PARALLELISM_KEY;
+  public static final String PARAM_CONTAINER_NUMBER =
+      RuntimeManagerRunner.RUNTIME_MANAGER_CONTAINER_NUMBER_KEY;
   public static final String PARAM_USER_RUNTIME_CONFIG =
       RuntimeManagerRunner.RUNTIME_MANAGER_RUNTIME_CONFIG_KEY;
 

--- a/heron/tools/apiserver/src/java/org/apache/heron/apiserver/resources/TopologyResource.java
+++ b/heron/tools/apiserver/src/java/org/apache/heron/apiserver/resources/TopologyResource.java
@@ -341,7 +341,7 @@ public class TopologyResource extends HeronResource {
   @Path("/{cluster}/{role}/{environment}/{name}/update")
   @Produces(MediaType.APPLICATION_JSON)
   @SuppressWarnings({"IllegalCatch", "JavadocMethod"})
-  public Response update(/// add code here
+  public Response update(
       final @PathParam("cluster") String cluster,
       final @PathParam("role") String role,
       final @PathParam("environment") String environment,

--- a/heron/tools/apiserver/src/java/org/apache/heron/apiserver/resources/TopologyResource.java
+++ b/heron/tools/apiserver/src/java/org/apache/heron/apiserver/resources/TopologyResource.java
@@ -341,7 +341,7 @@ public class TopologyResource extends HeronResource {
   @Path("/{cluster}/{role}/{environment}/{name}/update")
   @Produces(MediaType.APPLICATION_JSON)
   @SuppressWarnings({"IllegalCatch", "JavadocMethod"})
-  public Response update( /// add code here
+  public Response update(/// add code here
       final @PathParam("cluster") String cluster,
       final @PathParam("role") String role,
       final @PathParam("environment") String environment,
@@ -356,11 +356,15 @@ public class TopologyResource extends HeronResource {
       } else {
         List<String> components = params.get(PARAM_COMPONENT_PARALLELISM);
         List<String> runtimeConfigs = params.get(PARAM_RUNTIME_CONFIG_KEY);
-        String containers = params.get(PARAM_CONTAINER_NUMBER);
+        List<String> containersList = params.get(PARAM_CONTAINER_NUMBER);
+        if (containersList.size() > 1) {
+          Utils.createMessage("only one value should be specified for container_number. "
+              + "picking first value.");
+        }
 
-        if ((components != null && !components.isEmpty()) || (containers != null)) {
+        if ((components != null && !components.isEmpty()) || (containersList.get(0) != null)) {
           return updateComponentParallelism(cluster, role, environment, name, params,
-              components, containers);
+              components, containersList.get(0));
         } else if (runtimeConfigs != null && !runtimeConfigs.isEmpty()) {
           return updateRuntimeConfig(cluster, role, environment, name, params, runtimeConfigs);
         } else {
@@ -390,6 +394,7 @@ public class TopologyResource extends HeronResource {
       MultivaluedMap<String, String> params,
       List<String> components,
       String containers) {
+
     final List<Pair<String, Object>> keyValues = new ArrayList<>(
         Arrays.asList(
             Pair.create(Key.CLUSTER.value(), cluster),

--- a/heron/tools/apiserver/src/java/org/apache/heron/apiserver/resources/TopologyResource.java
+++ b/heron/tools/apiserver/src/java/org/apache/heron/apiserver/resources/TopologyResource.java
@@ -117,6 +117,7 @@ public class TopologyResource extends HeronResource {
   private static final String PARAM_DRY_RUN = "dry_run";
   private static final String PARAM_DRY_RUN_FORMAT = "dry_run_format";
   private static final String DEFAULT_DRY_RUN_FORMAT = DryRunFormatType.TABLE.toString();
+  private static final String PARAM_CONTAINER_NUMBER = "container_number";
 
   // path format /topologies/{cluster}/{role}/{environment}/{name}
   private static final String TOPOLOGY_PATH_FORMAT = "/topologies/%s/%s/%s/%s";
@@ -340,7 +341,7 @@ public class TopologyResource extends HeronResource {
   @Path("/{cluster}/{role}/{environment}/{name}/update")
   @Produces(MediaType.APPLICATION_JSON)
   @SuppressWarnings({"IllegalCatch", "JavadocMethod"})
-  public Response update(
+  public Response update( /// add code here
       final @PathParam("cluster") String cluster,
       final @PathParam("role") String role,
       final @PathParam("environment") String environment,
@@ -355,9 +356,11 @@ public class TopologyResource extends HeronResource {
       } else {
         List<String> components = params.get(PARAM_COMPONENT_PARALLELISM);
         List<String> runtimeConfigs = params.get(PARAM_RUNTIME_CONFIG_KEY);
+        String containers = params.get(PARAM_CONTAINER_NUMBER);
 
-        if (components != null && !components.isEmpty()) {
-          return updateComponentParallelism(cluster, role, environment, name, params, components);
+        if ((components != null && !components.isEmpty()) || (containers != null)) {
+          return updateComponentParallelism(cluster, role, environment, name, params,
+              components, containers);
         } else if (runtimeConfigs != null && !runtimeConfigs.isEmpty()) {
           return updateRuntimeConfig(cluster, role, environment, name, params, runtimeConfigs);
         } else {
@@ -385,13 +388,15 @@ public class TopologyResource extends HeronResource {
       String environment,
       String name,
       MultivaluedMap<String, String> params,
-      List<String> components) {
+      List<String> components,
+      String containers) {
     final List<Pair<String, Object>> keyValues = new ArrayList<>(
         Arrays.asList(
             Pair.create(Key.CLUSTER.value(), cluster),
             Pair.create(Key.ROLE.value(), role),
             Pair.create(Key.ENVIRON.value(), environment),
             Pair.create(Key.TOPOLOGY_NAME.value(), name),
+            Pair.create(Keys.PARAM_CONTAINER_NUMBER, containers),
             Pair.create(Keys.PARAM_COMPONENT_PARALLELISM,
                 String.join(",", components))
         )

--- a/heron/tools/apiserver/src/java/org/apache/heron/apiserver/resources/TopologyResource.java
+++ b/heron/tools/apiserver/src/java/org/apache/heron/apiserver/resources/TopologyResource.java
@@ -364,7 +364,7 @@ public class TopologyResource extends HeronResource {
 
         if ((components != null && !components.isEmpty()) || (containersList.get(0) != null)) {
           return updateComponentParallelism(cluster, role, environment, name, params,
-              components, containersList.get(0));
+              components, (containersList.size() > 0 ? containersList.get(0) : null));
         } else if (runtimeConfigs != null && !runtimeConfigs.isEmpty()) {
           return updateRuntimeConfig(cluster, role, environment, name, params, runtimeConfigs);
         } else {

--- a/heron/tools/cli/src/python/cli_helper.py
+++ b/heron/tools/cli/src/python/cli_helper.py
@@ -129,7 +129,6 @@ def run_direct(command, cl_args, action, extra_args=[], extra_lib_jars=[]):
       "--command", command,
   ]
   new_args += extra_args
-
   lib_jars = config.get_heron_libs(jars.scheduler_jars() + jars.statemgr_jars())
   lib_jars += extra_lib_jars
 

--- a/heron/tools/cli/src/python/update.py
+++ b/heron/tools/cli/src/python/update.py
@@ -113,13 +113,21 @@ def build_extra_args_dict(cl_args):
         "can't be updated at the same time")
 
   dict_extra_args = {}
+
+  nothing_set = True
   if component_parallelism:
     dict_extra_args.update({'component_parallelism': component_parallelism})
-  elif runtime_configs:
-    dict_extra_args.update({'runtime_config': runtime_configs})
-  elif container_number:
+    nothing_set = False
+
+  if container_number:
     dict_extra_args.update({'container_number': container_number})
-  else:
+    nothing_set = False
+
+  if runtime_configs:
+    dict_extra_args.update({'runtime_config': runtime_configs})
+    nothing_set = False
+
+  if nothing_set:
     raise Exception(
         "Missing arguments --component-parallelism or --runtime-config or --container-number")
 

--- a/heron/tools/cli/src/python/update.py
+++ b/heron/tools/cli/src/python/update.py
@@ -37,6 +37,7 @@ def create_parser(subparsers):
       help='Update a topology',
       usage="%(prog)s [options] cluster/[role]/[env] <topology-name> "
       + "[--component-parallelism <name:value>] "
+      + "[--container-number value] "
       + "[--runtime-config [component:]<name:value>]",
       add_help=True)
 
@@ -81,6 +82,21 @@ def create_parser(subparsers):
       help='Runtime configurations for topology and components '
       + 'colon-delimited: [component:]<name>:<value>')
 
+  def container_number_type(value):
+    pattern = re.compile(r"^\d+$")
+    if not pattern.match(value):
+      raise argparse.ArgumentTypeError(
+          "Invalid syntax for container number (value): %s"
+          % value)
+    return value
+
+  parser.add_argument(
+      '--container-number',
+      action='append',
+      type=container_number_type,
+      required=False,
+      help='Number of containers <value>')
+
   parser.set_defaults(subcommand='update')
   return parser
 
@@ -89,19 +105,23 @@ def build_extra_args_dict(cl_args):
   # Check parameters
   component_parallelism = cl_args['component_parallelism']
   runtime_configs = cl_args['runtime_config']
-  # Users need to provide either component-parallelism or runtime-config
-  if component_parallelism and runtime_configs:
+  container_number = cl_args['container_number']
+  # Users need to provide either (component-parallelism || container_number) or runtime-config
+  if (component_parallelism and runtime_configs) or (container_number and runtime_configs):
     raise Exception(
-        "component-parallelism and runtime-config can't be updated at the same time")
+        "(component-parallelism or container_num) and runtime-config " +
+        "can't be updated at the same time")
 
   dict_extra_args = {}
   if component_parallelism:
     dict_extra_args.update({'component_parallelism': component_parallelism})
   elif runtime_configs:
     dict_extra_args.update({'runtime_config': runtime_configs})
+  elif container_number:
+    dict_extra_args.update({'container_number': container_number})
   else:
     raise Exception(
-        "Missing arguments --component-parallelism or --runtime-config")
+        "Missing arguments --component-parallelism or --runtime-config or --container-number")
 
   if cl_args['dry_run']:
     dict_extra_args.update({'dry_run': True})
@@ -120,6 +140,9 @@ def convert_args_dict_to_list(dict_extra_args):
   if 'runtime_config' in dict_extra_args:
     list_extra_args += ["--runtime_config",
                         ','.join(dict_extra_args['runtime_config'])]
+  if 'container_number' in dict_extra_args:
+    list_extra_args += ["--container-number",
+                        ','.join(dict_extra_args['container_number'])]
   if 'dry_run' in dict_extra_args and dict_extra_args['dry_run']:
     list_extra_args += ['--dry_run']
   if 'dry_run_format' in dict_extra_args:

--- a/heron/tools/cli/src/python/update.py
+++ b/heron/tools/cli/src/python/update.py
@@ -141,7 +141,7 @@ def convert_args_dict_to_list(dict_extra_args):
     list_extra_args += ["--runtime_config",
                         ','.join(dict_extra_args['runtime_config'])]
   if 'container_number' in dict_extra_args:
-    list_extra_args += ["--container-number",
+    list_extra_args += ["--container_number",
                         ','.join(dict_extra_args['container_number'])]
   if 'dry_run' in dict_extra_args and dict_extra_args['dry_run']:
     list_extra_args += ['--dry_run']


### PR DESCRIPTION
Extended the update command to allow number of containers of a job to be updated at runtime. The only packing plan that supports this functionality currently is RoundRobinPackingPlan. Now, we can use a flag with the update command that specified the number of containers as follows:

/bin/heron update smf1/$USER/test jobName  --container-number 25  --verbose 

The previous semantics have been preserved, where either the runtime-config can be updated or either/both of component parallelism and number of containers can be updated at a time. 

The code has been tested locally and on Twitter's Aurora environment. 



