### PR TITLE
Refactor heron_executor to make it easier to customize

### DIFF
--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -146,8 +146,8 @@ class HeronExecutorTest(unittest.TestCase):
            "-XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=100M " \
            "-XX:+PrintPromotionFailure -XX:+PrintTenuringDistribution -XX:+PrintHeapAtGC " \
            "-XX:+HeapDumpOnOutOfMemoryError -XX:+UseConcMarkSweepGC -XX:ParallelGCThreads=4 " \
-           "-Xloggc:log-files/gc.%s.log -XX:+HeapDumpOnOutOfMemoryError " \
-           "-Djava.net.preferIPv4Stack=true -cp instance_classpath:classpath " \
+           "-Xloggc:log-files/gc.%s.log -Djava.net.preferIPv4Stack=true " \
+           "-cp instance_classpath:classpath -XX:+HeapDumpOnOutOfMemoryError " \
            "org.apache.heron.instance.HeronInstance -topology_name topname -topology_id topid -instance_id %s -component_name %s -task_id %d -component_index 0 -stmgr_id stmgr-%d " \
            "-stmgr_port tmaster_controller_port -metricsmgr_port metricsmgr_port -system_config_file %s -override_config_file %s" \
            % (instance_name, instance_name, component_name, instance_id,


### PR DESCRIPTION
Currently the main function and the function for generating java command are single functions. In case some users might need to customize it, it is hard to reuse code in the existing executor. After the refactor, users should be able to create their own executor by extending the HeronExecutor class and use it in the main function.

```
class UserHeronExecutor(oss_heron_executor.HeronExecutor):
  # pylint: disable=no-self-use
  def _get_jvm_instance_options(self, instance_id, component_name, remote_debugger_port):
    options = oss_heron_executor.HeronExecutor._get_jvm_instance_options(
        instance_id, component_name, remote_debugger_port)
    ....
    return options

def main():
  # Instantiate the executor
  parsed_args = oss_heron_executor.parse_args(sys.argv)
  executor = UserHeronExecutor(parsed_args, os.environ.copy())
  executor.initialize()

  # launch it
  oss_heron_executor.start(executor)

if __name__ == "__main__":
  main()
```