### PR TITLE
Yaoli/fix stateful test

### DIFF
--- a/integration_test/src/python/http_server/main.py
+++ b/integration_test/src/python/http_server/main.py
@@ -22,7 +22,6 @@ import tornado.ioloop
 import tornado.escape
 import tornado.web
 
-from sets import Set
 from heron.common.src.python.utils import log
 
 RESULTS_DIRECTORY = "results"

--- a/integration_test/src/python/http_server/main.py
+++ b/integration_test/src/python/http_server/main.py
@@ -22,6 +22,7 @@ import tornado.ioloop
 import tornado.escape
 import tornado.web
 
+from sets import Set
 from heron.common.src.python.utils import log
 
 RESULTS_DIRECTORY = "results"
@@ -106,7 +107,12 @@ class StateResultHandler(tornado.web.RequestHandler):
     data = tornado.escape.json_decode(self.request.body)
     if key:
       if key in self.result_map:
-        self.result_map[key].append(data)
+        # fix the duplicate record issue
+        for comp in self.result_map[key]:
+          if comp.keys()[0] == data.keys()[0]:
+            break
+        else:
+          self.result_map[key].append(data)
       else:
         self.result_map[key] = [data]
       self.write("Results written successfully: topology " + key + ' instance ' + data.keys()[0])
@@ -128,11 +134,11 @@ def main():
   # for instance states in stateful processing
   state_result_map = {}
   application = tornado.web.Application([
-      (r"/", MainHandler),
-      (r"^/results/([a-zA-Z0-9_-]+$)", FileHandler),
-      (r"^/state", MemoryMapGetAllHandler, dict(state_map=state_map)),
-      (r"^/state/([a-zA-Z0-9_-]+$)", MemoryMapHandler, dict(state_map=state_map)),
-      (r"^/stateResults/([a-zA-Z0-9_-]+$)", StateResultHandler, dict(result_map=state_result_map)),
+    (r"/", MainHandler),
+    (r"^/results/([a-zA-Z0-9_-]+$)", FileHandler),
+    (r"^/state", MemoryMapGetAllHandler, dict(state_map=state_map)),
+    (r"^/state/([a-zA-Z0-9_-]+$)", MemoryMapHandler, dict(state_map=state_map)),
+    (r"^/stateResults/([a-zA-Z0-9_-]+$)", StateResultHandler, dict(result_map=state_result_map)),
   ])
 
   if len(sys.argv) == 1:


### PR DESCRIPTION
Observed duplicated instance state info at http server during stateful integration test, which causes test failure. The issue is fixed in this PR.