### PR TITLE
Support bazel 0.20.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,6 +22,7 @@ build --python2_path /usr/bin/python2.7
 build --spawn_strategy=standalone
 build --workspace_status_command scripts/release/status.sh
 
+
 # For centos
 # To use it: bazel build --config=centos
 build:centos --experimental_action_listener=tools/cpp:compile_cpp
@@ -60,6 +61,10 @@ build:darwin --ignore_unsupported_sandboxing
 build:darwin --python2_path /usr/bin/python2.7
 build:darwin --spawn_strategy=standalone
 build:darwin --workspace_status_command scripts/release/status.sh
+build:darwin --javacopt="-XepDisableAllChecks"
+build:darwin --javacopt="-source 8"
+build:darwin --javacopt="-target 8"
+
 
 # For Ubuntu
 # To use it: bazel build --config=ubuntu

--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,8 @@ build --ignore_unsupported_sandboxing
 build --python2_path /usr/bin/python2.7
 build --spawn_strategy=standalone
 build --workspace_status_command scripts/release/status.sh
+build --javacopt="-source 8"
+build --javacopt="-target 8"
 
 
 # For centos
@@ -62,8 +64,7 @@ build:darwin --python2_path /usr/bin/python2.7
 build:darwin --spawn_strategy=standalone
 build:darwin --workspace_status_command scripts/release/status.sh
 build:darwin --javacopt="-XepDisableAllChecks"
-build:darwin --javacopt="-source 8"
-build:darwin --javacopt="-target 8"
+
 
 
 # For Ubuntu

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ env:
 
 before_install:
   # download and install bazel
-  - wget -q 'https://github.com/bazelbuild/bazel/releases/download/0.14.1/bazel-0.14.1-installer-linux-x86_64.sh'
-  - chmod +x bazel-0.14.1-installer-linux-x86_64.sh
-  - ./bazel-0.14.1-installer-linux-x86_64.sh --user
+  - wget -q 'https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-installer-linux-x86_64.sh'
+  - chmod +x bazel-0.20.0-installer-linux-x86_64.sh
+  - ./bazel-0.20.0-installer-linux-x86_64.sh --user
 
 before_script:
   # install python module for wheel files

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -813,6 +813,8 @@ http_file(
     url = SETUPTOOLS_SRC,
 )
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 new_http_archive(
     name = "virtualenv",
     url = VIRTUALENV_SRC,
@@ -974,15 +976,19 @@ new_http_archive(
 )
 
 # scala integration
-rules_scala_version="5cdae2f034581a05e23c3473613b409de5978833" # update this as needed
+rules_scala_version="a89d44f7ef67d93dedfc9888630f48d7723516f7" # update this as needed
 
 http_archive(
-    name = "io_bazel_rules_scala",
-    url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip" % rules_scala_version,
-    type = "zip",
-    strip_prefix= "rules_scala-%s" % rules_scala_version,
-    sha256 = "bd66b178da5b9b6845f677bdfb2594de8f1050f831a8d69527c6737969376065",
+     name = "io_bazel_rules_scala",
+     url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip"%rules_scala_version,
+     type = "zip",
+     strip_prefix= "rules_scala-%s" % rules_scala_version,
+     sha256 = "e341dc30a397c77e6723a953d4a84539c050b49f163b4c50cf865c698ea598fe"
 )
 
+
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
+load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+scala_register_toolchains()
 scala_repositories()

--- a/examples/src/scala/BUILD
+++ b/examples/src/scala/BUILD
@@ -12,6 +12,7 @@ scala_binary(
         "//heron/api/src/scala:api-scala",
         "//third_party/java:kryo"
     ],
+     scalacopts = ["-target:jvm-1.8"],
     main_class = "org.apache.heron.examples.streamlet.scala.ScalaIntegerProcessingTopology"
 )
 

--- a/heron/api/src/scala/BUILD
+++ b/heron/api/src/scala/BUILD
@@ -5,6 +5,9 @@ package(default_visibility = ["//visibility:public"])
 scala_library(
     name = "api-scala",
     srcs = glob(["org/apache/heron/streamlet/scala/**/*.scala"]),
+    scalacopts = [
+     "-target:jvm-1.8"
+    ],
     deps = [
             "//heron/api/src/java:api-java-low-level",
             "//heron/api/src/java:api-java"


### PR DESCRIPTION
@kramasamy @nwangtw 

I expect this PR build to break.. I modified our bazel config to work with the newest release of Bazel.. I assuming that the changes I have made will not work with Bazel 0.14.1.  Just a FYI.

This PR allows Heron to be built with the latest version of Bazel (v0.20.0). There are a few file tree changes as well as global JDK arguments that are now passed as global options to each command to target JDK 8 now that Bazel version v0.20.0 defaults to using JDK 9.xxxx.  

The downside of this PR is that everyone who builds the system will have to update their workstation version of Bazel.  ~And CI will of course will have to have it's version  updated as well.~ <-- Took care of this