### PR TITLE
add flag to bypass integration test

### DIFF
--- a/scripts/travis/ci.sh
+++ b/scripts/travis/ci.sh
@@ -34,9 +34,13 @@ ${DIR}/check.sh
 #(cd website && make travis-site)
 #end_timer "$T"
 
-T="${DIR}/test.sh"
-start_timer "$T"
-${DIR}/test.sh
-end_timer "$T"
+if [ -z ${DISABLE_INTEGRATION_TESTS+x} ]; then
+  T="${DIR}/test.sh"
+  start_timer "$T"
+  ${DIR}/test.sh
+  end_timer "$T"
+else
+  echo "bypass integration tests"
+fi
 
 print_timer_summary


### PR DESCRIPTION
some developers have travis ci in their develop repo. however the current travis-ci costs longtime. this pr enables a flag to bypass integration test so that the developers can run basic unit test in their own travis ci. 

![screenshot 2018-08-21 13 54 33](https://user-images.githubusercontent.com/4208547/44428639-d46e6380-a549-11e8-8c46-5bfb37600804.png)
