### PR TITLE
Refactor window operations to avoid WindowConfigImpl cast

### DIFF
--- a/heron/api/src/java/org/apache/heron/streamlet/WindowConfig.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/WindowConfig.java
@@ -23,10 +23,13 @@ package org.apache.heron.streamlet;
 
 import java.time.Duration;
 
+import org.apache.heron.api.bolt.BaseWindowedBolt;
 import org.apache.heron.api.tuple.Tuple;
 import org.apache.heron.api.windowing.EvictionPolicy;
 import org.apache.heron.api.windowing.TriggerPolicy;
-import org.apache.heron.streamlet.impl.WindowConfigImpl;
+import org.apache.heron.streamlet.impl.CountWindowConfig;
+import org.apache.heron.streamlet.impl.CustomWindowConfig;
+import org.apache.heron.streamlet.impl.TimeWindowConfig;
 
 /**
  * WindowConfig allows Streamlet API users to program window configuration for operations
@@ -35,12 +38,18 @@ import org.apache.heron.streamlet.impl.WindowConfigImpl;
  */
 public interface WindowConfig {
   /**
+   * Attach this WindowConfig object to a WindowedBolt
+   * @param bolt the windowed bolt to attach
+   */
+  void attachWindowConfig(BaseWindowedBolt bolt);
+
+  /**
    * Creates a time based tumbling window of windowDuration
    * @param windowDuration the duration of the tumbling window
    * @return WindowConfig that can be passed to the transformation
    */
   static WindowConfig TumblingTimeWindow(Duration windowDuration) {
-    return new WindowConfigImpl(windowDuration, windowDuration);
+    return new TimeWindowConfig(windowDuration, windowDuration);
   }
 
   /**
@@ -51,7 +60,7 @@ public interface WindowConfig {
    * @return WindowConfig that can be passed to the transformation
    */
   static WindowConfig SlidingTimeWindow(Duration windowDuration, Duration slideInterval) {
-    return new WindowConfigImpl(windowDuration, slideInterval);
+    return new TimeWindowConfig(windowDuration, slideInterval);
   }
 
   /**
@@ -60,7 +69,7 @@ public interface WindowConfig {
    * @return WindowConfig that can be passed to the transformation
    */
   static WindowConfig TumblingCountWindow(int windowSize) {
-    return new WindowConfigImpl(windowSize, windowSize);
+    return new CountWindowConfig(windowSize, windowSize);
   }
 
   /**
@@ -71,7 +80,7 @@ public interface WindowConfig {
    * @return WindowConfig that can be passed to the transformation
    */
   static WindowConfig SlidingCountWindow(int windowSize, int slideSize) {
-    return new WindowConfigImpl(windowSize, slideSize);
+    return new CountWindowConfig(windowSize, slideSize);
   }
 
   /**
@@ -82,6 +91,6 @@ public interface WindowConfig {
    */
   static WindowConfig CustomWindow(TriggerPolicy<Tuple, ?> triggerPolicy,
                                    EvictionPolicy<Tuple, ?> evictionPolicy) {
-    return new WindowConfigImpl(triggerPolicy, evictionPolicy);
+    return new CustomWindowConfig(triggerPolicy, evictionPolicy);
   }
 }

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/GeneralReduceByKeyAndWindowStreamlet.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/GeneralReduceByKeyAndWindowStreamlet.java
@@ -29,7 +29,6 @@ import org.apache.heron.streamlet.SerializableBiFunction;
 import org.apache.heron.streamlet.SerializableFunction;
 import org.apache.heron.streamlet.WindowConfig;
 import org.apache.heron.streamlet.impl.StreamletImpl;
-import org.apache.heron.streamlet.impl.WindowConfigImpl;
 import org.apache.heron.streamlet.impl.groupings.ReduceByKeyAndWindowCustomGrouping;
 import org.apache.heron.streamlet.impl.operators.GeneralReduceByKeyAndWindowOperator;
 
@@ -44,7 +43,7 @@ public class GeneralReduceByKeyAndWindowStreamlet<K, V, VR>
     extends StreamletImpl<KeyValue<KeyedWindow<K>, VR>> {
   private StreamletImpl<V> parent;
   private SerializableFunction<V, K> keyExtractor;
-  private WindowConfigImpl windowCfg;
+  private WindowConfig windowCfg;
   private VR identity;
   private SerializableBiFunction<VR, V, ? extends VR> reduceFn;
 
@@ -55,7 +54,7 @@ public class GeneralReduceByKeyAndWindowStreamlet<K, V, VR>
                             SerializableBiFunction<VR, V, ? extends VR> reduceFn) {
     this.parent = parent;
     this.keyExtractor = keyExtractor;
-    this.windowCfg = (WindowConfigImpl) windowCfg;
+    this.windowCfg = windowCfg;
     this.identity = identity;
     this.reduceFn = reduceFn;
     setNumPartitions(parent.getNumPartitions());
@@ -64,10 +63,10 @@ public class GeneralReduceByKeyAndWindowStreamlet<K, V, VR>
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefix.REDUCE, stageNames);
-    GeneralReduceByKeyAndWindowOperator<K, V, VR> bolt =
+    GeneralReduceByKeyAndWindowOperator<K, V, VR> operator =
         new GeneralReduceByKeyAndWindowOperator<K, V, VR>(keyExtractor, identity, reduceFn);
