### PR TITLE
[healthmgr unit tests]fix code style

### DIFF
--- a/heron/healthmgr/tests/java/org/apache/heron/healthmgr/HealthManagerTest.java
+++ b/heron/healthmgr/tests/java/org/apache/heron/healthmgr/HealthManagerTest.java
@@ -106,7 +106,7 @@ public class HealthManagerTest {
     private final MetricsProvider metricsProvider;
 
     @Inject
-    public TestPolicy(HealthPolicyConfig config,
+    TestPolicy(HealthPolicyConfig config,
                       ISchedulerClient schedulerClient,
                       SchedulerStateManagerAdaptor stateMgrAdaptor,
                       MetricsProvider metricsProvider) {

--- a/heron/healthmgr/tests/java/org/apache/heron/healthmgr/detectors/BackPressureDetectorTest.java
+++ b/heron/healthmgr/tests/java/org/apache/heron/healthmgr/detectors/BackPressureDetectorTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class BackPressureDetectorTest {
-  Instant now;
+  private Instant now;
 
   @Before
   public void setup() {
@@ -76,7 +76,7 @@ public class BackPressureDetectorTest {
 
     Assert.assertEquals(2, symptoms.size());
     SymptomsTable compSymptom = SymptomsTable.of(symptoms).type(SYMPTOM_COMP_BACK_PRESSURE.text());
-    Assert.assertEquals(1,compSymptom.size());
+    Assert.assertEquals(1, compSymptom.size());
     Assert.assertEquals(1, compSymptom.get().iterator().next().assignments().size());
 
     SymptomsTable instanceSymptom

--- a/heron/healthmgr/tests/java/org/apache/heron/healthmgr/detectors/GrowingWaitQueueDetectorTest.java
+++ b/heron/healthmgr/tests/java/org/apache/heron/healthmgr/detectors/GrowingWaitQueueDetectorTest.java
@@ -43,21 +43,16 @@ public class GrowingWaitQueueDetectorTest {
     HealthPolicyConfig config = mock(HealthPolicyConfig.class);
     when(config.getConfig(CONF_LIMIT, 10.0)).thenReturn(5.0);
 
-    Measurement measurement1
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892222), 0.0);
-    Measurement measurement2
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892270), 300.0);
-    Measurement measurement3
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892330), 700.0);
-    Measurement measurement4
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892390), 1000.0);
-    Measurement measurement5
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892450), 1300.0);
+    Measurement measurement1 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892222), 0.0);
+    Measurement measurement2 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892270), 300.0);
+    Measurement measurement3 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892330), 700.0);
+    Measurement measurement4 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892390), 1000.0);
+    Measurement measurement5 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892450), 1300.0);
 
 
     Collection<Measurement> metrics = new ArrayList<>();
@@ -76,21 +71,16 @@ public class GrowingWaitQueueDetectorTest {
     assertEquals(1, symptoms.size());
     assertEquals(1, symptoms.iterator().next().assignments().size());
 
-    measurement1
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892222), 0.0);
-    measurement2
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892270), 200.0);
-    measurement3
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892330), 400.0);
-    measurement4
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892390), 600.0);
-    measurement5
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892450), 800.0);
+    measurement1 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892222), 0.0);
+    measurement2 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892270), 200.0);
+    measurement3 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892330), 400.0);
+    measurement4 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892390), 600.0);
+    measurement5 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892450), 800.0);
 
     metrics = new ArrayList<>();
     metrics.add(measurement1);

--- a/heron/healthmgr/tests/java/org/apache/heron/healthmgr/detectors/LargeWaitQueueDetectorTest.java
+++ b/heron/healthmgr/tests/java/org/apache/heron/healthmgr/detectors/LargeWaitQueueDetectorTest.java
@@ -43,12 +43,10 @@ public class LargeWaitQueueDetectorTest {
     HealthPolicyConfig config = mock(HealthPolicyConfig.class);
     when(config.getConfig(CONF_SIZE_LIMIT, 1000)).thenReturn(20);
 
-    Measurement measurement1
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892222), 21);
-    Measurement measurement2
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892322), 21);
+    Measurement measurement1 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892222), 21);
+    Measurement measurement2 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892322), 21);
 
     Collection<Measurement> metrics = new ArrayList<>();
     metrics.add(measurement1);
