### PR TITLE
Metrics added to measure the rate at which tuples are added to the queue at spout gateway

### DIFF
--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/BoltMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/BoltMetrics.java
@@ -80,7 +80,7 @@ public class BoltMetrics implements ComponentMetrics {
     topologyContext.registerMetric("__execute-latency/default", executeLatency, interval);
     topologyContext.registerMetric("__emit-count/default", emitCount, interval);
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
-    topologyContext.registerMetric("__data_tuple-added-to-outgoing-queue/default", tupleAddedToQueue, interval);
+    topologyContext.registerMetric("__data-tuple-added-to-outgoing-queue/default", tupleAddedToQueue, interval);
   }
 
   // For MultiCountMetrics, we need to set the default value for all streams.

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/BoltMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/BoltMetrics.java
@@ -44,13 +44,14 @@ public class BoltMetrics implements ComponentMetrics {
   private final CountMetric failCount;
   private final CountMetric executeCount;
   private final ReducedMetric<MeanReducerState, Number, Double> executeLatency;
-
+  private final CountMetric tupleAddedToQueue;
   // Time in nano-seconds spending in execute() at every interval
   private final CountMetric emitCount;
 
   // The # of times back-pressure happens on outStreamQueue
   // so instance could not produce more tuples
   private final CountMetric outQueueFullCount;
+
 
 
   public BoltMetrics() {
@@ -62,6 +63,7 @@ public class BoltMetrics implements ComponentMetrics {
     executeLatency = new ReducedMetric<>(new MeanReducer());
     emitCount = new CountMetric();
     outQueueFullCount = new CountMetric();
+    tupleAddedToQueue = new CountMetric();
   }
 
   public void registerMetrics(TopologyContextImpl topologyContext) {
@@ -78,6 +80,7 @@ public class BoltMetrics implements ComponentMetrics {
     topologyContext.registerMetric("__execute-latency/default", executeLatency, interval);
     topologyContext.registerMetric("__emit-count/default", emitCount, interval);
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
+    topologyContext.registerMetric("__data_tuple-added-to-outgoing-queue/default", tupleAddedToQueue, interval);
   }
 
   // For MultiCountMetrics, we need to set the default value for all streams.
@@ -107,6 +110,10 @@ public class BoltMetrics implements ComponentMetrics {
 
   public void emittedTuple(String streamId) {
     emitCount.incr();
+  }
+
+  public void addTupleToQueue() {
+    tupleAddedToQueue.incr();
   }
 
   public void updateOutQueueFullCount() {

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/BoltMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/BoltMetrics.java
@@ -80,7 +80,8 @@ public class BoltMetrics implements ComponentMetrics {
     topologyContext.registerMetric("__execute-latency/default", executeLatency, interval);
     topologyContext.registerMetric("__emit-count/default", emitCount, interval);
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
-    topologyContext.registerMetric("__data-tuple-added-to-outgoing-queue/default", tupleAddedToQueue, interval);
+    topologyContext.registerMetric("__data-tuple-added-to-outgoing-queue/default",
+        tupleAddedToQueue, interval);
   }
 
   // For MultiCountMetrics, we need to set the default value for all streams.
@@ -112,7 +113,7 @@ public class BoltMetrics implements ComponentMetrics {
     emitCount.incr();
   }
 
-  public void addTupleToQueue() {
+  public void addTupleToQueue(int size) {
     tupleAddedToQueue.incr();
   }
 

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/ComponentMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/ComponentMetrics.java
@@ -28,7 +28,7 @@ import org.apache.heron.classification.InterfaceStability;
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public interface ComponentMetrics {
-
   void serializeDataTuple(String streamId, long latency);
   void emittedTuple(String streamId);
+  void addTupleToQueue();
 }

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/ComponentMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/ComponentMetrics.java
@@ -30,5 +30,5 @@ import org.apache.heron.classification.InterfaceStability;
 public interface ComponentMetrics {
   void serializeDataTuple(String streamId, long latency);
   void emittedTuple(String streamId);
-  void addTupleToQueue();
+  void addTupleToQueue(int size);
 }

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/FullBoltMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/FullBoltMetrics.java
@@ -52,6 +52,7 @@ public class FullBoltMetrics extends BoltMetrics {
   // Time in nano-seconds spending in execute() at every interval
   private final MultiCountMetric executeTimeNs;
   private final MultiCountMetric emitCount;
+  private final CountMetric tupleAddedToQueue;
   private final MultiCountMetric totalDeserializationTimeNs;
   private final MultiCountMetric totalSerializationTimeNs;
   private final MultiReducedMetric<MeanReducerState, Number, Double> averageSerializationTimeNs;
@@ -60,7 +61,6 @@ public class FullBoltMetrics extends BoltMetrics {
   // The # of times back-pressure happens on outStreamQueue
   // so instance could not produce more tuples
   private final CountMetric outQueueFullCount;
-
 
   public FullBoltMetrics() {
     ackCount = new MultiCountMetric();
@@ -72,6 +72,7 @@ public class FullBoltMetrics extends BoltMetrics {
     executeTimeNs = new MultiCountMetric();
     emitCount = new MultiCountMetric();
     outQueueFullCount = new CountMetric();
+    tupleAddedToQueue = new CountMetric();
 
     totalDeserializationTimeNs = new MultiCountMetric();
     totalSerializationTimeNs = new MultiCountMetric();
@@ -103,6 +104,8 @@ public class FullBoltMetrics extends BoltMetrics {
         "__av-tuple-deserialization-time-ns", totalDeserializationTimeNs, interval);
     topologyContext.registerMetric(
         "__av-tuple-serialization-time-ns", totalSerializationTimeNs, interval);
+    topologyContext.registerMetric("__data-tuple-added-to-outgoing-queue/default",
+        tupleAddedToQueue, interval);
   }
 
   // For MultiCountMetrics, we need to set the default value for all streams.
@@ -177,6 +180,10 @@ public class FullBoltMetrics extends BoltMetrics {
 
   public void emittedTuple(String streamId) {
     emitCount.scope(streamId).incr();
+  }
+
+  public void addTupleToQueue() {
+    tupleAddedToQueue.incr();
   }
 
   public void updateOutQueueFullCount() {

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/FullBoltMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/FullBoltMetrics.java
@@ -182,7 +182,7 @@ public class FullBoltMetrics extends BoltMetrics {
     emitCount.scope(streamId).incr();
   }
 
-  public void addTupleToQueue() {
+  public void addTupleToQueue(int size) {
     tupleAddedToQueue.incr();
   }
 

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/FullSpoutMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/FullSpoutMetrics.java
@@ -53,7 +53,7 @@ public class FullSpoutMetrics extends SpoutMetrics {
   private final ReducedMetric<MeanReducerState, Number, Double> nextTupleLatency;
   private final CountMetric nextTupleCount;
   private final MultiCountMetric serializationTimeNs;
-
+  private final CountMetric tupleAddedToQueue;
   // The # of times back-pressure happens on outStreamQueue so instance could not
   // produce more tuples
   private final CountMetric outQueueFullCount;
@@ -73,6 +73,7 @@ public class FullSpoutMetrics extends SpoutMetrics {
     outQueueFullCount = new CountMetric();
     pendingTuplesCount = new ReducedMetric<>(new MeanReducer());
     serializationTimeNs = new MultiCountMetric();
+    tupleAddedToQueue = new CountMetric();
   }
 
   public void registerMetrics(TopologyContextImpl topologyContext) {
@@ -92,6 +93,8 @@ public class FullSpoutMetrics extends SpoutMetrics {
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
     topologyContext.registerMetric("__pending-acked-count", pendingTuplesCount, interval);
     topologyContext.registerMetric("__tuple-serialization-time-ns", serializationTimeNs, interval);
+    topologyContext.registerMetric("__data-tuple-added-to-outgoing-queue/default",
+        tupleAddedToQueue, interval);
   }
 
   // For MultiCountMetrics, we need to set the default value for all streams.
@@ -133,6 +136,10 @@ public class FullSpoutMetrics extends SpoutMetrics {
   public void nextTuple(long latency) {
     nextTupleLatency.update(latency);
     nextTupleCount.incr();
+  }
+
+  public void addTupleToQueue() {
+    tupleAddedToQueue.incr();
   }
 
   public void updateOutQueueFullCount() {

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/FullSpoutMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/FullSpoutMetrics.java
@@ -96,6 +96,11 @@ public class FullSpoutMetrics extends SpoutMetrics {
     topologyContext.registerMetric("__pending-acked-count", pendingTuplesCount, interval);
     topologyContext.registerMetric("__tuple-serialization-time-ns", serializationTimeNs,
         interval);
+
+    // The following metrics measure the rate at which tuples are added to the outgoing
+    // queues at spouts and the sizes of these queues. This allows us to measure whether
+    // the gateway thread pulls out tuples from the queue fast enough, thereby preventing
+    // the spout from becoming a bottleneck.
     topologyContext.registerMetric("__data-tuple-added-to-outgoing-queue/default",
         tupleAddedToQueue, interval);
     topologyContext.registerMetric("__average-tuple-size-added-queue/default",

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/SpoutMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/SpoutMetrics.java
@@ -86,7 +86,8 @@ public class SpoutMetrics implements ComponentMetrics {
     topologyContext.registerMetric("__next-tuple-count", nextTupleCount, interval);
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
     topologyContext.registerMetric("__pending-acked-count", pendingTuplesCount, interval);
-    topologyContext.registerMetric("__data-tuple-added-to-outgoing-queue/default", tupleAddedToQueue, interval);
+    topologyContext.registerMetric("__data-tuple-added-to-outgoing-queue/default",
+        tupleAddedToQueue, interval);
   }
 
   // For MultiCountMetrics, we need to set the default value for all streams.
@@ -117,7 +118,7 @@ public class SpoutMetrics implements ComponentMetrics {
     emitCount.incr();
   }
 
-  public void addTupleToQueue() {
+  public void addTupleToQueue(int size) {
     tupleAddedToQueue.incr();
   }
 

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/SpoutMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/SpoutMetrics.java
@@ -86,7 +86,7 @@ public class SpoutMetrics implements ComponentMetrics {
     topologyContext.registerMetric("__next-tuple-count", nextTupleCount, interval);
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
     topologyContext.registerMetric("__pending-acked-count", pendingTuplesCount, interval);
-    topologyContext.registerMetric("__data_tuple-added-to-outgoing-queue/default", tupleAddedToQueue, interval);
+    topologyContext.registerMetric("__data-tuple-added-to-outgoing-queue/default", tupleAddedToQueue, interval);
   }
 
   // For MultiCountMetrics, we need to set the default value for all streams.

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/SpoutMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/SpoutMetrics.java
@@ -47,6 +47,7 @@ public class SpoutMetrics implements ComponentMetrics {
   private final CountMetric emitCount;
   private final ReducedMetric<MeanReducerState, Number, Double> nextTupleLatency;
   private final CountMetric nextTupleCount;
+  private final CountMetric tupleAddedToQueue;
 
   // The # of times back-pressure happens on outStreamQueue so instance could not
   // produce more tuples
@@ -66,6 +67,7 @@ public class SpoutMetrics implements ComponentMetrics {
     nextTupleCount = new CountMetric();
     outQueueFullCount = new CountMetric();
     pendingTuplesCount = new ReducedMetric<>(new MeanReducer());
+    tupleAddedToQueue = new CountMetric();
   }
 
   public void registerMetrics(TopologyContextImpl topologyContext) {
@@ -84,6 +86,7 @@ public class SpoutMetrics implements ComponentMetrics {
     topologyContext.registerMetric("__next-tuple-count", nextTupleCount, interval);
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
     topologyContext.registerMetric("__pending-acked-count", pendingTuplesCount, interval);
+    topologyContext.registerMetric("__data_tuple-added-to-outgoing-queue/default", tupleAddedToQueue, interval);
   }
 
   // For MultiCountMetrics, we need to set the default value for all streams.
@@ -112,6 +115,10 @@ public class SpoutMetrics implements ComponentMetrics {
 
   public void emittedTuple(String streamId) {
     emitCount.incr();
+  }
+
+  public void addTupleToQueue() {
+    tupleAddedToQueue.incr();
   }
 
   public void nextTuple(long latency) {

--- a/heron/instance/src/java/org/apache/heron/instance/AbstractOutputCollector.java
+++ b/heron/instance/src/java/org/apache/heron/instance/AbstractOutputCollector.java
@@ -81,7 +81,7 @@ public class AbstractOutputCollector {
       }
     }
 
-    this.outputter = new OutgoingTupleCollection(helper, streamOutQueue, lock);
+    this.outputter = new OutgoingTupleCollection(helper, streamOutQueue, lock, metrics);
   }
 
   public void updatePhysicalPlanHelper(PhysicalPlanHelper physicalPlanHelper) {

--- a/heron/instance/src/java/org/apache/heron/instance/OutgoingTupleCollection.java
+++ b/heron/instance/src/java/org/apache/heron/instance/OutgoingTupleCollection.java
@@ -35,6 +35,7 @@ import org.apache.heron.common.basics.Communicator;
 import org.apache.heron.common.basics.FileUtils;
 import org.apache.heron.common.basics.SingletonRegistry;
 import org.apache.heron.common.config.SystemConfig;
+import org.apache.heron.common.utils.metrics.ComponentMetrics;
 import org.apache.heron.common.utils.misc.PhysicalPlanHelper;
 import org.apache.heron.common.utils.misc.SerializeDeSerializeHelper;
 import org.apache.heron.proto.ckptmgr.CheckpointManager;
@@ -71,12 +72,16 @@ public class OutgoingTupleCollection {
 
   private final ReentrantLock lock;
 
+  protected final ComponentMetrics metrics;
+
   public OutgoingTupleCollection(
       PhysicalPlanHelper helper,
       Communicator<Message> outQueue,
-      ReentrantLock lock) {
+      ReentrantLock lock,
+      ComponentMetrics metrics) {
     this.outQueue = outQueue;
     this.helper = helper;
+    this.metrics = metrics;
     SystemConfig systemConfig =
         (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(SystemConfig.HERON_SYSTEM_CONFIG);
 
@@ -238,6 +243,7 @@ public class OutgoingTupleCollection {
       bldr.setData(currentDataTuple);
 
       pushTupleToQueue(bldr, outQueue);
+      metrics.addTupleToQueue();
 
       currentDataTuple = null;
     }

--- a/heron/instance/src/java/org/apache/heron/instance/OutgoingTupleCollection.java
+++ b/heron/instance/src/java/org/apache/heron/instance/OutgoingTupleCollection.java
@@ -243,7 +243,8 @@ public class OutgoingTupleCollection {
       bldr.setData(currentDataTuple);
 
       pushTupleToQueue(bldr, outQueue);
-      metrics.addTupleToQueue();
+      //TODO: fix hack
+      metrics.addTupleToQueue(currentDataTuple.getTuplesCount());
 
       currentDataTuple = null;
     }

--- a/heron/instance/src/java/org/apache/heron/instance/OutgoingTupleCollection.java
+++ b/heron/instance/src/java/org/apache/heron/instance/OutgoingTupleCollection.java
@@ -243,7 +243,6 @@ public class OutgoingTupleCollection {
       bldr.setData(currentDataTuple);
 
       pushTupleToQueue(bldr, outQueue);
-      //TODO: fix hack
       metrics.addTupleToQueue(currentDataTuple.getTuplesCount());
 
       currentDataTuple = null;

--- a/heron/instance/src/java/org/apache/heron/metrics/GatewayMetrics.java
+++ b/heron/instance/src/java/org/apache/heron/metrics/GatewayMetrics.java
@@ -46,6 +46,7 @@ public class GatewayMetrics {
   private final CountMetric sentMetricsSize;
   private final CountMetric sentMetricsCount;
   private final CountMetric sentExceptionsCount;
+  private final CountMetric outStreamQueueSizeCumulative;
 
   // The # of items in inStreamQueue
   private final ReducedMetric<MeanReducerState, Number, Double> inStreamQueueSize;
@@ -77,6 +78,7 @@ public class GatewayMetrics {
     outStreamQueueExpectedCapacity = new ReducedMetric<>(new MeanReducer());
 
     inQueueFullCount = new CountMetric();
+    outStreamQueueSizeCumulative = new CountMetric();
   }
 
   /**
@@ -122,6 +124,9 @@ public class GatewayMetrics {
     metricsCollector.registerMetric("__gateway-out-stream-queue-size",
         outStreamQueueSize,
         interval);
+    metricsCollector.registerMetric("__gateway-out-stream-queue-size-cumulative",
+        outStreamQueueSizeCumulative,
+        interval);
     metricsCollector.registerMetric("__gateway-in-stream-queue-expected-capacity",
         inStreamQueueExpectedCapacity,
         interval);
@@ -165,6 +170,7 @@ public class GatewayMetrics {
   }
 
   public void setOutStreamQueueSize(long size) {
+    outStreamQueueSizeCumulative.incrBy(size);
     outStreamQueueSize.update(size);
   }
 

--- a/heron/instance/src/java/org/apache/heron/metrics/GatewayMetrics.java
+++ b/heron/instance/src/java/org/apache/heron/metrics/GatewayMetrics.java
@@ -46,8 +46,6 @@ public class GatewayMetrics {
   private final CountMetric sentMetricsSize;
   private final CountMetric sentMetricsCount;
   private final CountMetric sentExceptionsCount;
-  private final CountMetric outStreamQueueSizeCumulative;
-
   // The # of items in inStreamQueue
   private final ReducedMetric<MeanReducerState, Number, Double> inStreamQueueSize;
   // The # of items in outStreamQueue
@@ -78,7 +76,6 @@ public class GatewayMetrics {
     outStreamQueueExpectedCapacity = new ReducedMetric<>(new MeanReducer());
 
     inQueueFullCount = new CountMetric();
-    outStreamQueueSizeCumulative = new CountMetric();
   }
 
   /**
@@ -124,9 +121,6 @@ public class GatewayMetrics {
     metricsCollector.registerMetric("__gateway-out-stream-queue-size",
         outStreamQueueSize,
         interval);
-    metricsCollector.registerMetric("__gateway-out-stream-queue-size-cumulative",
-        outStreamQueueSizeCumulative,
-        interval);
     metricsCollector.registerMetric("__gateway-in-stream-queue-expected-capacity",
         inStreamQueueExpectedCapacity,
         interval);
@@ -170,7 +164,6 @@ public class GatewayMetrics {
   }
 
   public void setOutStreamQueueSize(long size) {
-    outStreamQueueSizeCumulative.incrBy(size);
     outStreamQueueSize.update(size);
   }
 


### PR DESCRIPTION
This pull request includes metrics added that measure the rate at which tuples are added to the outgoing queues at spouts and the sizes of these queues. This allows us to measure whether the gateway thread pulls out tuples from the queue fast enough, thereby preventing the spout from becoming a bottleneck.