### PR TITLE
fix integration test failure with topo parallelism update

### DIFF
--- a/integration_test/src/java/org/apache/heron/integration_test/core/EmitUntilConditionTestSpout.java
+++ b/integration_test/src/java/org/apache/heron/integration_test/core/EmitUntilConditionTestSpout.java
@@ -131,6 +131,21 @@ class EmitUntilConditionTestSpout extends IntegrationTestSpout {
     }
   }
 
+  // Clear spout state during topology parallelism update. This is because during
+  // topology parallelism update, if one instance (identified as container_id-task_id)
+  // is not changed between the old and the new packing plans, it will not be killed, instead
+  // it will be deactivated and then activated which results in spout state before the update
+  // being reserved. On the contrary, if one instance is changed, spout state before the update
+  // will be lost. The same thing happens to bolts as well. But in this test, AT_LEAST_ONCE only
+  // requires tuples emitted at spouts to be a subset of tuples processed at bolts, thus clear
+  // spout state when update topology parallelism can guarantee test correctness no matter how
+  // packing plan changes.
+  @Override
+  public void activate() {
+    super.activate();
+    tuplesEmitted.clear();
+  }
+
   private final class EmitReportingTestSpoutCollector extends SpoutOutputCollector {
 
     private EmitReportingTestSpoutCollector(ISpoutOutputCollector delegate) {

--- a/integration_test/src/java/org/apache/heron/integration_test/core/EmitUntilConditionTestSpout.java
+++ b/integration_test/src/java/org/apache/heron/integration_test/core/EmitUntilConditionTestSpout.java
@@ -134,10 +134,10 @@ class EmitUntilConditionTestSpout extends IntegrationTestSpout {
   // Clear spout state during topology parallelism update. This is because during
   // topology parallelism update, if one instance (identified as container_id-task_id)
   // is not changed between the old and the new packing plans, it will not be killed, instead
-  // it will be deactivated and then activated which results in spout state before the update
-  // being reserved. On the contrary, if one instance is changed, spout state before the update
-  // will be lost. The same thing happens to bolts as well. But in this test, AT_LEAST_ONCE only
-  // requires tuples emitted at spouts to be a subset of tuples processed at bolts, thus clear
+  // it will be deactivated and then activated which results in instance state before the update
+  // being reserved. On the contrary, if one instance is changed, instance state before the update
+  // will be lost. The thing can happen to both spouts and bolts. But in this test, AT_LEAST_ONCE
+  // only requires tuples emitted at spouts to be a subset of tuples processed at bolts, thus clear
   // spout state when update topology parallelism can guarantee test correctness no matter how
   // packing plan changes.
   @Override


### PR DESCRIPTION
Two integration test with topo parallelism update fails in travis ci because of unmatched expected and actual results.
During topology parallelism update, one instance (identified as container_id-task_id) may be one of the following case:
1. If it is not changed between the old and the new packing plans, it will not be killed, instead it will be deactivated and then activated which results in instance state before the update being reserved. 
2. If it is changed, it will be killed and start somewhere else, thus instance state before the update will be lost. 
The thing can happen to both spouts and bolts. But in the two tests, AT_LEAST_ONCE only requires tuples emitted at spouts to be a subset of tuples processed at bolts, thus clear spout state when update topology parallelism can guarantee test correctness no matter how packing plan changes.