@@ -64,12 +62,10 @@ public class LargeWaitQueueDetectorTest {
     assertEquals(1, symptoms.iterator().next().assignments().size());
 
 
-    measurement1
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892222), 11);
-    measurement2
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892322), 10);
+    measurement1 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892222), 11);
+    measurement2 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892322), 10);
 
     metrics = new ArrayList<>();
     metrics.add(measurement1);

--- a/heron/healthmgr/tests/java/org/apache/heron/healthmgr/detectors/ProcessingRateSkewDetectorTest.java
+++ b/heron/healthmgr/tests/java/org/apache/heron/healthmgr/detectors/ProcessingRateSkewDetectorTest.java
@@ -22,7 +22,6 @@ package org.apache.heron.healthmgr.detectors;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 
 import com.microsoft.dhalion.core.Measurement;
 import com.microsoft.dhalion.core.MeasurementsTable;
@@ -47,18 +46,14 @@ public class ProcessingRateSkewDetectorTest {
     HealthPolicyConfig config = mock(HealthPolicyConfig.class);
     when(config.getConfig(CONF_SKEW_RATIO, 1.5)).thenReturn(2.5);
 
-    Measurement measurement1
-        = new Measurement("bolt", "i1", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 1000);
-    Measurement measurement2
-        = new Measurement("bolt", "i1", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892122), 3000);
-    Measurement measurement3
-        = new Measurement("bolt", "i2", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 200.0);
-    Measurement measurement4
-        = new Measurement("bolt", "i2", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 400.0);
+    Measurement measurement1 = new Measurement(
+        "bolt", "i1", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 1000);
+    Measurement measurement2 = new Measurement(
+        "bolt", "i1", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892122), 3000);
+    Measurement measurement3 = new Measurement(
+        "bolt", "i2", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 200.0);
+    Measurement measurement4 = new Measurement(
+        "bolt", "i2", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 400.0);
 
     Collection<Measurement> metrics = new ArrayList<>();
     metrics.add(measurement1);