-    windowCfg.attachWindowConfig(bolt);
-    bldr.setBolt(getName(), bolt, getNumPartitions())
+    windowCfg.attachWindowConfig(operator);
+    bldr.setBolt(getName(), operator, getNumPartitions())
         .customGrouping(parent.getName(), parent.getStreamId(),
             new ReduceByKeyAndWindowCustomGrouping<K, V>(keyExtractor));
     return true;

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/JoinStreamlet.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/JoinStreamlet.java
@@ -30,7 +30,6 @@ import org.apache.heron.streamlet.SerializableBiFunction;
 import org.apache.heron.streamlet.SerializableFunction;
 import org.apache.heron.streamlet.WindowConfig;
 import org.apache.heron.streamlet.impl.StreamletImpl;
-import org.apache.heron.streamlet.impl.WindowConfigImpl;
 import org.apache.heron.streamlet.impl.groupings.JoinCustomGrouping;
 import org.apache.heron.streamlet.impl.operators.JoinOperator;
 
@@ -47,7 +46,7 @@ public final class JoinStreamlet<K, R, S, T> extends StreamletImpl<KeyValue<Keye
   private StreamletImpl<S> right;
   private SerializableFunction<R, K> leftKeyExtractor;
   private SerializableFunction<S, K> rightKeyExtractor;
-  private WindowConfigImpl windowCfg;
+  private WindowConfig windowCfg;
   private SerializableBiFunction<R, S, ? extends T> joinFn;
 
   public static <A, B, C, D> JoinStreamlet<A, B, C, D>
@@ -73,7 +72,7 @@ public final class JoinStreamlet<K, R, S, T> extends StreamletImpl<KeyValue<Keye
     this.right = right;
     this.leftKeyExtractor = leftKeyExtractor;
     this.rightKeyExtractor = rightKeyExtractor;
-    this.windowCfg = (WindowConfigImpl) windowCfg;
+    this.windowCfg = windowCfg;
     this.joinFn = joinFn;
     setNumPartitions(left.getNumPartitions());
   }

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/ReduceByKeyAndWindowStreamlet.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/ReduceByKeyAndWindowStreamlet.java
@@ -29,7 +29,6 @@ import org.apache.heron.streamlet.SerializableBinaryOperator;
 import org.apache.heron.streamlet.SerializableFunction;
 import org.apache.heron.streamlet.WindowConfig;
 import org.apache.heron.streamlet.impl.StreamletImpl;
-import org.apache.heron.streamlet.impl.WindowConfigImpl;
 import org.apache.heron.streamlet.impl.groupings.ReduceByKeyAndWindowCustomGrouping;
 import org.apache.heron.streamlet.impl.operators.ReduceByKeyAndWindowOperator;
 
@@ -45,7 +44,7 @@ public class ReduceByKeyAndWindowStreamlet<K, V, R>
   private StreamletImpl<R> parent;
   private SerializableFunction<R, K> keyExtractor;
   private SerializableFunction<R, V> valueExtractor;
-  private WindowConfigImpl windowCfg;
+  private WindowConfig windowCfg;
   private SerializableBinaryOperator<V> reduceFn;
 
   public ReduceByKeyAndWindowStreamlet(StreamletImpl<R> parent,
@@ -56,7 +55,7 @@ public class ReduceByKeyAndWindowStreamlet<K, V, R>
     this.parent = parent;
     this.keyExtractor = keyExtractor;
     this.valueExtractor = valueExtractor;
-    this.windowCfg = (WindowConfigImpl) windowCfg;
+    this.windowCfg = windowCfg;
     this.reduceFn = reduceFn;
     setNumPartitions(parent.getNumPartitions());
   }
