### PR TITLE
Fix docker rc and scripts for building heron

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -1,6 +1,7 @@
 # Docker
 
 ## To compile source, into Heron release artifacts, using a docker container:
+Make sure enough resources are configured in Docker settings: 2 CPU, 4G RAM and 128G disk.
 ```
 ./docker/scripts/build-artifacts.sh <platform> <version_string> [source-tarball] <output-directory>
 # e.g.  ./docker/scripts/build-artifacts.sh ubuntu14.04 testbuild ~/heron-release

--- a/docker/scripts/build-exec-docker.sh
+++ b/docker/scripts/build-exec-docker.sh
@@ -49,7 +49,7 @@ build_exec_image() {
   HERON_VERSION=$2
   OUTPUT_DIRECTORY=$(realpath $3)
 
-  DOCKER_FILE="$SCRATCH_DIR/Dockerfile.dist.$TARGET_PLATFORM"
+  DOCKER_FILE="$SCRATCH_DIR/dist/Dockerfile.dist.$TARGET_PLATFORM"
   DOCKER_TAG="heron:$HERON_VERSION-$TARGET_PLATFORM"
 
   setup_scratch_dir $SCRATCH_DIR

--- a/docker/scripts/compile-platform.sh
+++ b/docker/scripts/compile-platform.sh
@@ -57,6 +57,7 @@ else
   exit 1
 fi
 
+bazel version
 ./bazel_configure.py
 bazel clean
 

--- a/tools/docker/bazel.rc
+++ b/tools/docker/bazel.rc
@@ -24,3 +24,11 @@ build --verbose_failures
 # fails to run tests.
 build --spawn_strategy=standalone --genrule_strategy=standalone
 test --test_strategy=standalone
+
+# Workaround https://github.com/bazelbuild/bazel/issues/3645
+# Bazel doesn't calculate the memory ceiling correctly when running under Docker.
+# Limit Bazel to consuming 4G ram and 2 cores.
+build --local_resources=4096,2.0,1.0
+
+# Echo all the configuration settings and their source
+ build --announce_rc

--- a/website/content/docs/operators/deployment/schedulers/dcos.md
+++ b/website/content/docs/operators/deployment/schedulers/dcos.md
@@ -78,7 +78,7 @@ bucket).
 * `heron.executor.docker.image` --- Specified the Docker image to be used for running the executor.
 For the time being, a public image has been made available at `ndustrialio/heron-executor:jre8`. 
 However, you can create your own version of this Docker image by creating a Docker image with
-the Dockerfile provided at `heron/docker/Dockerfile.dist.ubuntu14.04` and pushing it to your own 
+the Dockerfile provided at `heron/docker/dist/Dockerfile.dist.ubuntu14.04` and pushing it to your own
 publicly-available Docker repository.
 
 ### Example Marathon Scheduler Configuration


### PR DESCRIPTION
I was getting the following error when building heron for centos and ubunto on mac using docker.

ERROR: /scratch/heron/proto/BUILD:141:1: Building heron/proto/libproto_ckptmgr_java.jar (1 source jar) failed: Worker process quit or closed its stdin str
eam when we tried to send a WorkRequest:

---8<---8<--- Exception details ---8<---8<---
java.io.IOException: Stream closed
       at java.lang.ProcessBuilder$NullOutputStream.write(ProcessBuilder.java:433)
       at java.io.OutputStream.write(OutputStream.java:116)


The PR added lines to specify resource limitation in bazel and I can build now.

$ ./docker/scripts/build-artifacts.sh centos7 testbuild ~/heron-release