### PR TITLE
get back newParallelism ifelse branch

### DIFF
--- a/heron/scheduler-core/src/java/org/apache/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/org/apache/heron/scheduler/RuntimeManagerRunner.java
@@ -195,11 +195,11 @@ public class RuntimeManagerRunner {
       throws TopologyRuntimeManagementException, PackingException, UpdateDryRunResponse {
     assert !potentialStaleExecutionData;
     String newParallelism = updateConfig.getStringValue(RUNTIME_MANAGER_COMPONENT_PARALLELISM_KEY);
-    LOG.info("newParallelism " + newParallelism);
     String newContainerNumber = updateConfig.getStringValue(RUNTIME_MANAGER_CONTAINER_NUMBER_KEY);
-    LOG.info("newContainerNumber " + newContainerNumber);
     String userRuntimeConfig = updateConfig.getStringValue(RUNTIME_MANAGER_RUNTIME_CONFIG_KEY);
-    LOG.info("userRuntimeConfig " + userRuntimeConfig);
+    LOG.info("userRuntimeConfig " + userRuntimeConfig
+        + "; newParallelism " + newParallelism
+        + "; newContainerNumber " + newContainerNumber);
 
     // parallelism and runtime config can not be updated at the same time.
     if (((newParallelism != null && !newParallelism.isEmpty())

--- a/heron/scheduler-core/src/java/org/apache/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/org/apache/heron/scheduler/RuntimeManagerRunner.java
@@ -264,9 +264,10 @@ public class RuntimeManagerRunner {
       throws TopologyRuntimeManagementException, PackingException, UpdateDryRunResponse {
     LOG.fine(String.format("updateTopologyHandler called for %s with %s",
         topologyName, newParallelism));
+    Map<String, Integer> changeRequests = parseNewParallelismParam(newParallelism);
+
     SchedulerStateManagerAdaptor manager = Runtime.schedulerStateManagerAdaptor(runtime);
     TopologyAPI.Topology topology = manager.getTopology(topologyName);
-    Map<String, Integer> changeRequests = parseNewParallelismParam(newParallelism);
     PackingPlans.PackingPlan currentPlan = manager.getPackingPlan(topologyName);
 
     if (!parallelismChangeDetected(currentPlan, changeRequests)) {
@@ -297,10 +298,9 @@ public class RuntimeManagerRunner {
     SchedulerStateManagerAdaptor manager = Runtime.schedulerStateManagerAdaptor(runtime);
     TopologyAPI.Topology topology = manager.getTopology(topologyName);
     PackingPlans.PackingPlan currentPlan = manager.getPackingPlan(topologyName);
-    boolean parallelismChange = parallelismChangeDetected(currentPlan, changeRequests);
-    boolean containerChange = containersNumChangeDetected(currentPlan, containerNum);
 
-    if (!parallelismChange && !containerChange) {
+    if (!containersNumChangeDetected(currentPlan, containerNum)
+        && !parallelismChangeDetected(currentPlan, changeRequests)) {
       throw new TopologyRuntimeManagementException(
           String.format("Both component parallelism request and container number are the "
               + "same as in the running topology."));

--- a/heron/scheduler-core/src/java/org/apache/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/org/apache/heron/scheduler/RuntimeManagerRunner.java
@@ -195,8 +195,11 @@ public class RuntimeManagerRunner {
       throws TopologyRuntimeManagementException, PackingException, UpdateDryRunResponse {
     assert !potentialStaleExecutionData;
     String newParallelism = updateConfig.getStringValue(RUNTIME_MANAGER_COMPONENT_PARALLELISM_KEY);
+    LOG.info("newParallelism " + newParallelism);
     String newContainerNumber = updateConfig.getStringValue(RUNTIME_MANAGER_CONTAINER_NUMBER_KEY);
+    LOG.info("newContainerNumber " + newContainerNumber);
     String userRuntimeConfig = updateConfig.getStringValue(RUNTIME_MANAGER_RUNTIME_CONFIG_KEY);
+    LOG.info("userRuntimeConfig " + userRuntimeConfig);
 
     // parallelism and runtime config can not be updated at the same time.
     if (((newParallelism != null && !newParallelism.isEmpty())
@@ -209,19 +212,16 @@ public class RuntimeManagerRunner {
     if (userRuntimeConfig != null && !userRuntimeConfig.isEmpty()) {
       // Update user runtime config if userRuntimeConfig parameter is available
       updateTopologyUserRuntimeConfig(topologyName, userRuntimeConfig);
-    } else if ((newParallelism != null && !newParallelism.isEmpty())
-        || (newContainerNumber != null && !newContainerNumber.isEmpty())) {
-      int newContainers = getCurrentContainerNumber(topologyName);
+    } else if (newContainerNumber != null && !newContainerNumber.isEmpty()) {
+      int newContainers = Integer.parseInt(newContainerNumber);
       Map<String, Integer> changeRequests = new HashMap<String, Integer>();
-
       if (newParallelism != null && !newParallelism.isEmpty()) {
         changeRequests = parseNewParallelismParam(newParallelism);
       }
-      if (newContainerNumber != null && !newContainerNumber.isEmpty()) {
-        newContainers = Integer.parseInt(newContainerNumber);
-      }
       updatePackingPlan(topologyName, newContainers, changeRequests);
-
+    } else if (newParallelism != null && !newParallelism.isEmpty()) {
+      // Update parallelism if newParallelism parameter is available
+      updateTopologyComponentParallelism(topologyName, newParallelism);
     } else {
       throw new TopologyRuntimeManagementException("Missing arguments. Not taking action.");
     }
@@ -237,6 +237,46 @@ public class RuntimeManagerRunner {
     return cPlan.getContainers().size();
   }
 
+  @VisibleForTesting
+  void updateTopologyComponentParallelism(String topologyName, String  newParallelism)
+      throws TopologyRuntimeManagementException, PackingException, UpdateDryRunResponse {
+    LOG.fine(String.format("updateTopologyHandler called for %s with %s",
+        topologyName, newParallelism));
+    SchedulerStateManagerAdaptor manager = Runtime.schedulerStateManagerAdaptor(runtime);
+    TopologyAPI.Topology topology = manager.getTopology(topologyName);
+    Map<String, Integer> changeRequests = parseNewParallelismParam(newParallelism);
+    PackingPlans.PackingPlan currentPlan = manager.getPackingPlan(topologyName);
+
+    if (!changeDetected(currentPlan, changeRequests)) {
+      throw new TopologyRuntimeManagementException(
+          String.format("The component parallelism request (%s) is the same as the "
+              + "current topology parallelism. Not taking action.", newParallelism));
+    }
+
+    PackingPlans.PackingPlan proposedPlan = buildNewPackingPlan(currentPlan, changeRequests,
+        topology);
+
+    if (Context.dryRun(config)) {
+      PackingPlanProtoDeserializer deserializer = new PackingPlanProtoDeserializer();
+      PackingPlan oldPlan = deserializer.fromProto(currentPlan);
+      PackingPlan newPlan = deserializer.fromProto(proposedPlan);
+      throw new UpdateDryRunResponse(topology, config, newPlan, oldPlan, changeRequests);
+    }
+
+    Scheduler.UpdateTopologyRequest updateTopologyRequest =
+        Scheduler.UpdateTopologyRequest.newBuilder()
+            .setCurrentPackingPlan(currentPlan)
+            .setProposedPackingPlan(proposedPlan)
+            .build();
+
+    LOG.fine("Sending Updating topology request: " + updateTopologyRequest);
+    if (!schedulerClient.updateTopology(updateTopologyRequest)) {
+      throw new TopologyRuntimeManagementException(
+          "Failed to update topology with Scheduler, updateTopologyRequest="
+              + updateTopologyRequest + "The topology can be in a strange stage. "
+              + "Please check carefully or redeploy the topology !!");
+    }
+  }
 
   @VisibleForTesting
   void updatePackingPlan(String topologyName,
@@ -368,6 +408,39 @@ public class RuntimeManagerRunner {
   @VisibleForTesting
   PackingPlans.PackingPlan buildNewPackingPlan(PackingPlans.PackingPlan currentProtoPlan,
                                                Map<String, Integer> changeRequests,
+                                               TopologyAPI.Topology topology)
+      throws PackingException {
+    PackingPlanProtoDeserializer deserializer = new PackingPlanProtoDeserializer();
+    PackingPlanProtoSerializer serializer = new PackingPlanProtoSerializer();
+    PackingPlan currentPackingPlan = deserializer.fromProto(currentProtoPlan);
+
+    Map<String, Integer> componentCounts = currentPackingPlan.getComponentCounts();
+    Map<String, Integer> componentChanges = parallelismDelta(componentCounts, changeRequests);
+
+    // Create an instance of the packing class
+    String repackingClass = Context.repackingClass(config);
+    IRepacking packing;
+    try {
+      // create an instance of the packing class
+      packing = ReflectionUtils.newInstance(repackingClass);
+    } catch (IllegalAccessException | InstantiationException | ClassNotFoundException e) {
+      throw new IllegalArgumentException(
+          "Failed to instantiate packing instance: " + repackingClass, e);
+    }
+
+    LOG.info("Updating packing plan using " + repackingClass);
+    try {
+      packing.initialize(config, topology);
+      PackingPlan packedPlan = packing.repack(currentPackingPlan, componentChanges);
+      return serializer.toProto(packedPlan);
+    } finally {
+      SysUtils.closeIgnoringExceptions(packing);
+    }
+  }
+
+  @VisibleForTesting
+  PackingPlans.PackingPlan buildNewPackingPlan(PackingPlans.PackingPlan currentProtoPlan,
+                                               Map<String, Integer> changeRequests,
                                                int containerNum,
                                                TopologyAPI.Topology topology)
       throws PackingException {
@@ -469,6 +542,18 @@ public class RuntimeManagerRunner {
 
   private static boolean parallelismChangeDetected(PackingPlans.PackingPlan currentProtoPlan,
                                                    Map<String, Integer> changeRequests) {
+    PackingPlanProtoDeserializer deserializer = new PackingPlanProtoDeserializer();
+    PackingPlan currentPlan = deserializer.fromProto(currentProtoPlan);
+    for (String component : changeRequests.keySet()) {
+      if (changeRequests.get(component) != currentPlan.getComponentCounts().get(component)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean changeDetected(PackingPlans.PackingPlan currentProtoPlan,
+                                        Map<String, Integer> changeRequests) {
     PackingPlanProtoDeserializer deserializer = new PackingPlanProtoDeserializer();
     PackingPlan currentPlan = deserializer.fromProto(currentProtoPlan);
     for (String component : changeRequests.keySet()) {

--- a/heron/scheduler-core/tests/java/org/apache/heron/scheduler/RuntimeManagerRunnerTest.java
+++ b/heron/scheduler-core/tests/java/org/apache/heron/scheduler/RuntimeManagerRunnerTest.java
@@ -236,7 +236,7 @@ public class RuntimeManagerRunnerTest {
 
     when(manager.getPackingPlan(eq(TOPOLOGY_NAME))).thenReturn(currentPlan);
     doReturn(proposedPlan).when(runner).buildNewPackingPlan(
-        eq(currentPlan), eq(changeRequests), 1, any(TopologyAPI.Topology.class));
+        eq(currentPlan), eq(changeRequests), any(TopologyAPI.Topology.class));
 
     Scheduler.UpdateTopologyRequest updateTopologyRequest =
         Scheduler.UpdateTopologyRequest.newBuilder()
@@ -246,7 +246,7 @@ public class RuntimeManagerRunnerTest {
 
     when(client.updateTopology(updateTopologyRequest)).thenReturn(true);
     try {
-      runner.updatePackingPlan(TOPOLOGY_NAME, 1, changeRequests);
+      runner.updateTopologyComponentParallelism(TOPOLOGY_NAME, newParallelism);
     } finally {
       int expectedClientUpdateCalls = expectedResult ? 1 : 0;
       verify(client, times(expectedClientUpdateCalls)).updateTopology(updateTopologyRequest);


### PR DESCRIPTION
In #2980, `updateTopologyHandler()`, if-else branch `newParallelism` was changed to cover both `newParallelism` and `newContainerNumber`, which failed several unit tests.
This PR gets `newParallelism` back, and puts `newContainerNumber` as the 3rd if-else branch.