@@ -64,10 +63,10 @@ public class ReduceByKeyAndWindowStreamlet<K, V, R>
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefix.REDUCE, stageNames);
-    ReduceByKeyAndWindowOperator<K, V, R> bolt = new ReduceByKeyAndWindowOperator<>(keyExtractor,
-        valueExtractor, reduceFn);
-    windowCfg.attachWindowConfig(bolt);
-    bldr.setBolt(getName(), bolt, getNumPartitions())
+    ReduceByKeyAndWindowOperator<K, V, R> operator =
+        new ReduceByKeyAndWindowOperator<>(keyExtractor, valueExtractor, reduceFn);
+    windowCfg.attachWindowConfig(operator);
+    bldr.setBolt(getName(), operator, getNumPartitions())
         .customGrouping(parent.getName(), parent.getStreamId(),
             new ReduceByKeyAndWindowCustomGrouping<K, R>(keyExtractor));
     return true;

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/windowings/CountWindowConfig.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/windowings/CountWindowConfig.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.streamlet.impl;
+
+import org.apache.heron.api.bolt.BaseWindowedBolt;
+import org.apache.heron.streamlet.WindowConfig;
+
+/**
+ * CountWindowConfig implements a count based WindowConfig.
+ */
+public final class CountWindowConfig implements WindowConfig {
+  private int windowSize;
+  private int slideInterval;
+
+  public CountWindowConfig(int windowSize, int slideInterval) {
+    this.windowSize = windowSize;
+    this.slideInterval = slideInterval;
+  }
+
+  public void attachWindowConfig(BaseWindowedBolt bolt) {
+    bolt.withWindow(BaseWindowedBolt.Count.of(windowSize),
+                    BaseWindowedBolt.Count.of(slideInterval));
+  }
+}

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/windowings/CustomWindowConfig.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/windowings/CustomWindowConfig.java
@@ -19,8 +19,6 @@
 
 package org.apache.heron.streamlet.impl;
 
-import java.time.Duration;
-
 import org.apache.heron.api.bolt.BaseWindowedBolt;
 import org.apache.heron.api.tuple.Tuple;
 import org.apache.heron.api.windowing.EvictionPolicy;
@@ -28,50 +26,21 @@ import org.apache.heron.api.windowing.TriggerPolicy;
 import org.apache.heron.streamlet.WindowConfig;
 
 /**
- * WindowConfigImpl implements the WindowConfig interface.
+ * CustomWindowConfig implements a trigger/eviction based WindowConfig.
  */
-public final class WindowConfigImpl implements WindowConfig {
-  private enum WindowType { TIME, COUNT, CUSTOM }
-  private WindowType windowType;
-  private int windowSize;
-  private int slideInterval;
-  private Duration windowDuration;
-  private Duration slidingIntervalDuration;
+public final class CustomWindowConfig implements WindowConfig {
   private TriggerPolicy<Tuple, ?> triggerPolicy;
   private EvictionPolicy<Tuple, ?> evictionPolicy;
 
-  public WindowConfigImpl(Duration windowDuration, Duration slidingIntervalDuration) {
-    this.windowType = WindowType.TIME;
-    this.windowDuration = windowDuration;
-    this.slidingIntervalDuration = slidingIntervalDuration;
-  }
-  public WindowConfigImpl(int windowSize, int slideInterval) {
-    this.windowType = WindowType.COUNT;
-    this.windowSize = windowSize;
-    this.slideInterval = slideInterval;
-  }
-  public WindowConfigImpl(TriggerPolicy<Tuple, ?> triggerPolicy,
+  public CustomWindowConfig(TriggerPolicy<Tuple, ?> triggerPolicy,
                           EvictionPolicy<Tuple, ?> evictionPolicy) {
-    this.windowType = WindowType.CUSTOM;
     this.triggerPolicy = triggerPolicy;
     this.evictionPolicy = evictionPolicy;
   }
 
+  @Override
   public void attachWindowConfig(BaseWindowedBolt bolt) {
-    switch(windowType) {
-      case COUNT:
-        bolt.withWindow(BaseWindowedBolt.Count.of(windowSize),
-                        BaseWindowedBolt.Count.of(slideInterval));
-        break;
-      case TIME:
-        bolt.withWindow(windowDuration, slidingIntervalDuration);
-        break;
-      case CUSTOM:
-        bolt.withCustomEvictor(evictionPolicy);
-        bolt.withCustomTrigger(triggerPolicy);
-        break;
-      default:
-        throw new RuntimeException("Unknown windowType " + String.valueOf(windowType));
-    }
+    bolt.withCustomEvictor(evictionPolicy);
+    bolt.withCustomTrigger(triggerPolicy);
   }
 }

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/windowings/TimeWindowConfig.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/windowings/TimeWindowConfig.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.streamlet.impl;
+
+import java.time.Duration;
+
+import org.apache.heron.api.bolt.BaseWindowedBolt;
+import org.apache.heron.streamlet.WindowConfig;
+
+/**
+ * TimeWindowConfig implements a time based WindowConfig.
+ */
+public final class TimeWindowConfig implements WindowConfig {
+  private Duration windowDuration;
+  private Duration slidingIntervalDuration;
+
+  public TimeWindowConfig(Duration windowDuration, Duration slidingIntervalDuration) {
+    this.windowDuration = windowDuration;
+    this.slidingIntervalDuration = slidingIntervalDuration;
+  }
+
+  @Override
+  public void attachWindowConfig(BaseWindowedBolt bolt) {
+    bolt.withWindow(windowDuration, slidingIntervalDuration);
+  }
+}


### PR DESCRIPTION
- The WindowConfigImpl has a type variable and a select block. Refactor them into separated class to make the code more readable.
- Add an attachWindowConfig() function in WindowConfig interface to avoid casting in code.