### PR TITLE
Fix build error on Mac.

### DIFF
--- a/heron/common/src/java/org/apache/heron/common/basics/ByteAmount.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/ByteAmount.java
@@ -25,7 +25,9 @@ package org.apache.heron.common.basics;
 public final class ByteAmount implements Comparable<ByteAmount> {
   private static final long MB = 1024L * 1024;
   private static final long GB = MB * 1024;
+  @SuppressWarnings("MathRoundIntLong")
   private static final long MAX_MB = Math.round(Long.MAX_VALUE / MB);
+  @SuppressWarnings("MathRoundIntLong")
   private static final long MAX_GB = Math.round(Long.MAX_VALUE / GB);
 
   public static final ByteAmount ZERO = ByteAmount.fromBytes(0);

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/mesos/framework/LaunchableTask.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/mesos/framework/LaunchableTask.java
@@ -67,7 +67,7 @@ public class LaunchableTask {
 
     String role = "*";
     for (Protos.Resource resource : reservedResources) {
-      if (resource.getName().equalsIgnoreCase(name) && resource.getScalar().getValue() >= value) {
+      if (resource.getName().equals(name) && resource.getScalar().getValue() >= value) {
         role = resource.getRole();
         break;
 
@@ -95,7 +95,7 @@ public class LaunchableTask {
 
     String role = "*";
     for (Protos.Resource resource : reservedResources) {
-      if (resource.getName().equalsIgnoreCase(name)) {
+      if (resource.getName().equals(name)) {
         Protos.Value.Ranges ranges = resource.getRanges();
         for (Protos.Value.Range range : ranges.getRangeList()) {
           if (range.getBegin() <= begin && range.getEnd() >= end) {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/mesos/framework/LaunchableTask.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/mesos/framework/LaunchableTask.java
@@ -67,7 +67,7 @@ public class LaunchableTask {
 
     String role = "*";
     for (Protos.Resource resource : reservedResources) {
-      if (resource.getName() == name && resource.getScalar().getValue() >= value) {
+      if (resource.getName().equalsIgnoreCase(name) && resource.getScalar().getValue() >= value) {
         role = resource.getRole();
         break;
 
@@ -95,7 +95,7 @@ public class LaunchableTask {
 
     String role = "*";
     for (Protos.Resource resource : reservedResources) {
-      if (resource.getName() == name) {
+      if (resource.getName().equalsIgnoreCase(name)) {
         Protos.Value.Ranges ranges = resource.getRanges();
         for (Protos.Value.Range range : ranges.getRangeList()) {
           if (range.getBegin() <= begin && range.getEnd() >= end) {


### PR DESCRIPTION
Fix build error on Mac.

```
INFO: From Executing genrule //scripts/packages:generate-package-info:
find: ./local-spawn-runner.200177576272998968: No such file or directory
ERROR: /Users/thinker0/aa/opensource/heron/heron/schedulers/src/java/BUILD:183:1: Building heron/schedulers/src/java/mesos-scheduler-unshaded.jar (8 source files) failed (Exit 1)
heron/schedulers/src/java/com/twitter/heron/scheduler/mesos/framework/LaunchableTask.java:66: error: [ProtoStringFieldReferenceEquality] Comparing protobuf fields of type String using reference equality
      if (resource.getName() == name && resource.getScalar().getValue() >= value) {
                             ^
    (see https://errorprone.info/bugpattern/ProtoStringFieldReferenceEquality)
  Did you mean 'if (resource.getName().equals(name) && resource.getScalar().getValue() >= value) {'?
heron/schedulers/src/java/com/twitter/heron/scheduler/mesos/framework/LaunchableTask.java:94: error: [ProtoStringFieldReferenceEquality] Comparing protobuf fields of type String using reference equality
      if (resource.getName() == name) {
                             ^
    (see https://errorprone.info/bugpattern/ProtoStringFieldReferenceEquality)
  Did you mean 'if (resource.getName().equals(name)) {'?
Target //scripts/packages:binpkgs failed to build
Use --verbose_failures to see the command lines of failed build steps.
```

add #3046
```
ERROR: /Users/thinker0/aa/opensource/heron/heron/common/src/java/BUILD:11:1: Building heron/common/src/java/libbasics-java.jar (13 source files) failed (Exit 1)
heron/common/src/java/com/twitter/heron/common/basics/ByteAmount.java:22: error: [MathRoundIntLong] Math.round(Integer) results in truncation
  private static final long MAX_MB = Math.round(Long.MAX_VALUE / MB);
                                               ^
    (see https://errorprone.info/bugpattern/MathRoundIntLong)
  Did you mean 'private static final long MAX_MB = Ints.saturatedCast(Long.MAX_VALUE / MB);'?
heron/common/src/java/com/twitter/heron/common/basics/ByteAmount.java:23: error: [MathRoundIntLong] Math.round(Integer) results in truncation
  private static final long MAX_GB = Math.round(Long.MAX_VALUE / GB);
                                               ^
    (see https://errorprone.info/bugpattern/MathRoundIntLong)
  Did you mean 'private static final long MAX_GB = Ints.saturatedCast(Long.MAX_VALUE / GB);'?
Target //scripts/packages:binpkgs failed to build
Use --verbose_failures to see the command lines of failed build steps.
```