### PR TITLE
Add KVStreamlet and keyBy() operation

### DIFF
--- a/heron/api/src/java/org/apache/heron/streamlet/KVStreamlet.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/KVStreamlet.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.streamlet;
+
+import org.apache.heron.classification.InterfaceStability;
+
+/**
+ * A KVStreamlet is a Streamlet with KeyValue data.
+ */
+@InterfaceStability.Evolving
+public interface KVStreamlet<K, V> extends Streamlet<KeyValue<K, V>> {
+}

--- a/heron/api/src/java/org/apache/heron/streamlet/Streamlet.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/Streamlet.java
@@ -145,7 +145,7 @@ public interface Streamlet<R> {
    * have. Typical windowing strategies are sliding windows and tumbling windows
    * @param joinFunction The join function that needs to be applied
    */
-  <K, S, T> Streamlet<KeyValue<KeyedWindow<K>, T>>
+  <K, S, T> KVStreamlet<KeyedWindow<K>, T>
         join(Streamlet<S> other, SerializableFunction<R, K> thisKeyExtractor,
              SerializableFunction<S, K> otherKeyExtractor, WindowConfig windowCfg,
              SerializableBiFunction<R, S, ? extends T> joinFunction);
@@ -166,7 +166,7 @@ public interface Streamlet<R> {
    * @param joinType Type of Join. Options {@link JoinType}
    * @param joinFunction The join function that needs to be applied
    */
-  <K, S, T> Streamlet<KeyValue<KeyedWindow<K>, T>>
+  <K, S, T> KVStreamlet<KeyedWindow<K>, T>
         join(Streamlet<S> other, SerializableFunction<R, K> thisKeyExtractor,
              SerializableFunction<S, K> otherKeyExtractor, WindowConfig windowCfg,
              JoinType joinType, SerializableBiFunction<R, S, ? extends T> joinFunction);
@@ -181,7 +181,7 @@ public interface Streamlet<R> {
    * Typical windowing strategies are sliding windows and tumbling windows
    * @param reduceFn The reduce function that you want to apply to all the values of a key.
    */
-  <K, V> Streamlet<KeyValue<KeyedWindow<K>, V>> reduceByKeyAndWindow(
+  <K, V> KVStreamlet<KeyedWindow<K>, V> reduceByKeyAndWindow(
       SerializableFunction<R, K> keyExtractor, SerializableFunction<R, V> valueExtractor,
       WindowConfig windowCfg, SerializableBinaryOperator<V> reduceFn);
 
@@ -198,7 +198,7 @@ public interface Streamlet<R> {
    * @param reduceFn The reduce function takes two parameters: a partial result of the reduction
    * and the next element of the stream. It returns a new partial result.
    */
-  <K, T> Streamlet<KeyValue<KeyedWindow<K>, T>> reduceByKeyAndWindow(
+  <K, T> KVStreamlet<KeyedWindow<K>, T> reduceByKeyAndWindow(
       SerializableFunction<R, K> keyExtractor, WindowConfig windowCfg,
       T identity, SerializableBiFunction<T, R, ? extends T> reduceFn);
 
@@ -242,6 +242,21 @@ public interface Streamlet<R> {
    * Note that there could be 0 or multiple target stream ids
    */
   Streamlet<R> split(Map<String, SerializablePredicate<R>> splitFns);
+
+  /**
+   * Return a new KVStreamlet<K, R> by applying key extractor to each element of this Streamlet
+   * @param keyExtractor The function applied to a tuple of this streamlet to get the key
+   */
+  <K> KVStreamlet<K, R> keyBy(SerializableFunction<R, K> keyExtractor);
+
+  /**
+   * Return a new KVStreamlet<K, V> by applying key and value extractor to each element of this
+   * Streamlet
+   * @param keyExtractor The function applied to a tuple of this streamlet to get the key
+   * @param valueExtractor The function applied to a tuple of this streamlet to extract the value
+   */
+  <K, V> KVStreamlet<K, V> keyBy(SerializableFunction<R, K> keyExtractor,
+                                 SerializableFunction<R, V> valueExtractor);
 
   /**
    * Logs every element of the streamlet using String.valueOf function

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/KVStreamletImpl.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/KVStreamletImpl.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.heron.streamlet.impl;
+
+import org.apache.heron.streamlet.KVStreamlet;
+import org.apache.heron.streamlet.KeyValue;
+
+/**
+ * A KVStreamlet is a Streamlet with KeyValue data.
+ */
+public abstract class KVStreamletImpl<K, V>
+    extends StreamletImpl<KeyValue<K, V>>
+    implements KVStreamlet<K, V> {
+}

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/operators/KeyByOperator.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/operators/KeyByOperator.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.streamlet.impl.operators;
+
+import org.apache.heron.api.tuple.Tuple;
+import org.apache.heron.api.tuple.Values;
+import org.apache.heron.streamlet.KeyValue;
+import org.apache.heron.streamlet.SerializableFunction;
+
+/**
+ * KeyByOperator is the class that implements keyBy functionality.
+ * It takes in a key extractor and a value extractor as input.
+ * For every tuple, the bolt convert the steam to a key-value pair tuple
+ * by applying the extractors.
+ */
+public class KeyByOperator<R, K, V> extends StreamletOperator<R, KeyValue<K, V>> {
+  private SerializableFunction<R, K> keyExtractor;
+  private SerializableFunction<R, V> valueExtractor;
+
+  public KeyByOperator(SerializableFunction<R, K> keyExtractor,
+                       SerializableFunction<R, V> valueExtractor) {
+    this.keyExtractor = keyExtractor;
+    this.valueExtractor = valueExtractor;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void execute(Tuple tuple) {
+    R obj = (R) tuple.getValue(0);
+    K key = keyExtractor.apply(obj);
+    V value = valueExtractor.apply(obj);
+
+    collector.emit(new Values(new KeyValue<>(key, value)));
+    collector.ack(tuple);
+  }
+}

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/operators/KeyByOperator.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/operators/KeyByOperator.java
@@ -27,7 +27,7 @@ import org.apache.heron.streamlet.SerializableFunction;
 /**
  * KeyByOperator is the class that implements keyBy functionality.
  * It takes in a key extractor and a value extractor as input.
- * For every tuple, the bolt convert the steam to a key-value pair tuple
+ * For every tuple, the bolt convert the stream to a key-value pair tuple
  * by applying the extractors.
  */
 public class KeyByOperator<R, K, V> extends StreamletOperator<R, KeyValue<K, V>> {

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/GeneralReduceByKeyAndWindowStreamlet.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/GeneralReduceByKeyAndWindowStreamlet.java
@@ -23,11 +23,11 @@ package org.apache.heron.streamlet.impl.streamlets;
 import java.util.Set;
 
 import org.apache.heron.api.topology.TopologyBuilder;
-import org.apache.heron.streamlet.KeyValue;
 import org.apache.heron.streamlet.KeyedWindow;
 import org.apache.heron.streamlet.SerializableBiFunction;
 import org.apache.heron.streamlet.SerializableFunction;
 import org.apache.heron.streamlet.WindowConfig;
+import org.apache.heron.streamlet.impl.KVStreamletImpl;
 import org.apache.heron.streamlet.impl.StreamletImpl;
 import org.apache.heron.streamlet.impl.groupings.ReduceByKeyAndWindowCustomGrouping;
 import org.apache.heron.streamlet.impl.operators.GeneralReduceByKeyAndWindowOperator;
@@ -40,7 +40,7 @@ import org.apache.heron.streamlet.impl.operators.GeneralReduceByKeyAndWindowOper
  * KeyWindowInfo&lt;K&gt; type and the value is of type T.
  */
 public class GeneralReduceByKeyAndWindowStreamlet<R, K, T>
-    extends StreamletImpl<KeyValue<KeyedWindow<K>, T>> {
+    extends KVStreamletImpl<KeyedWindow<K>, T> {
   private StreamletImpl<R> parent;
   private SerializableFunction<R, K> keyExtractor;
   private WindowConfig windowCfg;

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/JoinStreamlet.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/JoinStreamlet.java
@@ -24,11 +24,11 @@ import java.util.Set;
 
 import org.apache.heron.api.topology.TopologyBuilder;
 import org.apache.heron.streamlet.JoinType;
-import org.apache.heron.streamlet.KeyValue;
 import org.apache.heron.streamlet.KeyedWindow;
 import org.apache.heron.streamlet.SerializableBiFunction;
 import org.apache.heron.streamlet.SerializableFunction;
 import org.apache.heron.streamlet.WindowConfig;
+import org.apache.heron.streamlet.impl.KVStreamletImpl;
 import org.apache.heron.streamlet.impl.StreamletImpl;
 import org.apache.heron.streamlet.impl.groupings.JoinCustomGrouping;
 import org.apache.heron.streamlet.impl.operators.JoinOperator;
@@ -40,7 +40,7 @@ import org.apache.heron.streamlet.impl.operators.JoinOperator;
  * JoinStreamlet's elements are of KeyValue type where the key is KeyWindowInfo&lt;K&gt; type
  * and the value is of type VR.
  */
-public final class JoinStreamlet<K, R, S, T> extends StreamletImpl<KeyValue<KeyedWindow<K>, T>> {
+public final class JoinStreamlet<K, R, S, T> extends KVStreamletImpl<KeyedWindow<K>, T> {
   private JoinType joinType;
   private StreamletImpl<R> left;
   private StreamletImpl<S> right;

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/KeyByStreamlet.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/streamlets/KeyByStreamlet.java
@@ -26,7 +26,6 @@ import org.apache.heron.api.topology.TopologyBuilder;
 import org.apache.heron.streamlet.SerializableFunction;
 import org.apache.heron.streamlet.impl.KVStreamletImpl;
 import org.apache.heron.streamlet.impl.StreamletImpl;
-import org.apache.heron.streamlet.impl.groupings.ReduceByKeyAndWindowCustomGrouping;
 import org.apache.heron.streamlet.impl.operators.KeyByOperator;
 
 /**
@@ -52,9 +51,7 @@ public class KeyByStreamlet<R, K, V> extends KVStreamletImpl<K, V> {
     setDefaultNameIfNone(StreamletNamePrefix.KEYBY, stageNames);
     KeyByOperator<R, K, V> bolt = new KeyByOperator<>(keyExtractor, valueExtractor);
     bldr.setBolt(getName(), bolt, getNumPartitions())
-        .customGrouping(parent.getName(), parent.getStreamId(),
-            // TODO: rename this grouping class to be more general
-            new ReduceByKeyAndWindowCustomGrouping<K, R>(keyExtractor));
+        .shuffleGrouping(parent.getName(), parent.getStreamId());
     return true;
   }
 }

--- a/heron/api/src/scala/org/apache/heron/streamlet/scala/KVStreamlet.scala
+++ b/heron/api/src/scala/org/apache/heron/streamlet/scala/KVStreamlet.scala
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.heron.streamlet.scala
+
+import org.apache.heron.streamlet.KeyValue
+
+/**
+ * A KVStreamlet is a Streamlet with KeyValue data.
+ */
+trait KVStreamlet[K, V] extends Streamlet[KeyValue[K, V]] {
+}

--- a/heron/api/src/scala/org/apache/heron/streamlet/scala/Streamlet.scala
+++ b/heron/api/src/scala/org/apache/heron/streamlet/scala/Streamlet.scala
@@ -265,6 +265,20 @@ trait Streamlet[R] {
   def split(splitFns: Map[String, R => Boolean]): Streamlet[R]
 
   /**
+   * Return a new KVStreamlet<K, R> by applying key extractor to each element of this Streamlet
+   * @param keyExtractor The function applied to a tuple of this streamlet to get the key
+   */
+  def keyBy[K](keyExtractor: R => K): KVStreamlet[K, R]
+
+  /**
+   * Return a new KVStreamlet<K, V> by applying key and value extractor to each element of this
+   * Streamlet
+   * @param keyExtractor The function applied to a tuple of this streamlet to get the key
+   * @param valueExtractor The function applied to a tuple of this streamlet to extract the value
+   */
+  def keyBy[K, T](keyExtractor: R => K, valueExtractor: R => T): KVStreamlet[K, T]
+
+  /**
     * Logs every element of the streamlet using String.valueOf function
     * This is one of the sink functions in the sense that this operation returns void
     */

--- a/heron/api/src/scala/org/apache/heron/streamlet/scala/impl/KVStreamletImpl.scala
+++ b/heron/api/src/scala/org/apache/heron/streamlet/scala/impl/KVStreamletImpl.scala
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.heron.streamlet.scala.impl
+
+import org.apache.heron.streamlet.{
+  KVStreamlet => JavaKVStreamlet,
+  Streamlet => JavaStreamlet
+}
+import org.apache.heron.streamlet.scala.KVStreamlet
+
+object KVStreamletImpl {
+  def fromJavaKVStreamlet[K, V](javaKVStreamlet: JavaKVStreamlet[K, V]): KVStreamlet[K, V] =
+    new KVStreamletImpl[K, V](javaKVStreamlet)
+
+  def toJavaKVStreamlet[K, V](streamlet: KVStreamlet[K, V]): JavaKVStreamlet[K, V] =
+    streamlet.asInstanceOf[KVStreamletImpl[K, V]].javaKVStreamlet
+}
+
+/**
+ * This class provides Scala Streamlet Implementation by wrapping Java Streamlet API.
+ * Passed User defined Scala Functions are transformed to related FunctionalInterface versions and
+ * related Java Streamlet is transformed to Scala version again.
+ */
+class KVStreamletImpl[K, V](val javaKVStreamlet: JavaKVStreamlet[K, V])
+    extends StreamletImpl(javaKVStreamlet) with KVStreamlet[K, V] {
+}

--- a/heron/api/tests/java/BUILD
+++ b/heron/api/tests/java/BUILD
@@ -29,6 +29,7 @@ java_tests(
     "org.apache.heron.api.bolt.BaseWindowedBoltTest",
     "org.apache.heron.streamlet.impl.StreamletImplTest",
     "org.apache.heron.streamlet.impl.operators.JoinOperatorTest",
+    "org.apache.heron.streamlet.impl.operators.KeyByOperatorTest",
     "org.apache.heron.streamlet.impl.operators.ReduceByKeyAndWindowOperatorTest",
     "org.apache.heron.streamlet.impl.operators.GeneralReduceByKeyAndWindowOperatorTest",
     "org.apache.heron.streamlet.impl.utils.StreamletUtilsTest",

--- a/heron/api/tests/java/org/apache/heron/streamlet/impl/StreamletImplTest.java
+++ b/heron/api/tests/java/org/apache/heron/streamlet/impl/StreamletImplTest.java
@@ -44,6 +44,7 @@ import org.apache.heron.streamlet.Context;
 import org.apache.heron.streamlet.IStreamletBasicOperator;
 import org.apache.heron.streamlet.IStreamletRichOperator;
 import org.apache.heron.streamlet.IStreamletWindowOperator;
+import org.apache.heron.streamlet.KVStreamlet;
 import org.apache.heron.streamlet.SerializableConsumer;
 import org.apache.heron.streamlet.SerializablePredicate;
 import org.apache.heron.streamlet.SerializableTransformer;
@@ -55,6 +56,7 @@ import org.apache.heron.streamlet.impl.streamlets.CustomStreamlet;
 import org.apache.heron.streamlet.impl.streamlets.FilterStreamlet;
 import org.apache.heron.streamlet.impl.streamlets.FlatMapStreamlet;
 import org.apache.heron.streamlet.impl.streamlets.JoinStreamlet;
+import org.apache.heron.streamlet.impl.streamlets.KeyByStreamlet;
 import org.apache.heron.streamlet.impl.streamlets.MapStreamlet;
 import org.apache.heron.streamlet.impl.streamlets.ReduceByKeyAndWindowStreamlet;
 import org.apache.heron.streamlet.impl.streamlets.SourceStreamlet;
@@ -350,6 +352,20 @@ public class StreamletImplTest {
     SupplierStreamlet<Double> supplierStreamlet = (SupplierStreamlet<Double>) baseStreamlet;
     assertEquals(supplierStreamlet.getChildren().size(), 1);
     assertEquals(supplierStreamlet.getChildren().get(0), streamlet);
+  }
+
+  @Test
+  public void testKeyByStreamlet() {
+    Streamlet<Double> baseStreamlet = builder.newSource(() -> Math.random());
+    KVStreamlet<Long, Double> kvStream = baseStreamlet.keyBy(x -> Math.round(x));
+
+    assertTrue(kvStream instanceof KeyByStreamlet);
+    KeyByStreamlet<Double, Long, Double> mStreamlet =
+        (KeyByStreamlet<Double, Long, Double>) kvStream;
+    assertEquals(1, mStreamlet.getNumPartitions());
+    SupplierStreamlet<Double> supplierStreamlet = (SupplierStreamlet<Double>) baseStreamlet;
+    assertEquals(supplierStreamlet.getChildren().size(), 1);
+    assertEquals(supplierStreamlet.getChildren().get(0), kvStream);
   }
 
   @Test

--- a/heron/api/tests/java/org/apache/heron/streamlet/impl/operators/KeyByOperatorTest.java
+++ b/heron/api/tests/java/org/apache/heron/streamlet/impl/operators/KeyByOperatorTest.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.streamlet.impl.operators;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.api.mockito.PowerMockito;
+
+import org.apache.heron.api.Config;
+import org.apache.heron.api.bolt.IOutputCollector;
+import org.apache.heron.api.bolt.OutputCollector;
+import org.apache.heron.api.generated.TopologyAPI;
+import org.apache.heron.api.topology.TopologyBuilder;
+import org.apache.heron.api.topology.TopologyContext;
+import org.apache.heron.api.tuple.Fields;
+import org.apache.heron.api.tuple.Tuple;
+import org.apache.heron.api.tuple.Values;
+import org.apache.heron.common.utils.topology.TopologyContextImpl;
+import org.apache.heron.common.utils.tuple.TupleImpl;
+import org.apache.heron.streamlet.KeyValue;
+
+public class KeyByOperatorTest {
+
+  private List<Object> emittedTuples;
+
+  @Before
+  public void setUp() {
+    emittedTuples = new LinkedList<>();
+  }
+
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void testKeyByOperator() {
+    KeyByOperator<String, String, Integer> keyByOperator = getKeyByOperator();
+
+    HashMap<String, Integer> expectedResults = new HashMap<>();
+    expectedResults.put("even", 0);
+    expectedResults.put("odd", 1);
+    expectedResults.put("even", 2);
+
+    TopologyAPI.StreamId componentStreamId
+        = TopologyAPI.StreamId.newBuilder()
+        .setComponentName("sourceComponent").setId("default").build();
+
+    keyByOperator.execute(getTuple(componentStreamId, new Fields("a"), new Values("0")));
+    keyByOperator.execute(getTuple(componentStreamId, new Fields("a"), new Values("1")));
+    keyByOperator.execute(getTuple(componentStreamId, new Fields("a"), new Values("2")));
+
+    Assert.assertEquals(3, emittedTuples.size());
+    String[] s = {"even", "odd"};
+    for (Object object : emittedTuples) {
+      KeyValue<String, Integer> tuple = (KeyValue<String, Integer>) object;
+      Assert.assertEquals(s[tuple.getValue() % 2], tuple.getKey());
+    }
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private KeyByOperator<String, String, Integer> getKeyByOperator() {
+    KeyByOperator<String, String, Integer> keyByOperator =
+        new KeyByOperator<String, String, Integer>(
+            x -> (Integer.valueOf(x) % 2 == 0) ? "even" : "odd",
+            x -> Integer.valueOf(x));
+
+    keyByOperator.prepare(new Config(), PowerMockito.mock(TopologyContext.class),
+        new OutputCollector(new IOutputCollector() {
+
+          @Override
+          public void reportError(Throwable error) {
+          }
+
+          @Override
+          public List<Integer> emit(String streamId,
+                                    Collection<Tuple> anchors, List<Object> tuple) {
+            emittedTuples.addAll(tuple);
+            return null;
+          }
+
+          @Override
+          public void emitDirect(int taskId, String streamId,
+                                 Collection<Tuple> anchors, List<Object> tuple) {
+          }
+
+          @Override
+          public void ack(Tuple input) {
+          }
+
+          @Override
+          public void fail(Tuple input) {
+          }
+        }));
+    return keyByOperator;
+  }
+
+  private Tuple getTuple(TopologyAPI.StreamId streamId, final Fields fields, Values values) {
+
+    TopologyContext topologyContext = getContext(fields);
+    return new TupleImpl(topologyContext, streamId, 0,
+        null, values, 1) {
+      @Override
+      public TopologyAPI.StreamId getSourceGlobalStreamId() {
+        return TopologyAPI.StreamId.newBuilder().setComponentName("sourceComponent")
+            .setId("default").build();
+      }
+    };
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private TopologyContext getContext(final Fields fields) {
+    TopologyBuilder builder = new TopologyBuilder();
+    return new TopologyContextImpl(new Config(),
+        builder.createTopology()
+            .setConfig(new Config())
+            .setName("test")
+            .setState(TopologyAPI.TopologyState.RUNNING)
+            .getTopology(),
+        new HashMap(), 1, null) {
+      @Override
+      public Fields getComponentOutputFields(
+          String componentId, String streamId) {
+        return fields;
+      }
+
+    };
+  }
+}

--- a/heron/api/tests/scala/org/apache/heron/streamlet/scala/impl/StreamletImplTest.scala
+++ b/heron/api/tests/scala/org/apache/heron/streamlet/scala/impl/StreamletImplTest.scala
@@ -40,6 +40,7 @@ import org.apache.heron.streamlet.impl.streamlets.{
   FlatMapStreamlet,
   LogStreamlet,
   JoinStreamlet,
+  KeyByStreamlet,
   MapStreamlet,
   ReduceByKeyAndWindowStreamlet,
   RemapStreamlet,
@@ -636,6 +637,33 @@ class StreamletImplTest extends BaseFunSuite {
     assertEquals("Reduce_Streamlet_1", mapStreamlet.getName)
     assertEquals(5, mapStreamlet.getNumPartitions)
     assertEquals(0, mapStreamlet.getChildren.size())
+  }
+
+  test("StreamletImpl should support keyBy operation") {
+    val supplierStreamlet = builder
+      .newSource(() => Random.nextInt(10))
+      .setName("Supplier_Streamlet_1")
+      .setNumPartitions(3)
+
+    supplierStreamlet
+      .keyBy[Int, Int]((key: Int) => key % 3,  // Put into 3 groups
+                       (value: Int) => value)
+      .setName("KeyBy_Streamlet_1")
+      .setNumPartitions(5)
+
+    val supplierStreamletImpl =
+      supplierStreamlet.asInstanceOf[StreamletImpl[Int]]
+    assertEquals(1, supplierStreamletImpl.getChildren.size)
+    assertTrue(
+      supplierStreamletImpl
+        .getChildren(0)
+        .isInstanceOf[KeyByStreamlet[_, _, _]])
+    val keyByStreamlet = supplierStreamletImpl
+      .getChildren(0)
+      .asInstanceOf[KeyByStreamlet[Int, Int, Int]]
+    assertEquals("KeyBy_Streamlet_1", keyByStreamlet.getName)
+    assertEquals(5, keyByStreamlet.getNumPartitions)
+    assertEquals(0, keyByStreamlet.getChildren.size())
   }
 
   private def verifyClonedStreamlets[R](supplierStreamlet: Streamlet[R],


### PR DESCRIPTION
Currently Streamlet is the only interface with data type R. Key value is fairly common in streaming process in more complicated jobs. But with a single interface, it is impossible to have special functions for kv data.

Regular reduceByKeyAndWindow() function and future aggregation functions could have simpler signature with a new KVStreamlet interface and the operations can be chained. User code could also be cleaner and more readable.

For example (assuming reduce, count and sum functions are available):

Streamlet<KeyValue<Integer, Integer>> reduced = stream  // Streamlet<Integer>
  .reduceByKey(Integer x -> x % 10, .....);

reduced
  .countByKey(KeyValue<Integer, Integer> x -> x.getKey())
  .log();

reduced.
  .sumByKey(KeyValue<Integer, Integer> x -> x.getKey(),
                      KeyValue<Integer, Integer> x -> x.getValue() * getWeight(x.getKey()))
  .log();

can be written into:

KVStreamlet<Integer, Integer> reduced = stream  // Streamlet<Integer>
  .reduceByKey(Integer x -> x % 10, .....)

reduced.countByKey().log
reduced.sumByKey((Integer key, Integer value) -> value * getWeight(key)).log


Note that reduceByKey, countByKey and sumByKey can also have shorter function names in KVStreamlet.
