### PR TITLE
Add CumulativeCountMetric and metrics to monitor instance task

### DIFF
--- a/heron/api/src/java/org/apache/heron/api/metric/CumulativeCountMetric.java
+++ b/heron/api/src/java/org/apache/heron/api/metric/CumulativeCountMetric.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.api.metric;
+
+/**
+ * This is a different kind of counter that value is not
+ * reset after fetched.
+ */
+public class CumulativeCountMetric extends CountMetric {
+  @Override
+  public Long getValueAndReset() {
+    // Return value without resetting.
+    return getValue();
+  }
+}

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/IBoltMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/IBoltMetrics.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.common.utils.metrics;
+
+import org.apache.heron.common.utils.misc.PhysicalPlanHelper;
+import org.apache.heron.common.utils.topology.TopologyContextImpl;
+
+/**
+ * Bolt's metrics to be collect
+ * We need to:
+ * 1. Define the metrics to be collected
+ * 2. New them in the constructor
+ * 3. Register them in registerMetrics(...) by using MetricsCollector's registerMetric(...)
+ * 4. Expose methods which could be called externally to change the value of metrics
+ */
+
+public interface IBoltMetrics extends ComponentMetrics {
+  void registerMetrics(TopologyContextImpl topologyContext);
+
+  // For MultiCountMetrics, we need to set the default value for all streams.
+  // Otherwise, it is possible one metric for a particular stream is null.
+  // For instance, the fail-count on a particular stream could be undefined
+  // causing metrics not be exported.
+  // However, it will not set the Multi Reduced/Assignable Metrics,
+  // since we could not have default values for them
+  void initMultiCountMetrics(PhysicalPlanHelper helper);
+
+  void ackedTuple(String streamId, String sourceComponent, long latency);
+
+  void failedTuple(String streamId, String sourceComponent, long latency);
+
+  void executeTuple(String streamId, String sourceComponent, long latency);
+
+  void updateOutQueueFullCount();
+
+  void deserializeDataTuple(String streamId, String sourceComponent, long latency);
+
+  void serializeDataTuple(String streamId, long latency);
+
+  void updateTaskRunCount();
+
+  void updateExecutionCount();
+
+  void updateContinueWorkCount();
+}

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/ISpoutMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/ISpoutMetrics.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.common.utils.metrics;
+
+import org.apache.heron.common.utils.misc.PhysicalPlanHelper;
+import org.apache.heron.common.utils.topology.TopologyContextImpl;
+
+
+/**
+ * Spout's metrics to be collect
+ * We need to:
+ * 1. Define the metrics to be collected
+ * 2. New them in the constructor
+ * 3. Register them in registerMetrics(...) by using MetricsCollector's registerMetric(...)
+ * 4. Expose methods which could be called externally to change the value of metrics
+ */
+
+public interface ISpoutMetrics extends ComponentMetrics {
+
+  void registerMetrics(TopologyContextImpl topologyContext);
+
+  // For MultiCountMetrics, we need to set the default value for all streams.
+  // Otherwise, it is possible one metric for a particular stream is null.
+  // For instance, the fail-count on a particular stream could be undefined
+  // causing metrics not be exported.
+  // However, it will not set the Multi Reduced/Assignable Metrics,
+  // since we could not have default values for them
+  void initMultiCountMetrics(PhysicalPlanHelper helper);
+
+  void ackedTuple(String streamId, long latency);
+
+  void failedTuple(String streamId, long latency);
+
+  void timeoutTuple(String streamId);
+
+  void nextTuple(long latency);
+
+  void updateOutQueueFullCount();
+
+  void updatePendingTuplesCount(long count);
+
+  void updateTaskRunCount();
+
+  void updateProduceTupleCount();
+
+  void updateContinueWorkCount();
+}

--- a/heron/instance/src/java/org/apache/heron/instance/bolt/BoltOutputCollectorImpl.java
+++ b/heron/instance/src/java/org/apache/heron/instance/bolt/BoltOutputCollectorImpl.java
@@ -33,7 +33,7 @@ import org.apache.heron.api.bolt.IOutputCollector;
 import org.apache.heron.api.serializer.IPluggableSerializer;
 import org.apache.heron.api.tuple.Tuple;
 import org.apache.heron.common.basics.Communicator;
