### PR TITLE
Add support for building Heron release in a Ubuntu 18.04 docker container

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -1,6 +1,6 @@
 # Docker
 
-## To compile source using a docker container:
+## To compile source, into Heron release artifacts, using a docker container:
 ```
 ./docker/scripts/build-artifacts.sh <platform> <version_string> [source-tarball] <output-directory>
 # e.g.  ./docker/scripts/build-artifacts.sh ubuntu14.04 testbuild ~/heron-release
@@ -11,25 +11,3 @@
 ./docker/scripts/build-docker.sh <platform> <version_string> <output-directory>
 # e.g. ./docker/scripts/build-docker.sh ubuntu14.04 testbuild ~/heron-release
 ```
-
-### To run docker containers for local dev work:
-```
-./docker/start-docker.sh heron:<version_string>-<platform>
-# e.g. ./docker/start-docker.sh heron:testbuild-ubuntu14.04
-```
-### To stop docker containers for local dev work:
-```
-./docker/stop-docker.sh
-```
-### To submit/activate/kill a topology:
-```
-#To submit a topology:
-        docker exec heron_executor_1 heron submit local /usr/local/heron/examples/heron-api-examples.jar org.apache.heron.examples.api.ExclamationTopology ExclamationTopology --deploy-deactivated
-#To activate a topology:
-        docker exec -it heron_executor_1 heron activate local ExclamationTopology
-#To kill a topology:
-        docker exec -it heron_executor_1 heron kill local ExclamationTopology
-```
-## To access heron ui:
-* determine the IP of your docker host
-* navigate to http://<your docker host>:8889 in your web browser

--- a/docker/compile/Dockerfile.ubuntu18.04
+++ b/docker/compile/Dockerfile.ubuntu18.04
@@ -1,0 +1,28 @@
+FROM ubuntu:18.04
+
+# This is passed to the heron build command via the --config flag
+ENV TARGET_PLATFORM ubuntu
+ENV bazelVersion 0.14.1
+
+RUN apt-get update && apt-get -y install \
+      g++ \
+      cmake \
+      automake \
+      libtool-bin \
+      libunwind8 \
+      patch \
+      python-dev \
+      wget \
+      zip \
+      unzip
+
+RUN apt-get -y install openjdk-8-jdk-headless
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
+RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/$bazelVersion/bazel-$bazelVersion-installer-linux-x86_64.sh \
+      && chmod +x /tmp/bazel.sh \
+      && /tmp/bazel.sh
+
+ADD bazelrc /root/.bazelrc
+ADD scripts/compile-platform.sh /compile-platform.sh

--- a/docker/dist/Dockerfile.dist.ubuntu18.04
+++ b/docker/dist/Dockerfile.dist.ubuntu18.04
@@ -1,0 +1,23 @@
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get -y install \
+    unzip software-properties-common curl supervisor openjdk-8-jdk-headless
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+RUN update-ca-certificates -f
+
+ADD artifacts /heron
+
+WORKDIR /heron
+
+# run heron installers
+RUN /heron/heron-install.sh
+
+RUN tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
+
+RUN rm -f /heron/heron-install.sh
+RUN rm -f /heron/heron-core.tar.gz
+
+ENV HERON_HOME /heron/heron-core/
+RUN export HERON_HOME

--- a/docker/scripts/build-artifacts.sh
+++ b/docker/scripts/build-artifacts.sh
@@ -166,7 +166,7 @@ case $# in
     echo "  "
     echo "Script to build heron artifacts for different platforms"
     echo "  "
-    echo "Platforms Supported: darwin, ubuntu14.04, ubuntu16.04, centos7, debian9"
+    echo "Platforms Supported: darwin, debian9, ubuntu14.04, ubuntu16.04, ubuntu18.04, centos7"
     echo "  "
     echo "Example:"
     echo "  ./build-artifacts.sh ubuntu14.04 0.12.0 ."

--- a/docker/scripts/build-base.sh
+++ b/docker/scripts/build-base.sh
@@ -59,7 +59,7 @@ run_build() {
   DOCKER_TAG="heron/base:$HERON_VERSION"
   DOCKER_LATEST_TAG="heron/base:latest"
 
-  if [ "$TARGET_PLATFORM" == "debian8" ]; then
+  if [ "$TARGET_PLATFORM" == "debian9" ]; then
     DOCKER_TAG="heron/base:$HERON_VERSION"
     DOCKER_LATEST_TAG="heron/base:latest"
     DOCKER_IMAGE_FILE="$OUTPUT_DIRECTORY/base-$HERON_VERSION.tar"
@@ -91,7 +91,7 @@ case $# in
     echo "  "
     echo "Usage: $0 <platform> <version_string> <output-directory>"
     echo "  "
-    echo "Platforms Supported: debian9, ubuntu14.04, ubuntu16.04, centos7"
+    echo "Platforms Supported: darwin, debian9, ubuntu14.04, ubuntu16.04, ubuntu18.04, centos7"
     echo "  "
     echo "Example:"
     echo "  ./build-base.sh ubuntu14.04 0.12.0 ~/ubuntu"

--- a/docker/scripts/build-docker.sh
+++ b/docker/scripts/build-docker.sh
@@ -58,7 +58,7 @@ run_build() {
   CORE_FILE="$OUTPUT_DIRECTORY/heron-core-$HERON_VERSION-$TARGET_PLATFORM.tar.gz"
   CORE_OUT_FILE="$SCRATCH_DIR/artifacts/heron-core.tar.gz"
 
-  ALL_FILE="$OUTPUT_DIRECTORY/heron-install.sh"
+  ALL_FILE="$OUTPUT_DIRECTORY/heron-install-$HERON_VERSION-$TARGET_PLATFORM.sh"
   ALL_OUT_FILE="$SCRATCH_DIR/artifacts/heron-install.sh"
 
   cp $CORE_FILE $CORE_OUT_FILE
@@ -88,7 +88,7 @@ case $# in
     echo "  "
     echo "Usage: $0 <platform> <version_string> <artifact-directory> "
     echo "  "
-    echo "Platforms Supported: ubuntu14.04, ubuntu16.04, centos7, debian8"
+    echo "Platforms Supported: darwin, debian9, ubuntu14.04, ubuntu16.04, ubuntu18.04, centos7"
     echo "  "
     echo "Example:"
     echo "  ./build-docker.sh ubuntu14.04 0.12.0 ~/ubuntu"

--- a/docker/scripts/build-exec-docker.sh
+++ b/docker/scripts/build-exec-docker.sh
@@ -86,7 +86,7 @@ case $# in
   *)
     echo "Usage: $0 <platform> <version_string> <output-directory> "
     echo "  "
-    echo "Platforms Supported: ubuntu14.04, ubuntu16.04, debian9, centos7"
+    echo "Platforms Supported: darwin, debian9, ubuntu14.04, ubuntu16.04, ubuntu18.04, centos7"
     echo "  "
     echo "Example:"
     echo "  ./build-exec-docker.sh ubuntu14.04 0.12.0 ."


### PR DESCRIPTION
* Added Ubuntu 18.04 based compilation and distribution containers

* Updated docker script help text with correct distro names

* Removed defunct (the scripts have been removed) docker based instructions for running Heron in containers on a local machine 