### PR TITLE
Nwang/remove stateful from streamletoperator

### DIFF
--- a/heron/api/src/java/org/apache/heron/streamlet/impl/operators/StreamletOperator.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/operators/StreamletOperator.java
@@ -20,11 +20,7 @@
 
 package org.apache.heron.streamlet.impl.operators;
 
-import java.io.Serializable;
-
 import org.apache.heron.api.bolt.BaseRichBolt;
-import org.apache.heron.api.state.State;
-import org.apache.heron.api.topology.IStatefulComponent;
 import org.apache.heron.api.topology.OutputFieldsDeclarer;
 import org.apache.heron.api.tuple.Fields;
 

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/operators/StreamletOperator.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/operators/StreamletOperator.java
@@ -32,16 +32,17 @@ import org.apache.heron.api.tuple.Fields;
  * The Bolt interface that other operators of the streamlet packages extend.
  * The only common stuff amongst all of them is the output streams
  */
-public abstract class StreamletOperator extends BaseRichBolt
-    implements IStatefulComponent<Serializable, Serializable> {
+public abstract class StreamletOperator extends BaseRichBolt {
   private static final long serialVersionUID = 8524238140745238942L;
   private static final String OUTPUT_FIELD_NAME = "output";
 
+  /*
   @Override
   public void initState(State<Serializable, Serializable> state) { }
 
   @Override
   public void preSave(String checkpointId) { }
+*/
 
   /**
    * The operators implementing streamlet functionality have some properties.

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/operators/StreamletOperator.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/operators/StreamletOperator.java
@@ -36,14 +36,6 @@ public abstract class StreamletOperator extends BaseRichBolt {
   private static final long serialVersionUID = 8524238140745238942L;
   private static final String OUTPUT_FIELD_NAME = "output";
 
-  /*
-  @Override
-  public void initState(State<Serializable, Serializable> state) { }
-
-  @Override
-  public void preSave(String checkpointId) { }
-*/
-
   /**
    * The operators implementing streamlet functionality have some properties.
    * 1. They all output only one stream

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/operators/TransformOperator.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/operators/TransformOperator.java
@@ -59,7 +59,6 @@ public class TransformOperator<R, T> extends StreamletOperator
 
   @Override
   public void preSave(String checkpointId) {
-    // TODO
   }
 
   @Override

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/operators/TransformOperator.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/operators/TransformOperator.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.apache.heron.api.bolt.OutputCollector;
 import org.apache.heron.api.state.State;
+import org.apache.heron.api.topology.IStatefulComponent;
 import org.apache.heron.api.topology.TopologyContext;
 import org.apache.heron.api.tuple.Tuple;
 import org.apache.heron.api.tuple.Values;
@@ -38,7 +39,8 @@ import org.apache.heron.streamlet.impl.ContextImpl;
  * It calls the transformFunction setup/cleanup at the beginning/end of the
  * processing. And for every tuple, it applies the transformFunction, and emits the resulting value
  */
-public class TransformOperator<R, T> extends StreamletOperator {
+public class TransformOperator<R, T> extends StreamletOperator
+    implements IStatefulComponent<Serializable, Serializable> {
   private static final long serialVersionUID = 429297144878185182L;
   private SerializableTransformer<? super R, ? extends T> serializableTransformer;
 
@@ -56,13 +58,19 @@ public class TransformOperator<R, T> extends StreamletOperator {
   }
 
   @Override
+  public void preSave(String checkpointId) {
+    // TODO
+  }
+
+  @Override
   public void cleanup() {
     serializableTransformer.cleanup();
   }
 
   @SuppressWarnings("rawtypes")
   @Override
-  public void prepare(Map<String, Object> map, TopologyContext topologyContext,
+  public void prepare(Map<String, Object> map,
+                      TopologyContext topologyContext,
                       OutputCollector outputCollector) {
     collector = outputCollector;
     Context context = new ContextImpl(topologyContext, map, state);

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/sinks/ComplexSink.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/sinks/ComplexSink.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.apache.heron.api.bolt.OutputCollector;
 import org.apache.heron.api.state.State;
+import org.apache.heron.api.topology.IStatefulComponent;
 import org.apache.heron.api.topology.TopologyContext;
 import org.apache.heron.api.tuple.Tuple;
 import org.apache.heron.streamlet.Context;
@@ -36,7 +37,8 @@ import org.apache.heron.streamlet.impl.operators.StreamletOperator;
  * ConsumerSink is a very simple Sink that basically invokes a user supplied
  * consume function for every tuple.
  */
-public class ComplexSink<R> extends StreamletOperator {
+public class ComplexSink<R> extends StreamletOperator
+    implements IStatefulComponent<Serializable, Serializable> {
   private static final long serialVersionUID = 8717991188885786658L;
   private Sink<R> sink;
   private OutputCollector collector;
@@ -49,6 +51,11 @@ public class ComplexSink<R> extends StreamletOperator {
   @Override
   public void initState(State<Serializable, Serializable> startupState) {
     this.state = startupState;
+  }
+
+  @Override
+  public void preSave(String checkpointId) {
+    // TODO
   }
 
   @SuppressWarnings("rawtypes")

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/sinks/ComplexSink.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/sinks/ComplexSink.java
@@ -55,7 +55,6 @@ public class ComplexSink<R> extends StreamletOperator
 
   @Override
   public void preSave(String checkpointId) {
-    // TODO
   }
 
   @SuppressWarnings("rawtypes")


### PR DESCRIPTION
StreamletOperator is the base class of many operators (there are windowed operators which are different). Not all these operators support or need the stateful interface, such as FilterOperator. Supporting stateful interface or not should be decided in the implementation level instead of the base level.

Plus, StreamletWindowedOperator doesn't support stateful interface either.