### PR TITLE
[Scala Streamlet API] Enable Documentation

### DIFF
--- a/website/content/snippets/heron-streamlet-api.md
+++ b/website/content/snippets/heron-streamlet-api.md
@@ -1,19 +1,20 @@
 Heron processing topologies can be written using an API called the **Heron Streamlet API**. The Heron Streamlet API is currently available for the following languages:
 
 * [Java](../../../developers/java/streamlet-api)
+* [Scala](../../../developers/scala/streamlet-api)
 <!-- * [Python](../../../developers/python/functional-api) -->
 
 > Although this document covers the new Heron Streamlet API, topologies created using the original [topology API](../../../concepts/topologies) can still be used with Heron (which means that all of your older topologies will still run).
 
 For a more in-depth conceptual guide to the new API, see [The Heron Streamlet API](../../../concepts/streamlet-api). A high-level overview can also be found in the section immediately [below](#the-heron-streamlet-api-vs-the-topology-api).
 
-## The Heron Streamlet API vs. the topology API
+## The Heron Streamlet API vs. The Topology API
 
-When Heron was first released, all Heron topologies needed to be written using an API based on the [Storm topology API](../topologies). Although this API is quite powerful (and can still be used), the **Heron Streamlet API** enables you to create topologies without needing to implement spouts and bolts directly or to connect spouts and bolts together.
+When Heron was first released, all Heron topologies needed to be written using an API based on the [Storm Topology API](../topologies). Although this API is quite powerful (and can still be used), the **Heron Streamlet API** enables you to create topologies without needing to implement spouts and bolts directly or to connect spouts and bolts together.
 
 Here are some crucial differences between the two APIs:
 
-Domain | Original topology API | Heron Streamlet API
+Domain | Original Topology API | Heron Streamlet API
 :------|:----------------------|:--------------------
 Programming style | Procedural, processing component based | Functional
 Abstraction level | **Low level**. Developers must think in terms of "physical" spout and bolt implementation logic. | **High level**. Developers can write processing logic in an idiomatic fashion in the language of their choice, without needing to write and connect spouts and bolts.

--- a/website/data/toc.yaml
+++ b/website/data/toc.yaml
@@ -32,7 +32,7 @@ sections:
         url: /docs/operators/deployment/configuration
       - name: The Heron API server
         url: /docs/operators/heron-api-server
-  - name: Topology development APIs
+  - name: Topology Development APIs
     sublinks:
     - name: The Heron Streamlet API for Java
       url: /docs/developers/java/streamlet-api


### PR DESCRIPTION
This PR aims the following changes:
- Enable Scala Streamlet API Documentation as public
- Documentation Fixes