@@ -81,12 +76,10 @@ public class ProcessingRateSkewDetectorTest {
     HealthPolicyConfig config = mock(HealthPolicyConfig.class);
     when(config.getConfig(CONF_SKEW_RATIO, 1.5)).thenReturn(2.5);
 
-    Measurement measurement1
-        = new Measurement("bolt", "i1", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 1000);
-    Measurement measurement2
-        = new Measurement("bolt", "i2", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 200.0);
+    Measurement measurement1 = new Measurement(
+        "bolt", "i1", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 1000);
+    Measurement measurement2 = new Measurement(
+        "bolt", "i2", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 200.0);
 
     Collection<Measurement> metrics = new ArrayList<>();
     metrics.add(measurement1);
@@ -101,21 +94,19 @@ public class ProcessingRateSkewDetectorTest {
 
     assertEquals(3, symptoms.size());
     SymptomsTable symptomsTable = SymptomsTable.of(symptoms);
-    assertEquals(1, symptomsTable.type("POSITIVE "+ BaseDetector.SymptomType
+    assertEquals(1, symptomsTable.type("POSITIVE " + BaseDetector.SymptomType
         .SYMPTOM_PROCESSING_RATE_SKEW).size());
-    assertEquals(1, symptomsTable.type("NEGATIVE "+ BaseDetector.SymptomType
+    assertEquals(1, symptomsTable.type("NEGATIVE " + BaseDetector.SymptomType
         .SYMPTOM_PROCESSING_RATE_SKEW).size());
-    assertEquals(1, symptomsTable.type("POSITIVE "+ BaseDetector.SymptomType
+    assertEquals(1, symptomsTable.type("POSITIVE " + BaseDetector.SymptomType
         .SYMPTOM_PROCESSING_RATE_SKEW).assignment("i1").size());
-    assertEquals(1, symptomsTable.type("NEGATIVE "+ BaseDetector.SymptomType
+    assertEquals(1, symptomsTable.type("NEGATIVE " + BaseDetector.SymptomType
         .SYMPTOM_PROCESSING_RATE_SKEW).assignment("i2").size());
 
-    measurement1
-        = new Measurement("bolt", "i1", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 1000);
-    measurement2
-        = new Measurement("bolt", "i2", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 500.0);
+    measurement1 = new Measurement(
+        "bolt", "i1", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 1000);
+    measurement2 = new Measurement(
+        "bolt", "i2", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 500.0);
 
     metrics = new ArrayList<>();
     metrics.add(measurement1);
@@ -133,28 +124,20 @@ public class ProcessingRateSkewDetectorTest {
     HealthPolicyConfig config = mock(HealthPolicyConfig.class);
     when(config.getConfig(CONF_SKEW_RATIO, 1.5)).thenReturn(2.5);
 
-    Measurement measurement1
-        = new Measurement("bolt", "i1", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 1000);
-    Measurement measurement2
-        = new Measurement("bolt", "i2", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 200.0);
+    Measurement measurement1 = new Measurement(
+        "bolt", "i1", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 1000);
+    Measurement measurement2 = new Measurement(
+        "bolt", "i2", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 200.0);
 
+    Measurement measurement3 = new Measurement(
+        "bolt2", "i3", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 1000);
+    Measurement measurement4 = new Measurement(
+        "bolt2", "i4", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 200.0);
 
-    Measurement measurement3
-        = new Measurement("bolt2", "i3", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 1000);
-    Measurement measurement4
-        = new Measurement("bolt2", "i4", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 200.0);
-
-
-    Measurement measurement5
-        = new Measurement("bolt3", "i5", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 1000);
-    Measurement measurement6
-        = new Measurement("bolt3", "i6", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond
-        (1497892222), 500.0);
+    Measurement measurement5 = new Measurement(
+        "bolt3", "i5", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 1000);
+    Measurement measurement6 = new Measurement(
+        "bolt3", "i6", METRIC_EXE_COUNT.text(), Instant.ofEpochSecond(1497892222), 500.0);
 
 
     Collection<Measurement> metrics = new ArrayList<>();
@@ -175,17 +158,17 @@ public class ProcessingRateSkewDetectorTest {
     assertEquals(6, symptoms.size());
 
     SymptomsTable symptomsTable = SymptomsTable.of(symptoms);
-    assertEquals(2, symptomsTable.type("POSITIVE "+ BaseDetector.SymptomType
+    assertEquals(2, symptomsTable.type("POSITIVE " + BaseDetector.SymptomType
         .SYMPTOM_PROCESSING_RATE_SKEW).size());
-    assertEquals(2, symptomsTable.type("NEGATIVE "+ BaseDetector.SymptomType
+    assertEquals(2, symptomsTable.type("NEGATIVE " + BaseDetector.SymptomType
         .SYMPTOM_PROCESSING_RATE_SKEW).size());
-    assertEquals(1, symptomsTable.type("POSITIVE "+ BaseDetector.SymptomType
+    assertEquals(1, symptomsTable.type("POSITIVE " + BaseDetector.SymptomType
         .SYMPTOM_PROCESSING_RATE_SKEW).assignment("i1").size());
-    assertEquals(1, symptomsTable.type("POSITIVE "+ BaseDetector.SymptomType
+    assertEquals(1, symptomsTable.type("POSITIVE " + BaseDetector.SymptomType
         .SYMPTOM_PROCESSING_RATE_SKEW).assignment("i3").size());
-    assertEquals(1, symptomsTable.type("NEGATIVE "+ BaseDetector.SymptomType
+    assertEquals(1, symptomsTable.type("NEGATIVE " + BaseDetector.SymptomType
         .SYMPTOM_PROCESSING_RATE_SKEW).assignment("i2").size());
-    assertEquals(1, symptomsTable.type("NEGATIVE "+ BaseDetector.SymptomType
+    assertEquals(1, symptomsTable.type("NEGATIVE " + BaseDetector.SymptomType
         .SYMPTOM_PROCESSING_RATE_SKEW).assignment("i4").size());
 
   }

--- a/heron/healthmgr/tests/java/org/apache/heron/healthmgr/detectors/WaitQueueSkewDetectorTest.java
+++ b/heron/healthmgr/tests/java/org/apache/heron/healthmgr/detectors/WaitQueueSkewDetectorTest.java
@@ -44,12 +44,10 @@ public class WaitQueueSkewDetectorTest {
     HealthPolicyConfig config = mock(HealthPolicyConfig.class);
     when(config.getConfig(CONF_SKEW_RATIO, 20.0)).thenReturn(15.0);
 
-    Measurement measurement1
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892222), 1501);
-    Measurement measurement2
-        = new Measurement("bolt", "i2", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892222), 100.0);
+    Measurement measurement1 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892222), 1501);
+    Measurement measurement2 = new Measurement(
+        "bolt", "i2", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892222), 100.0);
 
     Collection<Measurement> metrics = new ArrayList<>();
     metrics.add(measurement1);
@@ -63,22 +61,19 @@ public class WaitQueueSkewDetectorTest {
 
     assertEquals(3, symptoms.size());
     SymptomsTable symptomsTable = SymptomsTable.of(symptoms);
-    assertEquals(1, symptomsTable.type("POSITIVE "+ BaseDetector.SymptomType
+    assertEquals(1, symptomsTable.type("POSITIVE " + BaseDetector.SymptomType
         .SYMPTOM_WAIT_Q_SIZE_SKEW).size());
-    assertEquals(1, symptomsTable.type("NEGATIVE "+ BaseDetector.SymptomType
+    assertEquals(1, symptomsTable.type("NEGATIVE " + BaseDetector.SymptomType
         .SYMPTOM_WAIT_Q_SIZE_SKEW).size());
-    assertEquals(1, symptomsTable.type("POSITIVE "+ BaseDetector.SymptomType
+    assertEquals(1, symptomsTable.type("POSITIVE " + BaseDetector.SymptomType
         .SYMPTOM_WAIT_Q_SIZE_SKEW).assignment("i1").size());
-    assertEquals(1, symptomsTable.type("NEGATIVE "+ BaseDetector.SymptomType
+    assertEquals(1, symptomsTable.type("NEGATIVE " + BaseDetector.SymptomType
         .SYMPTOM_WAIT_Q_SIZE_SKEW).assignment("i2").size());
 
-
-     measurement1
-        = new Measurement("bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892222), 1500);
-     measurement2
-        = new Measurement("bolt", "i2", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond
-        (1497892222), 110.0);
+    measurement1 = new Measurement(
+        "bolt", "i1", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892222), 1500);
+    measurement2 = new Measurement(
+        "bolt", "i2", METRIC_WAIT_Q_SIZE.text(), Instant.ofEpochSecond(1497892222), 110.0);
 
     metrics = new ArrayList<>();
     metrics.add(measurement1);

--- a/heron/healthmgr/tests/java/org/apache/heron/healthmgr/resolvers/ScaleUpResolverTest.java
+++ b/heron/healthmgr/tests/java/org/apache/heron/healthmgr/resolvers/ScaleUpResolverTest.java
@@ -21,7 +21,6 @@ package org.apache.heron.healthmgr.resolvers;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,7 +41,6 @@ import org.apache.heron.api.generated.TopologyAPI;
 import org.apache.heron.common.utils.topology.TopologyTests;
 import org.apache.heron.healthmgr.common.PackingPlanProvider;
 import org.apache.heron.healthmgr.common.PhysicalPlanProvider;
-import org.apache.heron.healthmgr.HealthManagerMetrics;
 import org.apache.heron.packing.roundrobin.RoundRobinPacking;
 import org.apache.heron.proto.scheduler.Scheduler.UpdateTopologyRequest;
 import org.apache.heron.proto.system.PhysicalPlans.PhysicalPlan;
@@ -96,7 +94,8 @@ public class ScaleUpResolverTest {
     ScaleUpResolver spyResolver = spy(resolver);
 
     doReturn(2).when(spyResolver).computeScaleUpFactor("bolt");
-    doReturn(currentPlan).when(spyResolver).buildNewPackingPlan(any(HashMap.class), eq(currentPlan));
+    doReturn(currentPlan).when(spyResolver)
+        .buildNewPackingPlan(any(HashMap.class), eq(currentPlan));
 
     Collection<Action> result = spyResolver.resolve(diagnosis);
     verify(scheduler, times(1)).updateTopology(any(UpdateTopologyRequest.class));

--- a/heron/healthmgr/tests/java/org/apache/heron/healthmgr/sensors/BackPressureSensorTest.java
+++ b/heron/healthmgr/tests/java/org/apache/heron/healthmgr/sensors/BackPressureSensorTest.java
@@ -28,11 +28,9 @@ import java.util.Collections;
 import com.microsoft.dhalion.api.MetricsProvider;
 import com.microsoft.dhalion.core.Measurement;
 import com.microsoft.dhalion.core.MeasurementsTable;
-import com.microsoft.dhalion.policy.PoliciesExecutor;
 import com.microsoft.dhalion.policy.PoliciesExecutor.ExecutionContext;
 
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import org.apache.heron.healthmgr.HealthManagerMetrics;
 import org.apache.heron.healthmgr.common.PackingPlanProvider;

--- a/heron/healthmgr/tests/java/org/apache/heron/healthmgr/sensors/ExecuteCountSensorTest.java
+++ b/heron/healthmgr/tests/java/org/apache/heron/healthmgr/sensors/ExecuteCountSensorTest.java
@@ -61,7 +61,8 @@ public class ExecuteCountSensorTest {
 
     Collection<String> comps = Arrays.asList("bolt-1", "bolt-2");
     when(metricsProvider.getMeasurements(
-        any(Instant.class), eq(DEFAULT_METRIC_DURATION), eq(Collections.singletonList(metric)), eq(comps)))
+        any(Instant.class),
+        eq(DEFAULT_METRIC_DURATION), eq(Collections.singletonList(metric)), eq(comps)))
         .thenReturn(result);
 
     ExecuteCountSensor executeCountSensor

--- a/heron/healthmgr/tests/java/org/apache/heron/healthmgr/sensors/MetricsCacheMetricsProviderTest.java
+++ b/heron/healthmgr/tests/java/org/apache/heron/healthmgr/sensors/MetricsCacheMetricsProviderTest.java
@@ -88,7 +88,8 @@ public class MetricsCacheMetricsProviderTest {
         .build();
 
     doReturn(response).when(spyMetricsProvider)
-        .getMetricsFromMetricsCache(metric, comp, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
+        .getMetricsFromMetricsCache(
+            metric, comp, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
 
     Collection<Measurement> metrics =
         spyMetricsProvider.getMeasurements(Instant.ofEpochSecond(10),
@@ -126,7 +127,8 @@ public class MetricsCacheMetricsProviderTest {
         .build();
 
     doReturn(response1).when(spyMetricsProvider)
-        .getMetricsFromMetricsCache(metric, comp1, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
+        .getMetricsFromMetricsCache(
+            metric, comp1, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
 
     String comp2 = "bolt-2";
     TopologyMaster.MetricResponse response2 = TopologyMaster.MetricResponse.newBuilder()
@@ -153,7 +155,8 @@ public class MetricsCacheMetricsProviderTest {
         .build();
 
     doReturn(response2).when(spyMetricsProvider)
-        .getMetricsFromMetricsCache(metric, comp2, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
+        .getMetricsFromMetricsCache(
+            metric, comp2, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
 
     Collection<Measurement> metrics =
         spyMetricsProvider.getMeasurements(Instant.ofEpochSecond(10),
@@ -193,7 +196,8 @@ public class MetricsCacheMetricsProviderTest {
         .build();
 
     doReturn(response).when(spyMetricsProvider)
-        .getMetricsFromMetricsCache(metric, comp, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
+        .getMetricsFromMetricsCache(
+            metric, comp, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
     Collection<Measurement> metrics =
         spyMetricsProvider.getMeasurements(Instant.ofEpochSecond(10),
             Duration.ofSeconds(60),
@@ -217,7 +221,8 @@ public class MetricsCacheMetricsProviderTest {
         .build();
 
     doReturn(response).when(spyMetricsProvider)
-        .getMetricsFromMetricsCache(metric, comp, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
+        .getMetricsFromMetricsCache(
+            metric, comp, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
     Collection<Measurement> metrics =
         spyMetricsProvider.getMeasurements(Instant.ofEpochSecond(10),
             Duration.ofSeconds(60),
@@ -284,7 +289,8 @@ public class MetricsCacheMetricsProviderTest {
         .build();
 
     doReturn(response).when(spyMetricsProvider)
-        .getMetricsFromMetricsCache(metric, comp, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
+        .getMetricsFromMetricsCache(
+            metric, comp, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
 
     Collection<Measurement> metrics =
         spyMetricsProvider.getMeasurements(Instant.ofEpochSecond(10),

--- a/heron/healthmgr/tests/java/org/apache/heron/healthmgr/sensors/TrackerMetricsProviderTest.java
+++ b/heron/healthmgr/tests/java/org/apache/heron/healthmgr/sensors/TrackerMetricsProviderTest.java
@@ -42,13 +42,13 @@ public class TrackerMetricsProviderTest {
 
     String metric = "count";
     String comp = "bolt";
-    String response = "{\"status\": \"success\", \"executiontime\": 0.002241849899291992, " +
-        "\"message\": \"\", \"version\": \"ver\", \"result\": " +
-        "{\"timeline\": {\"count\": " +
-        "{\"container_1_bolt_1\": {\"1497481288\": \"104\"}, " +
-        "\"container_1_bolt_2\": {\"1497481228\": \"12\", \"1497481348\": \"2\", " +
-        "\"1497481168\": \"3\"}}}, " +
-        "\"endtime\": 1497481388, \"component\": \"bolt\", \"starttime\": 1497481208}}";
+    String response = "{\"status\": \"success\", \"executiontime\": 0.002241849899291992, "
+        + "\"message\": \"\", \"version\": \"ver\", \"result\": "
+        + "{\"timeline\": {\"count\": "
+        + "{\"container_1_bolt_1\": {\"1497481288\": \"104\"}, "
+        + "\"container_1_bolt_2\": {\"1497481228\": \"12\", \"1497481348\": \"2\", "
+        + "\"1497481168\": \"3\"}}}, "
+        + "\"endtime\": 1497481388, \"component\": \"bolt\", \"starttime\": 1497481208}}";
 
     doReturn(response).when(spyMetricsProvider)
         .getMetricsFromTracker(metric, comp, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
@@ -76,23 +76,23 @@ public class TrackerMetricsProviderTest {
 
     String metric = "count";
     String comp1 = "bolt-1";
-    String response1 = "{\"status\": \"success\", \"executiontime\": 0.002241849899291992, " +
-        "\"message\": \"\", \"version\": \"ver\", \"result\": " +
-        "{\"timeline\": {\"count\": " +
-        "{\"container_1_bolt-1_2\": {\"1497481288\": \"104\"}" +
-        "}}, " +
-        "\"endtime\": 1497481388, \"component\": \"bolt\", \"starttime\": 1497481208}}";
+    String response1 = "{\"status\": \"success\", \"executiontime\": 0.002241849899291992, "
+        + "\"message\": \"\", \"version\": \"ver\", \"result\": "
+        + "{\"timeline\": {\"count\": "
+        + "{\"container_1_bolt-1_2\": {\"1497481288\": \"104\"}"
+        + "}}, "
+        + "\"endtime\": 1497481388, \"component\": \"bolt\", \"starttime\": 1497481208}}";
 
     doReturn(response1).when(spyMetricsProvider)
         .getMetricsFromTracker(metric, comp1, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
 
     String comp2 = "bolt-2";
-    String response2 = "{\"status\": \"\", " + "\"executiontime\": 0.0026040077209472656, " +
-        "\"message\": \"\", \"version\": \"\", " +
-        "\"result\": {\"timeline\": {\"count\": " +
-        "{\"container_1_bolt-2_1\": {\"1497481228\": \"12\", \"1497481348\": \"2\", " +
-        "\"1497481168\": \"3\"}}}, " +
-        "\"interval\": 60, \"component\": \"bolt-2\"}}";
+    String response2 = "{\"status\": \"\", " + "\"executiontime\": 0.0026040077209472656, "
+        + "\"message\": \"\", \"version\": \"\", "
+        + "\"result\": {\"timeline\": {\"count\": "
+        + "{\"container_1_bolt-2_1\": {\"1497481228\": \"12\", \"1497481348\": \"2\", "
+        + "\"1497481168\": \"3\"}}}, "
+        + "\"interval\": 60, \"component\": \"bolt-2\"}}";
     doReturn(response2).when(spyMetricsProvider)
         .getMetricsFromTracker(metric, comp2, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
 
@@ -120,12 +120,12 @@ public class TrackerMetricsProviderTest {
 
     String metric = "__time_spent_back_pressure_by_compid/container_1_split_1";
     String comp = "__stmgr__";
-    String response = "{\"status\": \"success\", " +
-        "\"executiontime\": 0.30, \"message\": \"\", \"version\": \"v\", " +
-        "\"result\": " +
-        "{\"metrics\": {\"__time_spent_back_pressure_by_compid/container_1_split_1\": " +
-        "{\"stmgr-1\": {\"00\" : \"601\"}}}, " +
-        "\"interval\": 60, \"component\": \"__stmgr__\"}}";
+    String response = "{\"status\": \"success\", "
+        + "\"executiontime\": 0.30, \"message\": \"\", \"version\": \"v\", "
+        + "\"result\": "
+        + "{\"metrics\": {\"__time_spent_back_pressure_by_compid/container_1_split_1\": "
+        + "{\"stmgr-1\": {\"00\" : \"601\"}}}, "
+        + "\"interval\": 60, \"component\": \"__stmgr__\"}}";
 
     doReturn(response).when(spyMetricsProvider)
         .getMetricsFromTracker(metric, comp, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
@@ -148,9 +148,9 @@ public class TrackerMetricsProviderTest {
 
     String metric = "dummy";
     String comp = "split";
-    String response = "{\"status\": \"success\", \"executiontime\": 0.30780792236328125, " +
-        "\"message\": \"\", \"version\": \"v\", \"result\": " +
-        "{\"metrics\": {}, \"interval\": 0, \"component\": \"split\"}}";
+    String response = "{\"status\": \"success\", \"executiontime\": 0.30780792236328125, "
+        + "\"message\": \"\", \"version\": \"v\", \"result\": "
+        + "{\"metrics\": {}, \"interval\": 0, \"component\": \"split\"}}";
 
     doReturn(response).when(spyMetricsProvider)
         .getMetricsFromTracker(metric, comp, Instant.ofEpochSecond(10), Duration.ofSeconds(60));
@@ -178,13 +178,13 @@ public class TrackerMetricsProviderTest {
 
     String metric = "count";
     String comp = "bolt";
-    String response = "{\"status\": \"success\", \"executiontime\": 0.002241849899291992, " +
-        "\"message\": \"\", \"version\": \"ver\", \"result\": " +
-        "{\"timeline\": {\"count\": " +
-        "{\"container_1_bolt_1\": {\"1497481288\": \"104\"}, " +
-        "\"container_1_bolt_2\": {\"1497481228\": \"12\", \"1497481348\": \"2\", " +
-        "\"1497481168\": \"3\"}}}, " +
-        "\"endtime\": 1497481388, \"component\": \"bolt\", \"starttime\": 1497481208}}";
+    String response = "{\"status\": \"success\", \"executiontime\": 0.002241849899291992, "
+        + "\"message\": \"\", \"version\": \"ver\", \"result\": "
+        + "{\"timeline\": {\"count\": "
+        + "{\"container_1_bolt_1\": {\"1497481288\": \"104\"}, "
+        + "\"container_1_bolt_2\": {\"1497481228\": \"12\", \"1497481348\": \"2\", "
+        + "\"1497481168\": \"3\"}}}, "
+        + "\"endtime\": 1497481388, \"component\": \"bolt\", \"starttime\": 1497481208}}";
 
     doReturn(response).when(spyMetricsProvider)
         .getMetricsFromTracker(metric, comp, Instant.ofEpochSecond(10), Duration.ofSeconds(60));


### PR DESCRIPTION
fix code style in healthmgr unit tests

tested by:
```
bazel build --compilation_mode=dbg --config=darwin heron/... && \
bazel build --compilation_mode=dbg --config=darwin scripts/packages:binpkgs && \
bazel build --compilation_mode=dbg --config=darwin scripts/packages:tarpkgs && \
bazel test                         --config=darwin heron/healthmgr/...
```