### PR TITLE
revert heron_excutor.py -  delete unnecessary logs

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -812,9 +812,6 @@ class HeronExecutor(object):
       if container_plan.id == container_id:
         this_container_plan = container_plan
 
-    Log.info("container_id = ")
-    Log.info(container_id)
-    Log.info(packing_plan)
     # make sure that our shard id is a valid one
     assert this_container_plan is not None
     return this_container_plan.instance_plans


### PR DESCRIPTION
We added three logs in heron_executor.py and merge them into master for ci tests. The logs are deleted in this PR, and this file is reverted to the original one.