### PR TITLE
Update integration test runner to support language and test selection

### DIFF
--- a/scripts/run_integration_test.sh
+++ b/scripts/run_integration_test.sh
@@ -18,6 +18,16 @@
 #
 # Script to locally run the functional integration test.
 #
+# Usage:
+#   run_integration_test.sh [language] [test pattern]
+# Examples:
+# Run all tests in all languages:
+#   run_integration_test.sh
+# Run all tests in a specific language:
+#   run_integration_test.sh java
+# Run specific tests in a specific language:
+#   run_integration_test.sh java IntegrationTest_Streamlet_.*
+
 
 HTTP_SERVER="./bazel-bin/integration_test/src/python/http_server/http-server"
 TEST_RUNNER="./bazel-bin/integration_test/src/python/test_runner/test-runner.pex"
@@ -25,6 +35,34 @@ TEST_RUNNER="./bazel-bin/integration_test/src/python/test_runner/test-runner.pex
 JAVA_TESTS_DIR="integration_test/src/java/org/apache/heron/integration_test/topology"
 PYTHON_TESTS_DIR="integration_test/src/python/integration_test/topology"
 SCALA_TESTS_DIR="integration_test/src/scala/org/apache/heron/integration_test/topology"
+
+# Parse arguments
+LANGUAGE="all"
+TESTS_PATTERN=".*"
+if [ "$1" != "" ]; then
+  if [ "$1" == "--help" ] || [ "$1" == "-h" ];then
+    echo "Usage:"
+    echo "  run_integration_test.sh [language] [test name pattern]"
+    echo "Exampes:"
+    echo "Run all tests in all languages:"
+    echo "  run_integration_test.sh"
+    echo "Run all tests in a specific language:"
+    echo "  run_integration_test.sh java"
+    echo "Run specific tests in a specific language:"
+    echo "  run_integration_test.sh java IntegrationTest_Streamlet_.*"
+    exit 0
+  fi
+
+  LANGUAGE=$1
+
+  # Parameter 2 is test pattern
+  if [ "$2" != "" ]; then
+    TESTS_PATTERN=$2
+  fi
+fi
+
+echo "Topology language is: " $LANGUAGE
+echo "Topology filter pattern is: " $TESTS_PATTERN
 
 # integration test binaries have to be specified as absolute path
 JAVA_INTEGRATION_TESTS_BIN="${PWD}/bazel-genfiles/integration_test/src/java/integration-tests.jar"
@@ -47,22 +85,34 @@ http_server_id=$!
 trap "kill -9 $http_server_id" SIGINT SIGTERM EXIT
 
 # run the scala integration tests
-${TEST_RUNNER} \
-  -hc ~/.heron/bin/heron -tb ${SCALA_INTEGRATION_TESTS_BIN} \
-  -rh localhost -rp 8080 \
-  -tp ${SCALA_TESTS_DIR} \
-  -cl local -rl heron-staging -ev devel -pi ${CORE_PKG}
+if [ "$LANGUAGE" = "all" ] || [ "$LANGUAGE" = "scala" ]; then
+  echo "Run the Scala integration tests"
+  ${TEST_RUNNER} \
+    -hc ~/.heron/bin/heron -tb ${SCALA_INTEGRATION_TESTS_BIN} \
+    -rh localhost -rp 8080 \
+    -tp ${SCALA_TESTS_DIR} \
+    -cl local -rl heron-staging -ev devel -pi ${CORE_PKG} \
+    -ts ${TESTS_PATTERN}
+fi
 
 # run the java integration tests
-${TEST_RUNNER} \
-  -hc ~/.heron/bin/heron -tb ${JAVA_INTEGRATION_TESTS_BIN} \
-  -rh localhost -rp 8080 \
-  -tp ${JAVA_TESTS_DIR} \
-  -cl local -rl heron-staging -ev devel -pi ${CORE_PKG}
+if [ "$LANGUAGE" = "all" ] || [ "$LANGUAGE" = "java" ]; then
+echo "Run the Java integration tests"
+  ${TEST_RUNNER} \
+    -hc ~/.heron/bin/heron -tb ${JAVA_INTEGRATION_TESTS_BIN} \
+    -rh localhost -rp 8080 \
+    -tp ${JAVA_TESTS_DIR} \
+    -cl local -rl heron-staging -ev devel -pi ${CORE_PKG} \
+    -ts ${TESTS_PATTERN}
+fi
 
 # run the python integration tests
-${TEST_RUNNER} \
-  -hc ~/.heron/bin/heron -tb ${PYTHON_INTEGRATION_TESTS_BIN} \
-  -rh localhost -rp 8080 \
-  -tp ${PYTHON_TESTS_DIR} \
-  -cl local -rl heron-staging -ev devel -pi ${CORE_PKG}
+if [ "$LANGUAGE" = "all" ] || [ "$LANGUAGE" = "python" ]; then
+echo "Run the Python integration tests"
+  ${TEST_RUNNER} \
+    -hc ~/.heron/bin/heron -tb ${PYTHON_INTEGRATION_TESTS_BIN} \
+    -rh localhost -rp 8080 \
+    -tp ${PYTHON_TESTS_DIR} \
+    -cl local -rl heron-staging -ev devel -pi ${CORE_PKG} \
+    -ts ${TESTS_PATTERN}
+fi


### PR DESCRIPTION
Currently integration test script runs all integration test topologies which is painful for development of new integration tests.

In this PR, user can select language (like Java) and test pattern (like IntegrationTest_Streamlet_.*) to run specific tests.

Usage:
  run_integration_test.sh [language] [test pattern]
Examples:
Run all tests in all languages:
  run_integration_test.sh
Run all tests in a specific language:
  run_integration_test.sh java
Run specific tests in a specific language:
  run_integration_test.sh java IntegrationTest_Streamlet_.*