### PR TITLE
Fix RAM config in example code

### DIFF
--- a/examples/src/java/org/apache/heron/examples/api/ExampleResources.java
+++ b/examples/src/java/org/apache/heron/examples/api/ExampleResources.java
@@ -23,7 +23,7 @@ import org.apache.heron.common.basics.ByteAmount;
 
 public final class ExampleResources {
 
-  static final long COMPONENT_RAM_MB = 512;
+  static final long COMPONENT_RAM_MB = 1024;
 
   static ByteAmount getComponentRam() {
     return ByteAmount.fromMegabytes(COMPONENT_RAM_MB);

--- a/examples/src/java/org/apache/heron/examples/api/StatefulWordCountTopology.java
+++ b/examples/src/java/org/apache/heron/examples/api/StatefulWordCountTopology.java
@@ -205,9 +205,9 @@ public final class StatefulWordCountTopology {
 
     // configure component resources
     conf.setComponentRam("word",
-        ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB * 2));
+        ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB));
     conf.setComponentRam("consumer",
-        ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB * 2));
+        ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB));
 
     // configure container resources
     conf.setContainerDiskRequested(

--- a/examples/src/java/org/apache/heron/examples/api/WordCountTopology.java
+++ b/examples/src/java/org/apache/heron/examples/api/WordCountTopology.java
@@ -184,9 +184,9 @@ public final class WordCountTopology {
 
     // configure component resources
     conf.setComponentRam("word",
-        ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB * 2));
+        ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB));
     conf.setComponentRam("consumer",
-        ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB * 2));
+        ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB));
 
     // configure container resources
     conf.setContainerDiskRequested(


### PR DESCRIPTION
In the existing example code, the container ram size is calculated based on 512M component ram, but the real component ram size is 1G.