### PR TITLE
Nwang/make spout/bolt compatible to storm 1.x

### DIFF
--- a/eco-storm-examples/src/java/org/apache/heron/examples/eco/TestFibonacciSpout.java
+++ b/eco-storm-examples/src/java/org/apache/heron/examples/eco/TestFibonacciSpout.java
@@ -42,7 +42,7 @@ public class TestFibonacciSpout extends BaseRichSpout {
   }
 
   @Override
-  public void open(Map<String, Object> conf, TopologyContext context,
+  public void open(Map conf, TopologyContext context,
                    SpoutOutputCollector collector) {
     this.collector = collector;
   }

--- a/eco-storm-examples/src/java/org/apache/heron/examples/eco/TestNameSpout.java
+++ b/eco-storm-examples/src/java/org/apache/heron/examples/eco/TestNameSpout.java
@@ -45,7 +45,7 @@ public class TestNameSpout extends BaseRichSpout {
     isdistributed = isDistributed;
   }
 
-  public void open(Map<String, Object> conf, TopologyContext context,
+  public void open(Map conf, TopologyContext context,
                    SpoutOutputCollector collector) {
     this.collector = collector;
   }

--- a/eco-storm-examples/src/java/org/apache/heron/examples/eco/TestWindowBolt.java
+++ b/eco-storm-examples/src/java/org/apache/heron/examples/eco/TestWindowBolt.java
@@ -35,7 +35,7 @@ public class TestWindowBolt extends BaseWindowedBolt {
 
 
   @Override
-  public void prepare(Map<String, Object> topoConf, TopologyContext context,
+  public void prepare(Map topoConf, TopologyContext context,
                       OutputCollector collector) {
     this.collector = collector;
   }

--- a/storm-compatibility-examples/src/java/org/apache/storm/examples/SlidingWindowTopology.java
+++ b/storm-compatibility-examples/src/java/org/apache/storm/examples/SlidingWindowTopology.java
@@ -57,7 +57,7 @@ public final class SlidingWindowTopology {
 
     @Override
     @SuppressWarnings("HiddenField")
-    public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector
+    public void prepare(Map topoConf, TopologyContext context, OutputCollector
         collector) {
       this.collector = collector;
     }

--- a/storm-compatibility-examples/src/java/org/apache/storm/examples/bolt/SlidingWindowSumBolt.java
+++ b/storm-compatibility-examples/src/java/org/apache/storm/examples/bolt/SlidingWindowSumBolt.java
@@ -44,7 +44,7 @@ public class SlidingWindowSumBolt extends BaseWindowedBolt {
 
   @Override
   @SuppressWarnings("HiddenField")
-  public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector
+  public void prepare(Map topoConf, TopologyContext context, OutputCollector
       collector) {
     this.collector = collector;
   }

--- a/storm-compatibility-examples/src/java/org/apache/storm/examples/spout/RandomIntegerSpout.java
+++ b/storm-compatibility-examples/src/java/org/apache/storm/examples/spout/RandomIntegerSpout.java
@@ -48,7 +48,7 @@ public class RandomIntegerSpout extends BaseRichSpout {
 
   @Override
   @SuppressWarnings("HiddenField")
-  public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector
+  public void open(Map conf, TopologyContext context, SpoutOutputCollector
       collector) {
     this.collector = collector;
     this.rand = new Random();

--- a/storm-compatibility/src/java/org/apache/storm/metric/api/IMetricsConsumer.java
+++ b/storm-compatibility/src/java/org/apache/storm/metric/api/IMetricsConsumer.java
@@ -89,7 +89,7 @@ public interface IMetricsConsumer {
   }
 
   @SuppressWarnings("rawtypes")
-  void prepare(Map<String, Object> stormConf, Object registrationArgument,
+  void prepare(Map stormConf, Object registrationArgument,
                TopologyContext context, IErrorReporter errorReporter);
 
   void handleDataPoints(TaskInfo taskInfo, Collection<DataPoint> dataPoints);

--- a/storm-compatibility/src/java/org/apache/storm/spout/ISpout.java
+++ b/storm-compatibility/src/java/org/apache/storm/spout/ISpout.java
@@ -57,7 +57,7 @@ public interface ISpout extends Serializable {
    * @param collector The collector is used to emit tuples from this spout. Tuples can be emitted at any time, including the open and close methods. The collector is thread-safe and should be saved as an instance variable of this spout object.
    */
   @SuppressWarnings("rawtypes")
-  void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector);
+  void open(Map conf, TopologyContext context, SpoutOutputCollector collector);
 
   /**
    * Called when an ISpout is going to be shutdown. There is no guarentee that close

--- a/storm-compatibility/src/java/org/apache/storm/topology/IRichSpoutDelegate.java
+++ b/storm-compatibility/src/java/org/apache/storm/topology/IRichSpoutDelegate.java
@@ -45,7 +45,7 @@ public class IRichSpoutDelegate implements org.apache.heron.api.spout.IRichSpout
 
   @Override
   @SuppressWarnings("rawtypes")
-  public void open(Map<String, Object> conf, org.apache.heron.api.topology.TopologyContext context,
+  public void open(Map conf, org.apache.heron.api.topology.TopologyContext context,
                    SpoutOutputCollector collector) {
     topologyContextImpl = new TopologyContext(context);
     spoutOutputCollectorImpl = new SpoutOutputCollectorImpl(collector);

--- a/storm-compatibility/src/java/org/apache/storm/topology/IWindowedBolt.java
+++ b/storm-compatibility/src/java/org/apache/storm/topology/IWindowedBolt.java
@@ -33,7 +33,7 @@ public interface IWindowedBolt extends IComponent {
    * {@link org.apache.storm.task.IBolt#prepare(Map, TopologyContext, OutputCollector)} except
    * that while emitting, the tuples are automatically anchored to the tuples in the inputWindow.
    */
-  void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector);
+  void prepare(Map topoConf, TopologyContext context, OutputCollector collector);
 
   /**
    * Process the tuple window and optionally emit new tuples based on the tuples in the input

--- a/storm-compatibility/src/java/org/apache/storm/topology/base/BaseWindowedBolt.java
+++ b/storm-compatibility/src/java/org/apache/storm/topology/base/BaseWindowedBolt.java
@@ -524,7 +524,7 @@ public abstract class BaseWindowedBolt implements IWindowedBolt {
   }
 
   @Override
-  public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector
+  public void prepare(Map topoConf, TopologyContext context, OutputCollector
       collector) {
     // NOOP
   }


### PR DESCRIPTION
Currently in storm-compatibility API, the spout and bolt interfaces and derived classes are following storm 2.0 API. The config parameter for open() and prepare() functions has type Map<String, Object>.

Heron was designed to be compatible with Storm in API layer. However, when heron was developed a  few years ago, storm was pre 1.0 (2016 April). Storm 1.x API didn't change much in API layer, but 2.0 is not compatible although the changes are small. In conclusion, it might be better to freeze the storm compatibility layer to be compatible with storm 1.x so that we don't need to change the layer time by time and breaks existing topologies. (Even if we want to be compatible with storm 2.0, it is better to support both until the heron core code is really complete.)

Furthermore, storm 2.0 is not released yet so far so the API might change in future (although not likely).