### PR TITLE
Refactor StreamletShadow class to be more general

### DIFF
--- a/heron/api/src/java/org/apache/heron/streamlet/impl/StreamletImpl.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/StreamletImpl.java
@@ -231,9 +231,12 @@ public abstract class StreamletImpl<R> implements Streamlet<R> {
 
     Set<String> availableIds = getAvailableStreamIds();
     if (availableIds.contains(streamId)) {
-      StreamletShadow<R> shadow = new StreamletShadow<R>(this);
-      shadow.setStreamId(streamId);
-      return shadow;
+      return new StreamletShadow<R>(this) {
+        @Override
+        public String getStreamId() {
+          return streamId;
+        }
+      };
     } else {
       throw new RuntimeException(
           String.format("Stream id %s is not available in %s. Available ids are: %s.",

--- a/heron/api/src/java/org/apache/heron/streamlet/impl/StreamletShadow.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/impl/StreamletShadow.java
@@ -53,20 +53,9 @@ import org.apache.heron.streamlet.impl.StreamletImpl;
  */
 public class StreamletShadow<R> extends StreamletImpl<R> {
   private StreamletImpl<R> real;
-  // Extra properties for a Streamlet object
-  protected String streamId;
 
   public StreamletShadow(StreamletImpl<R> real) {
     this.real = real;
-    this.streamId = real.getStreamId();
-  }
-
-  /**
-   * Sets the stream id of this Streamlet.
-   * @param streamId the stream id for this streamlet.
-   */
-  public void setStreamId(String streamId) {
-    this.streamId = streamId;
   }
 
   /**
@@ -75,7 +64,7 @@ public class StreamletShadow<R> extends StreamletImpl<R> {
    */
   @Override
   public String getStreamId() {
-    return streamId;
+    return real.getStreamId();
   }
 
   /*

--- a/heron/api/tests/java/org/apache/heron/streamlet/impl/StreamletShadowTest.java
+++ b/heron/api/tests/java/org/apache/heron/streamlet/impl/StreamletShadowTest.java
@@ -56,13 +56,20 @@ public class StreamletShadowTest {
     assertEquals(shadow.getStreamId(), "real_stream");
 
     // set a different stream id
-    shadow.setStreamId("shadow_stream");
+    StreamletShadow<Double> shadow2 = new StreamletShadow(mockReal) {
+      @Override
+      public String getStreamId() {
+        return "shadow_stream";
+      }
+    };
+    assertEquals(shadow.getName(), "real_name");
+    assertEquals(shadow.getNumPartitions(), 1);
     assertEquals(shadow.getStreamId(), "shadow_stream");
 
     // addChild call should be forwarded to the real object
     verify(mockReal, never()).addChild(mockChild);
     shadow.addChild(mockChild);
-    verify(mockReal, times(1)).addChild(mockChild);
+    shadow2.addChild(mockChild);
+    verify(mockReal, times(2)).addChild(mockChild);
   }
-
 }


### PR DESCRIPTION
Clean up StreamletShadow class to be more general, so that it can be used for other Streamlet features.