### PR TITLE
Update path and package name in docs/comments/tests

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -24,7 +24,7 @@
 ### To submit/activate/kill a topology:
 ```
 #To submit a topology:
-        docker exec heron_executor_1 heron submit local /usr/local/heron/examples/heron-examples.jar org.apache.heron.examples.ExclamationTopology ExclamationTopology --deploy-deactivated
+        docker exec heron_executor_1 heron submit local /usr/local/heron/examples/heron-api-examples.jar org.apache.heron.examples.api.ExclamationTopology ExclamationTopology --deploy-deactivated
 #To activate a topology:
         docker exec -it heron_executor_1 heron activate local ExclamationTopology
 #To kill a topology:

--- a/heron/metricscachemgr/src/java/org/apache/heron/metricscachemgr/MetricsCacheManagerHttpServer.java
+++ b/heron/metricscachemgr/src/java/org/apache/heron/metricscachemgr/MetricsCacheManagerHttpServer.java
@@ -82,8 +82,8 @@ public class MetricsCacheManagerHttpServer {
    * &lt;host:port&gt; &lt;component_name&gt; &lt;metrics_name&gt;
    * Example:
    * 1. run the example topology,
-   * ~/bin/heron submit local ~/.heron/examples/heron-examples.jar \
-   * org.apache.heron.examples.ExclamationTopology ExclamationTopology \
+   * ~/bin/heron submit local ~/.heron/examples/heron-api-examples.jar \
+   * org.apache.heron.examples.api.ExclamationTopology ExclamationTopology \
    * --deploy-deactivated --verbose
    * 2. in the [source root directory],
    * bazel run heron/metricscachemgr/src/java:metricscache-queryclient-unshaded -- \

--- a/heron/tools/cli/tests/python/client_command_unittest.py
+++ b/heron/tools/cli/tests/python/client_command_unittest.py
@@ -78,12 +78,12 @@ class SubmitTest(ClientCommandTest):
   def test(self):
     subprocess.Popen = MagicMock()
 
-    command = 'heron submit local ~/.heron/examples/heron-examples.jar ' + \
-              'org.apache.heron.examples.ExclamationTopology EX'
+    command = 'heron submit local ~/.heron/examples/heron-api-examples.jar ' + \
+              'org.apache.heron.examples.api.ExclamationTopology EX'
 
     create_defn_commands = '/usr/lib/bin/java -client -Xmx1g -cp ' \
-    '~/.heron/examples/heron-examples.jar:/heron/lib/jars/third_party/* ' \
-    'org.apache.heron.examples.ExclamationTopology EX'
+    '~/.heron/examples/heron-api-examples.jar:/heron/lib/jars/third_party/* ' \
+    'org.apache.heron.examples.api.ExclamationTopology EX'
 
     submit_commands = '/usr/lib/bin/java -client -Xmx1g -cp ' \
                       ':/heron/lib/jars/scheduler/*:/heron/lib/jars/uploader/*:' \

--- a/website/content/docs/migrate-storm-to-heron.md
+++ b/website/content/docs/migrate-storm-to-heron.md
@@ -95,8 +95,8 @@ Start Guide](../getting-started) guide:
 
 ```bash
 $ heron submit local \
-  ~/.heron/examples/heron-examples.jar \ # The path of the topology's jar file
-  org.apache.heron.examples.ExclamationTopology \ # The topology's Java class
+  ~/.heron/examples/heron-api-examples.jar \ # The path of the topology's jar file
+  org.apache.heron.examples.api.ExclamationTopology \ # The topology's Java class
   ExclamationTopology # The name of the topology
 ```
 

--- a/website/content/docs/operators/deployment/schedulers/aurora-local-setup.md
+++ b/website/content/docs/operators/deployment/schedulers/aurora-local-setup.md
@@ -231,7 +231,7 @@ $ mv aurora devcluster
 Now you can submit a topology to the aurora cluster. this can be done with the following command.
 
 ```bash
-$ heron submit devcluster/heronuser/devel --config-path ~/.heron/conf/ ~/.heron/examples/heron-examples.jar org.apache.heron.examples.ExclamationTopology ExclamationTopology
+$ heron submit devcluster/heronuser/devel --config-path ~/.heron/conf/ ~/.heron/examples/heron-api-examples.jar org.apache.heron.examples.api.ExclamationTopology ExclamationTopology
 ```
 
 Now you should be able to see the topology in the Aurora UI ( http://192.168.33.7:8081/scheduler/heronuser ) .

--- a/website/content/docs/operators/deployment/schedulers/mesos-local-mac.md
+++ b/website/content/docs/operators/deployment/schedulers/mesos-local-mac.md
@@ -40,8 +40,8 @@ command loads the config in `$HOME/.heron/conf`. Add `--config-path=your_conf_pa
 config path.
 
 ```bash
-heron submit mesos --verbose ~/.heron/examples/heron-examples.jar \
-org.apache.heron.examples.ExclamationTopology ExclamationTopology
+heron submit mesos --verbose ~/.heron/examples/heron-api-examples.jar \
+org.apache.heron.examples.api.ExclamationTopology ExclamationTopology
 ```
 
 The following will be displayed upon a successful submit.

--- a/website/content/docs/operators/deployment/schedulers/yarn.md
+++ b/website/content/docs/operators/deployment/schedulers/yarn.md
@@ -75,12 +75,12 @@ deployment on a multi-node YARN cluster.
 
 **Under 0.14.2 version (including 0.14.2)**
 
-`$ heron submit yarn heron-examples.jar org.apache.heron.examples.AckingTopology AckingTopology`
+`$ heron submit yarn heron-api-examples.jar org.apache.heron.examples.api.AckingTopology AckingTopology`
 
 
 **After 0.14.3 version released**
 
-`$ heron submit yarn heron-examples.jar org.apache.heron.examples.AckingTopology AckingTopology --extra-launch-classpath <extra-classpath-value>`
+`$ heron submit yarn heron-api-examples.jar org.apache.heron.examples.api.AckingTopology AckingTopology --extra-launch-classpath <extra-classpath-value>`
 
 >**Tips**
 >


### PR DESCRIPTION
Some paths and package names are outdated, in documents, comments and tests.

For example:
/usr/local/heron/examples/heron-examples.jar  => /usr/local/heron/examples/heron-api-examples.jar
org.apache.heron.examples.ExclamationTopology => org.apache.heron.examples.api.ExclamationTopology