### PR TITLE
use RoundRobinPacking algorithm by default

### DIFF
--- a/heron/config/src/yaml/conf/aurora/packing.yaml
+++ b/heron/config/src/yaml/conf/aurora/packing.yaml
@@ -17,4 +17,4 @@
 
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
-heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.RoundRobinPacking

--- a/heron/config/src/yaml/conf/aurora/packing.yaml
+++ b/heron/config/src/yaml/conf/aurora/packing.yaml
@@ -16,5 +16,5 @@
 #  under the License.
 
 # packing algorithm for packing instances into containers
-heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
 heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking

--- a/heron/config/src/yaml/conf/kubernetes/packing.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/packing.yaml
@@ -17,4 +17,4 @@
 
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
-heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.RoundRobinPacking

--- a/heron/config/src/yaml/conf/kubernetes/packing.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/packing.yaml
@@ -16,5 +16,5 @@
 #  under the License.
 
 # packing algorithm for packing instances into containers
-heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
 heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking

--- a/heron/config/src/yaml/conf/local/packing.yaml
+++ b/heron/config/src/yaml/conf/local/packing.yaml
@@ -17,4 +17,4 @@
 
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
-heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.RoundRobinPacking

--- a/heron/config/src/yaml/conf/local/packing.yaml
+++ b/heron/config/src/yaml/conf/local/packing.yaml
@@ -16,5 +16,5 @@
 #  under the License.
 
 # packing algorithm for packing instances into containers
-heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
 heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking

--- a/heron/config/src/yaml/conf/localzk/packing.yaml
+++ b/heron/config/src/yaml/conf/localzk/packing.yaml
@@ -17,4 +17,4 @@
 
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
-heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.RoundRobinPacking

--- a/heron/config/src/yaml/conf/localzk/packing.yaml
+++ b/heron/config/src/yaml/conf/localzk/packing.yaml
@@ -16,5 +16,5 @@
 #  under the License.
 
 # packing algorithm for packing instances into containers
-heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
 heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking

--- a/heron/config/src/yaml/conf/marathon/packing.yaml
+++ b/heron/config/src/yaml/conf/marathon/packing.yaml
@@ -17,4 +17,4 @@
 
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
-heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.RoundRobinPacking

--- a/heron/config/src/yaml/conf/marathon/packing.yaml
+++ b/heron/config/src/yaml/conf/marathon/packing.yaml
@@ -16,5 +16,5 @@
 #  under the License.
 
 # packing algorithm for packing instances into containers
-heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
 heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking

--- a/heron/config/src/yaml/conf/mesos/packing.yaml
+++ b/heron/config/src/yaml/conf/mesos/packing.yaml
@@ -17,4 +17,4 @@
 
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
-heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.RoundRobinPacking

--- a/heron/config/src/yaml/conf/mesos/packing.yaml
+++ b/heron/config/src/yaml/conf/mesos/packing.yaml
@@ -16,5 +16,5 @@
 #  under the License.
 
 # packing algorithm for packing instances into containers
-heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
 heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking

--- a/heron/config/src/yaml/conf/nomad/packing.yaml
+++ b/heron/config/src/yaml/conf/nomad/packing.yaml
@@ -17,4 +17,4 @@
 
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
-heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.RoundRobinPacking

--- a/heron/config/src/yaml/conf/nomad/packing.yaml
+++ b/heron/config/src/yaml/conf/nomad/packing.yaml
@@ -16,5 +16,5 @@
 #  under the License.
 
 # packing algorithm for packing instances into containers
-heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
 heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking

--- a/heron/config/src/yaml/conf/sandbox/packing.yaml
+++ b/heron/config/src/yaml/conf/sandbox/packing.yaml
@@ -17,4 +17,4 @@
 
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
-heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.RoundRobinPacking

--- a/heron/config/src/yaml/conf/sandbox/packing.yaml
+++ b/heron/config/src/yaml/conf/sandbox/packing.yaml
@@ -16,5 +16,5 @@
 #  under the License.
 
 # packing algorithm for packing instances into containers
-heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
 heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking

--- a/heron/config/src/yaml/conf/slurm/packing.yaml
+++ b/heron/config/src/yaml/conf/slurm/packing.yaml
@@ -17,4 +17,4 @@
 
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
-heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.RoundRobinPacking

--- a/heron/config/src/yaml/conf/slurm/packing.yaml
+++ b/heron/config/src/yaml/conf/slurm/packing.yaml
@@ -16,5 +16,5 @@
 #  under the License.
 
 # packing algorithm for packing instances into containers
-heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
 heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking

--- a/heron/config/src/yaml/conf/standalone/packing.yaml
+++ b/heron/config/src/yaml/conf/standalone/packing.yaml
@@ -17,4 +17,4 @@
 
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
-heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.RoundRobinPacking

--- a/heron/config/src/yaml/conf/standalone/packing.yaml
+++ b/heron/config/src/yaml/conf/standalone/packing.yaml
@@ -16,5 +16,5 @@
 #  under the License.
 
 # packing algorithm for packing instances into containers
-heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
 heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking

--- a/heron/config/src/yaml/conf/yarn/packing.yaml
+++ b/heron/config/src/yaml/conf/yarn/packing.yaml
@@ -17,4 +17,4 @@
 
 # packing algorithm for packing instances into containers
 heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
-heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.RoundRobinPacking

--- a/heron/config/src/yaml/conf/yarn/packing.yaml
+++ b/heron/config/src/yaml/conf/yarn/packing.yaml
@@ -16,5 +16,5 @@
 #  under the License.
 
 # packing algorithm for packing instances into containers
-heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
+heron.class.packing.algorithm:    org.apache.heron.packing.roundrobin.RoundRobinPacking
 heron.class.repacking.algorithm:  org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking


### PR DESCRIPTION
As discussed in today's sync-up meeting, we decide to make the RoundRobinPacking algorithm as the default one.

This can avoid the submission failure problem when using the ResourceCompiliantRRPacking algorithm.

In long-term, there'll be fixes to the ResourceCompiliantRRPacking algorithm.