-import org.apache.heron.common.utils.metrics.BoltMetrics;
+import org.apache.heron.common.utils.metrics.IBoltMetrics;
 import org.apache.heron.common.utils.misc.PhysicalPlanHelper;
 import org.apache.heron.common.utils.tuple.TupleImpl;
 import org.apache.heron.instance.AbstractOutputCollector;
@@ -61,12 +61,12 @@ public class BoltOutputCollectorImpl extends AbstractOutputCollector implements 
   private static final Logger LOG = Logger.getLogger(BoltOutputCollectorImpl.class.getName());
 
   // Reference to update the bolt metrics
-  private final BoltMetrics boltMetrics;
+  private final IBoltMetrics boltMetrics;
 
   protected BoltOutputCollectorImpl(IPluggableSerializer serializer,
                                     PhysicalPlanHelper helper,
                                     Communicator<Message> streamOutQueue,
-                                    BoltMetrics boltMetrics) {
+                                    IBoltMetrics boltMetrics) {
     super(serializer, helper, streamOutQueue, boltMetrics);
     this.boltMetrics = boltMetrics;
 

--- a/heron/instance/src/java/org/apache/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/org/apache/heron/instance/spout/SpoutInstance.java
@@ -46,7 +46,7 @@ import org.apache.heron.common.basics.SlaveLooper;
 import org.apache.heron.common.basics.TypeUtils;
 import org.apache.heron.common.config.SystemConfig;
 import org.apache.heron.common.utils.metrics.FullSpoutMetrics;
-import org.apache.heron.common.utils.metrics.SpoutMetrics;
+import org.apache.heron.common.utils.metrics.ISpoutMetrics;
 import org.apache.heron.common.utils.misc.PhysicalPlanHelper;
 import org.apache.heron.common.utils.misc.SerializeDeSerializeHelper;
 import org.apache.heron.common.utils.topology.TopologyContextImpl;
@@ -60,7 +60,7 @@ public class SpoutInstance implements IInstance {
 
   protected final ISpout spout;
   protected final SpoutOutputCollectorImpl collector;
-  protected final SpoutMetrics spoutMetrics;
+  protected final ISpoutMetrics spoutMetrics;
   // The spout will read Control tuples from streamInQueue
   private final Communicator<Message> streamInQueue;
 
@@ -255,8 +255,11 @@ public class SpoutInstance implements IInstance {
     Runnable spoutTasks = new Runnable() {
       @Override
       public void run() {
+        spoutMetrics.updateTaskRunCount();
+
         // Check whether we should produce more tuples
         if (isProduceTuple()) {
+          spoutMetrics.updateProduceTupleCount();
           produceTuple();
           // Though we may execute MAX_READ tuples, finally we will packet it as
           // one outgoingPacket and push to out queues
@@ -281,6 +284,7 @@ public class SpoutInstance implements IInstance {
 
         // If we have more work to do
         if (isContinueWork()) {
+          spoutMetrics.updateContinueWorkCount();
           looper.wakeUp();
         }
       }


### PR DESCRIPTION
An internal user reported that in some edge case, spout instance could stop for a while. So far it is hard to tell the root cause but it seems like the spout task is not triggered. In this PR:
- added a new cumulative count metric.
- refactored SpoutMetrics and BoltMetrics.
- added metrics to monitor spout and bolt task runs and metric collector run.


Tested:
1. Build package and install cli.
2. Start an example topology: ~/.heron/bin/heron submit local   ~/.heron/examples/heron-streamlet-examples.jar   org.apache.heron.examples.streamlet.WindowedWordCountTopology   WindowedWordCountTopology
3. Open metrics log file and verify: vim ~/.herondata/topologies/local/nwang/WindowedWordCountTopology/metrics.json.metricsmgr-1.1
4. Stop topology:  ~/.heron/bin/heron kill local   WindowedWordCountTopology