### PR TITLE
refactor JavaSerializer for proper closing input/output streams

### DIFF
--- a/heron/api/src/java/org/apache/heron/api/serializer/JavaSerializer.java
+++ b/heron/api/src/java/org/apache/heron/api/serializer/JavaSerializer.java
@@ -34,25 +34,23 @@ public class JavaSerializer implements IPluggableSerializer {
 
   @Override
   public byte[] serialize(Object object) {
-    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    try {
-      ObjectOutputStream oos = new ObjectOutputStream(bos);
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+         ObjectOutputStream oos = new ObjectOutputStream(bos)) {
       oos.writeObject(object);
       oos.flush();
+      return bos.toByteArray();
     } catch (IOException e) {
       throw new RuntimeException("Failed to serialize object: " + object.toString(), e);
     }
-    return bos.toByteArray();
   }
 
   @Override
   public Object deserialize(byte[] input) {
-    ByteArrayInputStream bis = new ByteArrayInputStream(input);
-    try {
-      ObjectInputStream ois = new ObjectInputStream(bis);
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(input);
+         ObjectInputStream ois = new ObjectInputStream(bis)) {
       return ois.readObject();
     } catch (IOException | ClassNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException("Failed to deserialize object", e);
     }
   }
 }


### PR DESCRIPTION
Use try-with-resources statement ensures that each input/output stream is closed properly at the end of the statement.