### PR TITLE
Nwang/refactor grouping

### DIFF
--- a/heron/api/src/java/org/apache/heron/api/grouping/AllStreamGrouping.java
+++ b/heron/api/src/java/org/apache/heron/api/grouping/AllStreamGrouping.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.api.grouping;
+
+import org.apache.heron.api.generated.TopologyAPI;
+
+/**
+ * This is the stream grouping strategy that all tuples are transmitted to all instances of a bolt.
+ */
+public class AllStreamGrouping implements StreamGrouping {
+
+  public AllStreamGrouping() { }
+
+  public TopologyAPI.InputStream.Builder buildStream(String componentName, String streamId) {
+    TopologyAPI.InputStream.Builder bldr = TopologyAPI.InputStream.newBuilder();
+
+    bldr.setStream(
+        TopologyAPI.StreamId.newBuilder().setId(streamId).setComponentName(componentName));
+    bldr.setGtype(TopologyAPI.Grouping.ALL);
+
+    return bldr;
+  }
+}

--- a/heron/api/src/java/org/apache/heron/api/grouping/CustomStreamGrouping.java
+++ b/heron/api/src/java/org/apache/heron/api/grouping/CustomStreamGrouping.java
@@ -59,9 +59,7 @@ public interface CustomStreamGrouping extends StreamGrouping {
    * @param streamId The id of the input stream
    * @return An InputStream builder to be used by BoltDeclarer
    */
-  default TopologyAPI.InputStream.Builder buildStream(
-      String componentName, String streamId) {
-
+  default TopologyAPI.InputStream.Builder buildStream(String componentName, String streamId) {
     TopologyAPI.InputStream.Builder bldr = TopologyAPI.InputStream.newBuilder();
 
     bldr.setStream(

--- a/heron/api/src/java/org/apache/heron/api/grouping/CustomStreamGrouping.java
+++ b/heron/api/src/java/org/apache/heron/api/grouping/CustomStreamGrouping.java
@@ -33,9 +33,9 @@ import org.apache.heron.api.utils.Utils;
 public interface CustomStreamGrouping extends StreamGrouping {
 
   /**
-   * Tells the stream groupisng at runtime the tasks in the target bolt.
+   * Tells the stream grouping at runtime the tasks in the target bolt.
    * This information should be used in chooseTasks to determine the target tasks.
-   * <p>s
+   * <p>
    * It also tells the grouping the metadata on the stream this grouping will be used on.
    */
   void prepare(
@@ -48,7 +48,7 @@ public interface CustomStreamGrouping extends StreamGrouping {
    * This function implements a custom stream grouping. It takes in as input
    * the number of tasks in the target bolt in prepare and returns the
    * tasks to send the tuples to.
-   *s
+   *
    * @param values the values to group on
    */
   List<Integer> chooseTasks(List<Object> values);

--- a/heron/api/src/java/org/apache/heron/api/grouping/DirectStreamGrouping.java
+++ b/heron/api/src/java/org/apache/heron/api/grouping/DirectStreamGrouping.java
@@ -31,6 +31,8 @@ public class DirectStreamGrouping implements StreamGrouping {
   public TopologyAPI.InputStream.Builder buildStream(String componentName, String streamId) {
     TopologyAPI.InputStream.Builder bldr = TopologyAPI.InputStream.newBuilder();
 
+    bldr.setStream(
+        TopologyAPI.StreamId.newBuilder().setId(streamId).setComponentName(componentName));
     bldr.setGtype(TopologyAPI.Grouping.DIRECT);
     bldr.setType(TopologyAPI.CustomGroupingObjectType.JAVA_OBJECT);
 

--- a/heron/api/src/java/org/apache/heron/api/grouping/DirectStreamGrouping.java
+++ b/heron/api/src/java/org/apache/heron/api/grouping/DirectStreamGrouping.java
@@ -22,7 +22,7 @@ package org.apache.heron.api.grouping;
 import org.apache.heron.api.generated.TopologyAPI;
 
 /**
- * This is the stream grouping strategy that.
+ * This is the stream grouping strategy that tuples are sent to the instance of choice.
  */
 public class DirectStreamGrouping implements StreamGrouping {
 

--- a/heron/api/src/java/org/apache/heron/api/grouping/DirectStreamGrouping.java
+++ b/heron/api/src/java/org/apache/heron/api/grouping/DirectStreamGrouping.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.api.grouping;
+
+import org.apache.heron.api.generated.TopologyAPI;
+
+/**
+ * This is the stream grouping strategy that.
+ */
+public class DirectStreamGrouping implements StreamGrouping {
+
+  public DirectStreamGrouping() { }
+
+  public TopologyAPI.InputStream.Builder buildStream(String componentName, String streamId) {
+    TopologyAPI.InputStream.Builder bldr = TopologyAPI.InputStream.newBuilder();
+
+    bldr.setGtype(TopologyAPI.Grouping.DIRECT);
+    bldr.setType(TopologyAPI.CustomGroupingObjectType.JAVA_OBJECT);
+
+    return bldr;
+  }
+}

--- a/heron/api/src/java/org/apache/heron/api/grouping/FieldsStreamGrouping.java
+++ b/heron/api/src/java/org/apache/heron/api/grouping/FieldsStreamGrouping.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.api.grouping;
+
+import org.apache.heron.api.generated.TopologyAPI;
+import org.apache.heron.api.tuple.Fields;
+
+/**
+ * This is the stream grouping strategy that.
+ */
+public class FieldsStreamGrouping implements StreamGrouping {
+  private Fields fields;
+
+  public FieldsStreamGrouping(Fields fields) {
+    this.fields = fields;
+  }
+
+  public TopologyAPI.InputStream.Builder buildStream(String componentName, String streamId) {
+    TopologyAPI.InputStream.Builder bldr = TopologyAPI.InputStream.newBuilder();
+
+    bldr.setStream(
+        TopologyAPI.StreamId.newBuilder().setId(streamId).setComponentName(componentName));
+    bldr.setGtype(TopologyAPI.Grouping.FIELDS);
+    TopologyAPI.StreamSchema.Builder gfbldr = TopologyAPI.StreamSchema.newBuilder();
+    for (int i = 0; i < fields.size(); ++i) {
+      TopologyAPI.StreamSchema.KeyType.Builder ktBldr =
+          TopologyAPI.StreamSchema.KeyType.newBuilder();
+      ktBldr.setKey(fields.get(i));
+      ktBldr.setType(TopologyAPI.Type.OBJECT);
+      gfbldr.addKeys(ktBldr);
+    }
+    bldr.setGroupingFields(gfbldr);
+
+    return bldr;
+  }
+}

--- a/heron/api/src/java/org/apache/heron/api/grouping/FieldsStreamGrouping.java
+++ b/heron/api/src/java/org/apache/heron/api/grouping/FieldsStreamGrouping.java
@@ -23,7 +23,8 @@ import org.apache.heron.api.generated.TopologyAPI;
 import org.apache.heron.api.tuple.Fields;
 
 /**
- * This is the stream grouping strategy that.
+ * This is the stream grouping strategy that tuples are sent to the particular instance of
+ * the downstream bolt based on the values of a specified fields.
  */
 public class FieldsStreamGrouping implements StreamGrouping {
   private Fields fields;

--- a/heron/api/src/java/org/apache/heron/api/grouping/GlobalStreamGrouping.java
+++ b/heron/api/src/java/org/apache/heron/api/grouping/GlobalStreamGrouping.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.api.grouping;
+
+import org.apache.heron.api.generated.TopologyAPI;
+
+/**
+ * This is the stream grouping strategy that all tuples are transmitted to a single instance
+ * of a bolt with the lowest task id.
+ */
+public class GlobalStreamGrouping implements StreamGrouping {
+
+  public GlobalStreamGrouping() { }
+
+  public TopologyAPI.InputStream.Builder buildStream(String componentName, String streamId) {
+    TopologyAPI.InputStream.Builder bldr = TopologyAPI.InputStream.newBuilder();
+
+    bldr.setStream(
+        TopologyAPI.StreamId.newBuilder().setId(streamId).setComponentName(componentName));
+    bldr.setGtype(TopologyAPI.Grouping.LOWEST);
+
+    return bldr;
+  }
+}

--- a/heron/api/src/java/org/apache/heron/api/grouping/NoneStreamGrouping.java
+++ b/heron/api/src/java/org/apache/heron/api/grouping/NoneStreamGrouping.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.api.grouping;
+
+import org.apache.heron.api.generated.TopologyAPI;
+
+/**
+ * This is the stream grouping strategy that is the same as shuffle grouping.
+ */
+public class NoneStreamGrouping implements StreamGrouping {
+
+  public NoneStreamGrouping() { }
+
+  public TopologyAPI.InputStream.Builder buildStream(String componentName, String streamId) {
+    TopologyAPI.InputStream.Builder bldr = TopologyAPI.InputStream.newBuilder();
+
+    bldr.setStream(
+        TopologyAPI.StreamId.newBuilder().setId(streamId).setComponentName(componentName));
+    bldr.setGtype(TopologyAPI.Grouping.NONE);
+
+    return bldr;
+  }
+}

--- a/heron/api/src/java/org/apache/heron/api/grouping/ShuffleStreamGrouping.java
+++ b/heron/api/src/java/org/apache/heron/api/grouping/ShuffleStreamGrouping.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.api.grouping;
+
+import org.apache.heron.api.generated.TopologyAPI;
+
+/**
+ * This is the stream grouping strategy that tuples are randomly distributed to instances of
+ * the bolt.
+ */
+public class ShuffleStreamGrouping implements StreamGrouping {
+
+  public ShuffleStreamGrouping() { }
+
+  public TopologyAPI.InputStream.Builder buildStream(String componentName, String streamId) {
+    TopologyAPI.InputStream.Builder bldr = TopologyAPI.InputStream.newBuilder();
+
+    bldr.setStream(
+        TopologyAPI.StreamId.newBuilder().setId(streamId).setComponentName(componentName));
+    bldr.setGtype(TopologyAPI.Grouping.SHUFFLE);
+
+    return bldr;
+  }
+}

--- a/heron/api/src/java/org/apache/heron/api/grouping/StreamGrouping.java
+++ b/heron/api/src/java/org/apache/heron/api/grouping/StreamGrouping.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.api.grouping;
+
+import java.io.Serializable;
+
+import org.apache.heron.api.generated.TopologyAPI;
+
+/**
+ * This is the interface of stream grouping at runtime the tasks in the target bolt.
+ */
+public interface StreamGrouping extends Serializable {
+
+  /**
+   * Create an InputStream Builder object with the corresponding grouping logic.
+   * @param componentName The parent component of this grouping logic
+   * @param streamId The id of the input stream
+   * @return An InputStream builder to be used by BoltDeclarer
+   */
+  TopologyAPI.InputStream.Builder buildStream(String componentName, String streamId);
+}


### PR DESCRIPTION
Refactor grouping logic from BoltDeclarer functions to classes so that it is easier for them to be reused by Streamlet API, from calling different function

boltDeclarer.XGrouping(parent, streamId, ...);

to:

StreamGrouping grouper = new X(...);
boltDeclarer.grouping(parent, streamId, grouper);

- No logic change.
- Old functions are still available.