### PR TITLE
enable boolean in --config-property key-value

### DIFF
--- a/heron/tools/common/src/python/utils/config.py
+++ b/heron/tools/common/src/python/utils/config.py
@@ -413,7 +413,12 @@ def parse_override_config(namespace):
     kv = config.split("=")
     if len(kv) != 2:
       raise Exception("Invalid config property format (%s) expected key=value" % config)
-    overrides[kv[0]] = kv[1]
+    if kv[1] in ['true', 'True', 'TRUE']:
+      overrides[kv[0]] = True
+    elif kv[1] in ['false', 'False', 'FALSE']:
+      overrides[kv[0]] = False
+    else:
+      overrides[kv[0]] = kv[1]
   return overrides
 
 


### PR DESCRIPTION
The present `--config-property ` processes key-value to strings only. If passing bool value, it will be string as well.

This PR converts the string to bool in override.yaml when seeing bool string in `--config-property ` phrase.

