### PR TITLE
[Java Streamlet API] Support Abstractions on Streamlet Sources

### DIFF
--- a/heron/api/src/java/org/apache/heron/streamlet/Source.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/Source.java
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-
 package org.apache.heron.streamlet;
 
 import java.io.Serializable;

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/sources/ComplexSource.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/sources/ComplexSource.java
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-
 package org.apache.heron.streamlet.impl.sources;
 
 import java.io.Serializable;
@@ -38,10 +36,9 @@ import org.apache.heron.streamlet.impl.ContextImpl;
  * to generate the next tuple.
  */
 public class ComplexSource<R> extends StreamletSource {
+
   private static final long serialVersionUID = -5086763670301450007L;
   private Source<R> generator;
-
-  private SpoutOutputCollector collector;
   private State<Serializable, Serializable> state;
 
   public ComplexSource(Source<R> generator) {
@@ -57,18 +54,16 @@ public class ComplexSource<R> extends StreamletSource {
   @Override
   public void open(Map<String, Object> map, TopologyContext topologyContext,
                    SpoutOutputCollector outputCollector) {
-    collector = outputCollector;
+    super.open(map, topologyContext, outputCollector);
     Context context = new ContextImpl(topologyContext, map, state);
     generator.setup(context);
   }
 
   @Override
   public void nextTuple() {
-    Collection<R> val = generator.get();
-    if (val != null) {
-      for (R tuple : val) {
-        collector.emit(new Values(tuple));
-      }
+    Collection<R> tuples = generator.get();
+    if (tuples != null) {
+      tuples.forEach(tuple -> collector.emit(new Values(tuple)));
     }
   }
 }

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/sources/StreamletSource.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/sources/StreamletSource.java
@@ -16,16 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-
 package org.apache.heron.streamlet.impl.sources;
 
 import java.io.Serializable;
+import java.util.Map;
 
 import org.apache.heron.api.spout.BaseRichSpout;
+import org.apache.heron.api.spout.SpoutOutputCollector;
 import org.apache.heron.api.state.State;
 import org.apache.heron.api.topology.IStatefulComponent;
 import org.apache.heron.api.topology.OutputFieldsDeclarer;
+import org.apache.heron.api.topology.TopologyContext;
 import org.apache.heron.api.tuple.Fields;
 
 /**
@@ -38,11 +39,20 @@ public abstract class StreamletSource extends BaseRichSpout
   private static final long serialVersionUID = 8583965332619565343L;
   private static final String OUTPUT_FIELD_NAME = "output";
 
+  protected SpoutOutputCollector collector;
+
   @Override
   public void initState(State<Serializable, Serializable> state) { }
 
   @Override
   public void preSave(String checkpointId) { }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public void open(Map<String, Object> map, TopologyContext topologyContext,
+                   SpoutOutputCollector outputCollector) {
+    collector = outputCollector;
+  }
 
   /**
    * The sources implementing streamlet functionality have some properties.

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/sources/SupplierSource.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/sources/SupplierSource.java
@@ -16,14 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-
 package org.apache.heron.streamlet.impl.sources;
 
-import java.util.Map;
-
-import org.apache.heron.api.spout.SpoutOutputCollector;
-import org.apache.heron.api.topology.TopologyContext;
 import org.apache.heron.api.tuple.Values;
 import org.apache.heron.streamlet.SerializableSupplier;
 
@@ -33,19 +27,12 @@ import org.apache.heron.streamlet.SerializableSupplier;
  * to generate the next tuple.
  */
 public class SupplierSource<R> extends StreamletSource {
+
   private static final long serialVersionUID = 6476611751545430216L;
   private SerializableSupplier<R> supplier;
 
-  private SpoutOutputCollector collector;
-
   public SupplierSource(SerializableSupplier<R> supplier) {
     this.supplier = supplier;
-  }
-
-  @SuppressWarnings("rawtypes")
-  @Override
-  public void open(Map map, TopologyContext topologyContext, SpoutOutputCollector outputCollector) {
-    collector = outputCollector;
   }
 
   @Override

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/SourceStreamlet.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/SourceStreamlet.java
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-
 package org.apache.heron.streamlet.impl.streamlets;
 
 import java.util.Set;

--- a/heron/api/tests/java/org/apache/heron/streamlet/impl/StreamletImplTest.java
+++ b/heron/api/tests/java/org/apache/heron/streamlet/impl/StreamletImplTest.java
@@ -19,6 +19,7 @@
 package org.apache.heron.streamlet.impl;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -42,6 +43,7 @@ import org.apache.heron.streamlet.IStreamletRichOperator;
 import org.apache.heron.streamlet.IStreamletWindowOperator;
 import org.apache.heron.streamlet.SerializableConsumer;
 import org.apache.heron.streamlet.SerializableTransformer;
+import org.apache.heron.streamlet.Source;
 import org.apache.heron.streamlet.Streamlet;
 import org.apache.heron.streamlet.WindowConfig;
 import org.apache.heron.streamlet.impl.streamlets.ConsumerStreamlet;
@@ -51,6 +53,7 @@ import org.apache.heron.streamlet.impl.streamlets.FlatMapStreamlet;
 import org.apache.heron.streamlet.impl.streamlets.JoinStreamlet;
 import org.apache.heron.streamlet.impl.streamlets.MapStreamlet;
 import org.apache.heron.streamlet.impl.streamlets.ReduceByKeyAndWindowStreamlet;
+import org.apache.heron.streamlet.impl.streamlets.SourceStreamlet;
 import org.apache.heron.streamlet.impl.streamlets.SpoutStreamlet;
 import org.apache.heron.streamlet.impl.streamlets.SupplierStreamlet;
 import org.apache.heron.streamlet.impl.streamlets.TransformStreamlet;
@@ -88,6 +91,12 @@ public class StreamletImplTest {
   public void testSupplierStreamlet() {
     Streamlet<Double> streamlet = builder.newSource(() -> Math.random());
     assertTrue(streamlet instanceof SupplierStreamlet);
+  }
+
+  @Test
+  public void testSourceStreamlet() {
+    Streamlet<String> streamlet = builder.newSource(new TestSource());
+    assertTrue(streamlet instanceof SourceStreamlet);
   }
 
   @Test
@@ -495,6 +504,25 @@ public class StreamletImplTest {
       fail("Should have thrown an IllegalArgumentException because streamlet name is invalid");
     } catch (IllegalArgumentException e) {
       assertEquals("Streamlet name cannot be null/blank", e.getMessage());
+    }
+  }
+
+  private class TestSource implements Source<String> {
+
+    private List<String> list;
+    @Override
+    public void setup(Context context) {
+      list = Arrays.asList("aa", "bb", "cc");
+    }
+
+    @Override
+    public Collection<String> get() {
+      return list;
+    }
+
+    @Override
+    public void cleanup() {
+      list.clear();
     }
   }
 


### PR DESCRIPTION
### Motivation
Currently, `Source` and `SupplierSource` extend `StreamletSource`. Common logic needs to move `StreamletSource`.

### Modifications
1- `SpoutOutputCollector` property has been moved to `StreamletSource`
2- `open` function has been moved to `StreamletSource`
3- UT is added

### Test Coverage
A new UT is added and Existing UTs cover this patch.