### PR TITLE
Validate resource constraint (RAM and CPU) in RoundRobinPacking

### DIFF
--- a/examples/src/java/org/apache/heron/examples/api/ExampleResources.java
+++ b/examples/src/java/org/apache/heron/examples/api/ExampleResources.java
@@ -23,7 +23,9 @@ import org.apache.heron.common.basics.ByteAmount;
 
 public final class ExampleResources {
 
+  static final long DEFAULT_RAM_PADDING_PER_CONTAINER = 2 * 1024;
   static final long COMPONENT_RAM_MB = 1024;
+  static final double DEFAULT_CPU_PADDING_PER_CONTAINER = 1.0;
 
   static ByteAmount getComponentRam() {
     return ByteAmount.fromMegabytes(COMPONENT_RAM_MB);
@@ -35,12 +37,13 @@ public final class ExampleResources {
 
   static ByteAmount getContainerRam(int components, int containers) {
     final int componentsPerContainer = Math.max(components / containers, 1);
-    return ByteAmount.fromMegabytes(COMPONENT_RAM_MB * (componentsPerContainer + 2));
+    return ByteAmount.fromMegabytes(COMPONENT_RAM_MB * componentsPerContainer
+        + DEFAULT_RAM_PADDING_PER_CONTAINER);
   }
 
   static double getContainerCpu(int components, int containers) {
     final int componentsPerContainer = Math.max(components / containers, 1);
-    return componentsPerContainer + 1.0;
+    return componentsPerContainer + DEFAULT_CPU_PADDING_PER_CONTAINER;
   }
 
   private ExampleResources() {

--- a/examples/src/java/org/apache/heron/examples/api/ExampleResources.java
+++ b/examples/src/java/org/apache/heron/examples/api/ExampleResources.java
@@ -35,7 +35,12 @@ public final class ExampleResources {
 
   static ByteAmount getContainerRam(int components, int containers) {
     final int componentsPerContainer = Math.max(components / containers, 1);
-    return ByteAmount.fromMegabytes(COMPONENT_RAM_MB * componentsPerContainer);
+    return ByteAmount.fromMegabytes(COMPONENT_RAM_MB * (componentsPerContainer + 2));
+  }
+
+  static double getContainerCpu(int components, int containers) {
+    final int componentsPerContainer = Math.max(components / containers, 1);
+    return componentsPerContainer + 1.0;
   }
 
   private ExampleResources() {

--- a/examples/src/java/org/apache/heron/examples/api/WordCountTopology.java
+++ b/examples/src/java/org/apache/heron/examples/api/WordCountTopology.java
@@ -188,12 +188,16 @@ public final class WordCountTopology {
     conf.setComponentRam("consumer",
         ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB));
 
+    conf.setComponentCpu("word", 1.0);
+    conf.setComponentCpu("consumer", 1.0);
+
     // configure container resources
     conf.setContainerDiskRequested(
         ExampleResources.getContainerDisk(2 * parallelism, parallelism));
     conf.setContainerRamRequested(
         ExampleResources.getContainerRam(2 * parallelism, parallelism));
-    conf.setContainerCpuRequested(2);
+    conf.setContainerCpuRequested(
+        ExampleResources.getContainerCpu(2 * parallelism, parallelism));
 
     HeronSubmitter.submitTopology(args[0], conf, builder.createTopology());
   }

--- a/heron/common/src/java/org/apache/heron/common/basics/ByteAmount.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/ByteAmount.java
@@ -22,7 +22,7 @@ package org.apache.heron.common.basics;
 /**
  * Class that encapsulates number of bytes, with helpers to handle units properly.
  */
-public final class ByteAmount extends ResourceMeasure<ByteAmount, Long> {
+public final class ByteAmount extends ResourceMeasure<Long> {
   private static final long KB = 1024L;
   private static final long MB = KB * 1024;
   private static final long GB = MB * 1024;
@@ -131,7 +131,7 @@ public final class ByteAmount extends ResourceMeasure<ByteAmount, Long> {
    * @throws IllegalArgumentException if subtraction would overshoot Long.MIN_VALUE
    */
   @Override
-  public ByteAmount minus(ByteAmount other) {
+  public ByteAmount minus(ResourceMeasure<Long> other) {
     checkArgument(Long.MIN_VALUE + other.value <= value,
         String.format("Subtracting %s from %s would overshoot Long.MIN_LONG", other, this));
     return ByteAmount.fromBytes(value - other.value);
@@ -144,7 +144,7 @@ public final class ByteAmount extends ResourceMeasure<ByteAmount, Long> {
    * @throws IllegalArgumentException if addition would exceed Long.MAX_VALUE
    */
   @Override
-  public ByteAmount plus(ByteAmount other) {
+  public ByteAmount plus(ResourceMeasure<Long> other) {
     checkArgument(Long.MAX_VALUE - value >= other.value,
         String.format("Adding %s to %s would exceed Long.MAX_LONG", other, this));
     return ByteAmount.fromBytes(value + other.value);

--- a/heron/common/src/java/org/apache/heron/common/basics/ByteAmount.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/ByteAmount.java
@@ -22,7 +22,7 @@ package org.apache.heron.common.basics;
 /**
  * Class that encapsulates number of bytes, with helpers to handle units properly.
  */
-public final class ByteAmount implements Comparable<ByteAmount> {
+public final class ByteAmount implements ResourceMeasure<ByteAmount> {
   private static final long KB = 1024L;
   private static final long MB = KB * 1024;
   private static final long GB = MB * 1024;

--- a/heron/common/src/java/org/apache/heron/common/basics/ByteAmount.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/ByteAmount.java
@@ -203,24 +203,6 @@ public final class ByteAmount extends ResourceMeasure<Long> {
   }
 
   @Override
-  public boolean equals(Object other) {
-    if (this == other) {
-      return true;
-    }
-    if (!(other instanceof ByteAmount)) {
-      return false;
-    }
-
-    ByteAmount that = (ByteAmount) other;
-    return value.equals(that.value);
-  }
-
-  @Override
-  public int hashCode() {
-    return (int) (value ^ (value >>> 32));
-  }
-
-  @Override
   public String toString() {
     String str;
     if (asGigabytes() > 0) {

--- a/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
@@ -87,7 +87,7 @@ public final class CPUShare implements ResourceMeasure<CPUShare> {
     return cpuShare <= other.cpuShare;
   }
 
-  public static Map<String, CPUShare> fromDoubleMap(Map<String, Double> doubleMap) {
+  public static Map<String, CPUShare> convertDoubleMapToCpuShareMap(Map<String, Double> doubleMap) {
     Map<String, CPUShare> retval = new HashMap<>();
     for (Map.Entry<String, Double> entry : doubleMap.entrySet()) {
       retval.put(entry.getKey(), new CPUShare(entry.getValue()));
@@ -120,6 +120,6 @@ public final class CPUShare implements ResourceMeasure<CPUShare> {
 
   @Override
   public String toString() {
-    return super.toString();
+    return String.format("CPUShare{%.3f}", cpuShare);
   }
 }

--- a/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
@@ -22,7 +22,7 @@ package org.apache.heron.common.basics;
 import java.util.HashMap;
 import java.util.Map;
 
-public final class CPUShare extends ResourceMeasure<CPUShare, Double> {
+public final class CPUShare extends ResourceMeasure<Double> {
 
   private CPUShare(Double value) {
     super(value);
@@ -33,12 +33,12 @@ public final class CPUShare extends ResourceMeasure<CPUShare, Double> {
   }
 
   @Override
-  public CPUShare minus(CPUShare other) {
+  public CPUShare minus(ResourceMeasure<Double> other) {
     return new CPUShare(value - other.value);
   }
 
   @Override
-  public CPUShare plus(CPUShare other) {
+  public CPUShare plus(ResourceMeasure<Double> other) {
     return new CPUShare(value + other.value);
   }
 

--- a/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
@@ -22,69 +22,39 @@ package org.apache.heron.common.basics;
 import java.util.HashMap;
 import java.util.Map;
 
-public final class CPUShare implements ResourceMeasure<CPUShare> {
-  private final Double share;
+public final class CPUShare extends ResourceMeasure<CPUShare, Double> {
 
-  private CPUShare(Double share) {
-    this.share = share;
+  private CPUShare(Double value) {
+    super(value);
   }
 
-  public static CPUShare fromDouble(double share) {
-    return new CPUShare(share);
-  }
-
-  public Double getShare() {
-    return share;
-  }
-
-  @Override
-  public boolean isZero() {
-    return share == 0.0;
+  public static CPUShare fromDouble(double value) {
+    return new CPUShare(value);
   }
 
   @Override
   public CPUShare minus(CPUShare other) {
-    return new CPUShare(share - other.share);
+    return new CPUShare(value - other.value);
   }
 
   @Override
   public CPUShare plus(CPUShare other) {
-    return new CPUShare(share + other.share);
+    return new CPUShare(value + other.value);
   }
 
   @Override
   public CPUShare multiply(int factor) {
-    return new CPUShare(share * factor);
+    return new CPUShare(value * factor);
   }
 
   @Override
   public CPUShare divide(int factor) {
-    return new CPUShare(share / factor);
+    return new CPUShare(value / factor);
   }
 
   @Override
   public CPUShare increaseBy(int percentage) {
-    return new CPUShare(share * (1.0 + percentage / 100.0));
-  }
-
-  @Override
-  public boolean greaterThan(CPUShare other) {
-    return share > other.share;
-  }
-
-  @Override
-  public boolean greaterOrEqual(CPUShare other) {
-    return share >= other.share;
-  }
-
-  @Override
-  public boolean lessThan(CPUShare other) {
-    return share < other.share;
-  }
-
-  @Override
-  public boolean lessOrEqual(CPUShare other) {
-    return share <= other.share;
+    return new CPUShare(value * (1.0 + percentage / 100.0));
   }
 
   public static Map<String, CPUShare> convertDoubleMapToCpuShareMap(Map<String, Double> doubleMap) {
@@ -96,13 +66,8 @@ public final class CPUShare implements ResourceMeasure<CPUShare> {
   }
 
   @Override
-  public int compareTo(CPUShare o) {
-    return Double.compare(share, o.share);
-  }
-
-  @Override
   public int hashCode() {
-    return share.hashCode();
+    return value.hashCode();
   }
 
   @Override
@@ -115,11 +80,11 @@ public final class CPUShare implements ResourceMeasure<CPUShare> {
     }
 
     CPUShare that = (CPUShare) other;
-    return share.equals(that.share);
+    return value.equals(that.value);
   }
 
   @Override
   public String toString() {
-    return String.format("CPUShare{%.3f}", share);
+    return String.format("CPUShare{%.3f}", value);
   }
 }

--- a/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
@@ -66,24 +66,6 @@ public final class CPUShare extends ResourceMeasure<Double> {
   }
 
   @Override
-  public int hashCode() {
-    return value.hashCode();
-  }
-
-  @Override
-  public boolean equals(Object other) {
-    if (this == other) {
-      return true;
-    }
-    if (!(other instanceof CPUShare)) {
-      return false;
-    }
-
-    CPUShare that = (CPUShare) other;
-    return value.equals(that.value);
-  }
-
-  @Override
   public String toString() {
     return String.format("CPUShare{%.3f}", value);
   }

--- a/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
@@ -1,29 +1,36 @@
-//  Licensed to the Apache Software Foundation (ASF) under one
-//  or more contributor license agreements.  See the NOTICE file
-//  distributed with this work for additional information
-//  regarding copyright ownership.  The ASF licenses this file
-//  to you under the Apache License, Version 2.0 (the
-//  "License"); you may not use this file except in compliance
-//  with the License.  You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing,
-//  software distributed under the License is distributed on an
-//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-//  KIND, either express or implied.  See the License for the
-//  specific language governing permissions and limitations
-//  under the License.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.heron.common.basics;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class CPUShare implements ResourceMeasure<CPUShare> {
+public final class CPUShare implements ResourceMeasure<CPUShare> {
   private final Double cpuShare;
 
-  public CPUShare(Double cpuShare) {
+  private CPUShare(Double cpuShare) {
     this.cpuShare = cpuShare;
+  }
+
+  public static CPUShare fromDouble(double share) {
+    return new CPUShare(share);
   }
 
   public Double getCpuShare() {

--- a/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
@@ -23,68 +23,68 @@ import java.util.HashMap;
 import java.util.Map;
 
 public final class CPUShare implements ResourceMeasure<CPUShare> {
-  private final Double cpuShare;
+  private final Double share;
 
-  private CPUShare(Double cpuShare) {
-    this.cpuShare = cpuShare;
+  private CPUShare(Double share) {
+    this.share = share;
   }
 
   public static CPUShare fromDouble(double share) {
     return new CPUShare(share);
   }
 
-  public Double getCpuShare() {
-    return cpuShare;
+  public Double getShare() {
+    return share;
   }
 
   @Override
   public boolean isZero() {
-    return cpuShare == 0.0;
+    return share == 0.0;
   }
 
   @Override
   public CPUShare minus(CPUShare other) {
-    return new CPUShare(cpuShare - other.cpuShare);
+    return new CPUShare(share - other.share);
   }
 
   @Override
   public CPUShare plus(CPUShare other) {
-    return new CPUShare(cpuShare + other.cpuShare);
+    return new CPUShare(share + other.share);
   }
 
   @Override
   public CPUShare multiply(int factor) {
-    return new CPUShare(cpuShare * factor);
+    return new CPUShare(share * factor);
   }
 
   @Override
   public CPUShare divide(int factor) {
-    return new CPUShare(cpuShare / factor);
+    return new CPUShare(share / factor);
   }
 
   @Override
   public CPUShare increaseBy(int percentage) {
-    return new CPUShare(cpuShare * (1.0 + percentage / 100.0));
+    return new CPUShare(share * (1.0 + percentage / 100.0));
   }
 
   @Override
   public boolean greaterThan(CPUShare other) {
-    return cpuShare > other.cpuShare;
+    return share > other.share;
   }
 
   @Override
   public boolean greaterOrEqual(CPUShare other) {
-    return cpuShare >= other.cpuShare;
+    return share >= other.share;
   }
 
   @Override
   public boolean lessThan(CPUShare other) {
-    return cpuShare < other.cpuShare;
+    return share < other.share;
   }
 
   @Override
   public boolean lessOrEqual(CPUShare other) {
-    return cpuShare <= other.cpuShare;
+    return share <= other.share;
   }
 
   public static Map<String, CPUShare> convertDoubleMapToCpuShareMap(Map<String, Double> doubleMap) {
@@ -97,12 +97,12 @@ public final class CPUShare implements ResourceMeasure<CPUShare> {
 
   @Override
   public int compareTo(CPUShare o) {
-    return Double.compare(cpuShare, o.cpuShare);
+    return Double.compare(share, o.share);
   }
 
   @Override
   public int hashCode() {
-    return cpuShare.hashCode();
+    return share.hashCode();
   }
 
   @Override
@@ -110,16 +110,16 @@ public final class CPUShare implements ResourceMeasure<CPUShare> {
     if (this == other) {
       return true;
     }
-    if (other == null || getClass() != other.getClass()) {
+    if (!(other instanceof CPUShare)) {
       return false;
     }
 
     CPUShare that = (CPUShare) other;
-    return cpuShare.equals(that.cpuShare);
+    return share.equals(that.share);
   }
 
   @Override
   public String toString() {
-    return String.format("CPUShare{%.3f}", cpuShare);
+    return String.format("CPUShare{%.3f}", share);
   }
 }

--- a/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/CPUShare.java
@@ -1,0 +1,118 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+package org.apache.heron.common.basics;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CPUShare implements ResourceMeasure<CPUShare> {
+  private final Double cpuShare;
+
+  public CPUShare(Double cpuShare) {
+    this.cpuShare = cpuShare;
+  }
+
+  public Double getCpuShare() {
+    return cpuShare;
+  }
+
+  @Override
+  public boolean isZero() {
+    return cpuShare == 0.0;
+  }
+
+  @Override
+  public CPUShare minus(CPUShare other) {
+    return new CPUShare(cpuShare - other.cpuShare);
+  }
+
+  @Override
+  public CPUShare plus(CPUShare other) {
+    return new CPUShare(cpuShare + other.cpuShare);
+  }
+
+  @Override
+  public CPUShare multiply(int factor) {
+    return new CPUShare(cpuShare * factor);
+  }
+
+  @Override
+  public CPUShare divide(int factor) {
+    return new CPUShare(cpuShare / factor);
+  }
+
+  @Override
+  public CPUShare increaseBy(int percentage) {
+    return new CPUShare(cpuShare * (1.0 + percentage / 100.0));
+  }
+
+  @Override
+  public boolean greaterThan(CPUShare other) {
+    return cpuShare > other.cpuShare;
+  }
+
+  @Override
+  public boolean greaterOrEqual(CPUShare other) {
+    return cpuShare >= other.cpuShare;
+  }
+
+  @Override
+  public boolean lessThan(CPUShare other) {
+    return cpuShare < other.cpuShare;
+  }
+
+  @Override
+  public boolean lessOrEqual(CPUShare other) {
+    return cpuShare <= other.cpuShare;
+  }
+
+  public static Map<String, CPUShare> fromDoubleMap(Map<String, Double> doubleMap) {
+    Map<String, CPUShare> retval = new HashMap<>();
+    for (Map.Entry<String, Double> entry : doubleMap.entrySet()) {
+      retval.put(entry.getKey(), new CPUShare(entry.getValue()));
+    }
+    return retval;
+  }
+
+  @Override
+  public int compareTo(CPUShare o) {
+    return Double.compare(cpuShare, o.cpuShare);
+  }
+
+  @Override
+  public int hashCode() {
+    return cpuShare.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    CPUShare that = (CPUShare) other;
+    return cpuShare.equals(that.cpuShare);
+  }
+
+  @Override
+  public String toString() {
+    return super.toString();
+  }
+}

--- a/heron/common/src/java/org/apache/heron/common/basics/ResourceMeasure.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/ResourceMeasure.java
@@ -1,0 +1,40 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+package org.apache.heron.common.basics;
+
+public interface ResourceMeasure<T> extends Comparable<T> {
+
+  boolean isZero();
+
+  T minus(T other);
+
+  T plus(T other);
+
+  T multiply(int factor);
+
+  T divide(int factor);
+
+  T increaseBy(int percentage);
+
+  boolean greaterThan(T other);
+
+  boolean greaterOrEqual(T other);
+
+  boolean lessThan(T other);
+
+  boolean lessOrEqual(T other);
+}

--- a/heron/common/src/java/org/apache/heron/common/basics/ResourceMeasure.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/ResourceMeasure.java
@@ -19,8 +19,8 @@
 
 package org.apache.heron.common.basics;
 
-public abstract class ResourceMeasure<T extends ResourceMeasure, V extends Number & Comparable>
-    implements Comparable<T> {
+public abstract class ResourceMeasure<V extends Number & Comparable>
+    implements Comparable<ResourceMeasure<V>> {
 
   protected final V value;
 
@@ -39,39 +39,39 @@ public abstract class ResourceMeasure<T extends ResourceMeasure, V extends Numbe
     return value.doubleValue() == 0.0;
   }
 
-  public abstract T minus(T other);
+  public abstract ResourceMeasure<V> minus(ResourceMeasure<V> other);
 
-  public abstract T plus(T other);
+  public abstract ResourceMeasure<V> plus(ResourceMeasure<V> other);
 
-  public abstract T multiply(int factor);
+  public abstract ResourceMeasure<V> multiply(int factor);
 
-  public abstract T divide(int factor);
+  public abstract ResourceMeasure<V> divide(int factor);
 
-  public abstract T increaseBy(int percentage);
+  public abstract ResourceMeasure<V> increaseBy(int percentage);
 
   @SuppressWarnings("unchecked")
-  public boolean greaterThan(T other) {
+  public boolean greaterThan(ResourceMeasure<V> other) {
     return value.compareTo(other.value) > 0;
   }
 
   @SuppressWarnings("unchecked")
-  public boolean greaterOrEqual(T other) {
+  public boolean greaterOrEqual(ResourceMeasure<V> other) {
     return value.compareTo(other.value) >= 0;
   }
 
   @SuppressWarnings("unchecked")
-  public boolean lessThan(T other) {
+  public boolean lessThan(ResourceMeasure<V> other) {
     return value.compareTo(other.value) < 0;
   }
 
   @SuppressWarnings("unchecked")
-  public boolean lessOrEqual(T other) {
+  public boolean lessOrEqual(ResourceMeasure<V> other) {
     return value.compareTo(other.value) <= 0;
   }
 
   @SuppressWarnings("unchecked")
   @Override
-  public int compareTo(T o) {
+  public int compareTo(ResourceMeasure<V> o) {
     return value.compareTo(o.value);
   }
 }

--- a/heron/common/src/java/org/apache/heron/common/basics/ResourceMeasure.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/ResourceMeasure.java
@@ -19,25 +19,59 @@
 
 package org.apache.heron.common.basics;
 
-public interface ResourceMeasure<T> extends Comparable<T> {
+public abstract class ResourceMeasure<T extends ResourceMeasure, V extends Number & Comparable>
+    implements Comparable<T> {
 
-  boolean isZero();
+  protected final V value;
 
-  T minus(T other);
+  protected ResourceMeasure(V value) {
+    if (value == null) {
+      throw new IllegalArgumentException();
+    }
+    this.value = value;
+  }
 
-  T plus(T other);
+  public V getValue() {
+    return value;
+  }
 
-  T multiply(int factor);
+  public boolean isZero() {
+    return value.doubleValue() == 0.0;
+  }
 
-  T divide(int factor);
+  public abstract T minus(T other);
 
-  T increaseBy(int percentage);
+  public abstract T plus(T other);
 
-  boolean greaterThan(T other);
+  public abstract T multiply(int factor);
 
-  boolean greaterOrEqual(T other);
+  public abstract T divide(int factor);
 
-  boolean lessThan(T other);
+  public abstract T increaseBy(int percentage);
 
-  boolean lessOrEqual(T other);
+  @SuppressWarnings("unchecked")
+  public boolean greaterThan(T other) {
+    return value.compareTo(other.value) > 0;
+  }
+
+  @SuppressWarnings("unchecked")
+  public boolean greaterOrEqual(T other) {
+    return value.compareTo(other.value) >= 0;
+  }
+
+  @SuppressWarnings("unchecked")
+  public boolean lessThan(T other) {
+    return value.compareTo(other.value) < 0;
+  }
+
+  @SuppressWarnings("unchecked")
+  public boolean lessOrEqual(T other) {
+    return value.compareTo(other.value) <= 0;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public int compareTo(T o) {
+    return value.compareTo(o.value);
+  }
 }

--- a/heron/common/src/java/org/apache/heron/common/basics/ResourceMeasure.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/ResourceMeasure.java
@@ -74,4 +74,24 @@ public abstract class ResourceMeasure<V extends Number & Comparable>
   public int compareTo(ResourceMeasure<V> o) {
     return value.compareTo(o.value);
   }
+
+  @Override
+  public int hashCode() {
+    return value.hashCode();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    ResourceMeasure<V> that = (ResourceMeasure<V>) other;
+    return value.equals(that.value);
+  }
 }

--- a/heron/common/src/java/org/apache/heron/common/basics/ResourceMeasure.java
+++ b/heron/common/src/java/org/apache/heron/common/basics/ResourceMeasure.java
@@ -1,19 +1,22 @@
-//  Licensed to the Apache Software Foundation (ASF) under one
-//  or more contributor license agreements.  See the NOTICE file
-//  distributed with this work for additional information
-//  regarding copyright ownership.  The ASF licenses this file
-//  to you under the Apache License, Version 2.0 (the
-//  "License"); you may not use this file except in compliance
-//  with the License.  You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing,
-//  software distributed under the License is distributed on an
-//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-//  KIND, either express or implied.  See the License for the
-//  specific language governing permissions and limitations
-//  under the License.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.heron.common.basics;
 
 public interface ResourceMeasure<T> extends Comparable<T> {

--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
@@ -185,7 +185,7 @@ public class RoundRobinPacking implements IPacking, IRepacking {
 
       for (InstanceId instanceId : instanceList) {
         ByteAmount instanceRam = instancesRamMap.get(containerId).get(instanceId);
-        Double instanceCpu = instancesCpuMap.get(containerId).get(instanceId).getShare();
+        Double instanceCpu = instancesCpuMap.get(containerId).get(instanceId).getValue();
 
         // Currently not yet support disk config for different components, just use the default.
         ByteAmount instanceDisk = instanceDiskDefault;
@@ -295,7 +295,7 @@ public class RoundRobinPacking implements IPacking, IRepacking {
         // If container resource is specified
         if (!containerResHint.equals(notSpecified)) {
           // discount resource for heron internal process (padding) and used (usedRes)
-          T remainingRes = (T) ((T) containerResHint.minus(containerResPadding)).minus(usedRes);
+          T remainingRes = (T) containerResHint.minus(containerResPadding).minus(usedRes);
 
           if (remainingRes.lessOrEqual(zero)) {
             throw new PackingException(String.format("Invalid packing plan generated. "
@@ -330,7 +330,7 @@ public class RoundRobinPacking implements IPacking, IRepacking {
     }
 
     for (int i = 1; i <= numContainer; ++i) {
-      allocation.put(i, new ArrayList<InstanceId>());
+      allocation.put(i, new ArrayList<>());
     }
 
     int index = 1;

--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
@@ -86,7 +86,6 @@ import org.apache.heron.spi.packing.Resource;
 public class RoundRobinPacking implements IPacking, IRepacking {
   private static final Logger LOG = Logger.getLogger(RoundRobinPacking.class.getName());
 
-  // TODO(mfu): Read these values from Config
   @VisibleForTesting
   static final ByteAmount DEFAULT_RAM_PADDING_PER_CONTAINER = ByteAmount.fromGigabytes(2);
   @VisibleForTesting
@@ -303,11 +302,11 @@ public class RoundRobinPacking implements IPacking, IRepacking {
                 + "No enough %s to allocate for unspecified instances", resourceType));
           }
 
-          // Split remaining RAM evenly
+          // Split remaining resource evenly
           individualInstanceRes = (T) remainingRes.divide(unspecifiedInstances.size());
         }
 
-        // Put the results in instancesRam
+        // Put the results in resInsideContainer
         for (InstanceId instanceId : unspecifiedInstances) {
           resInsideContainer.put(instanceId, individualInstanceRes);
         }

--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
@@ -198,7 +198,8 @@ public class RoundRobinPacking implements IPacking, IRepacking {
         containerCpu += instanceCpu;
       }
 
-      Resource resource = new Resource(containerCpu, containerRam, containerDiskInBytes);
+      Resource resource = new Resource(Math.max(containerCpu, containerCpuHint),
+          containerRam, containerDiskInBytes);
       PackingPlan.ContainerPlan containerPlan = new PackingPlan.ContainerPlan(
           containerId, new HashSet<>(instancePlanMap.values()), resource);
 

--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
@@ -169,7 +169,7 @@ public class RoundRobinPacking implements IPacking, IRepacking {
     double containerCpuHint = getContainerCpuHint(roundRobinAllocation);
     ByteAmount containerRamHint = getContainerRamHint(roundRobinAllocation);
 
-    LOG.info(String.format("Pack internal: container CPU hint: %.1f, RAM hint: %s, disk hint: %s.",
+    LOG.info(String.format("Pack internal: container CPU hint: %.3f, RAM hint: %s, disk hint: %s.",
         containerCpuHint,
         containerRamHint.toString(),
         containerDiskInBytes.toString()));
@@ -186,7 +186,7 @@ public class RoundRobinPacking implements IPacking, IRepacking {
 
       for (InstanceId instanceId : instanceList) {
         ByteAmount instanceRam = instancesRamMap.get(containerId).get(instanceId);
-        Double instanceCpu = instancesCpuMap.get(containerId).get(instanceId).getCpuShare();
+        Double instanceCpu = instancesCpuMap.get(containerId).get(instanceId).getShare();
 
         // Currently not yet support disk config for different components, just use the default.
         ByteAmount instanceDisk = instanceDiskDefault;
@@ -214,7 +214,7 @@ public class RoundRobinPacking implements IPacking, IRepacking {
 
     PackingPlan plan = new PackingPlan(topology.getId(), containerPlans);
 
-    validateMinRam(plan);
+    validatePackingPlan(plan);
     return plan;
   }
 
@@ -414,12 +414,12 @@ public class RoundRobinPacking implements IPacking, IRepacking {
   }
 
   /**
-   * Check whether the PackingPlan configured each instance to have at least minimum required RAM
+   * Check whether the PackingPlan generated is valid
    *
    * @param plan The PackingPlan to check
    * @throws PackingException if it's not a valid plan
    */
-  private void validateMinRam(PackingPlan plan) throws PackingException {
+  private void validatePackingPlan(PackingPlan plan) throws PackingException {
     for (PackingPlan.ContainerPlan containerPlan : plan.getContainers()) {
       for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         // Safe check

--- a/heron/packing/tests/java/org/apache/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -177,7 +177,7 @@ public class RoundRobinPackingTest {
       Assert.assertEquals(1, resources.size());
       int instancesCount = containerPlan.getInstances().size();
       Assert.assertEquals(containerRam
-              .minus(RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER).divide(instancesCount),
+          .minus(RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER).divide(instancesCount),
           resources.iterator().next().getRam());
 
       Assert.assertEquals(

--- a/heron/packing/tests/java/org/apache/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -348,7 +348,7 @@ public class RoundRobinPackingTest {
         getRoundRobinPackingPlan(topologyExplicitCpuMap);
 
     AssertPacking.assertContainers(packingPlanExplicitCpuMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltCpu, spoutCpu, containerCpu);
+        BOLT_NAME, SPOUT_NAME, boltCpu, spoutCpu, null);
     Assert.assertEquals(totalInstances, packingPlanExplicitCpuMap.getInstanceCount());
   }
 

--- a/heron/packing/tests/java/org/apache/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -69,7 +69,7 @@ public class RoundRobinPackingTest {
   }
 
   @Test(expected = PackingException.class)
-  public void testCheckFailure() throws Exception {
+  public void testCheckInsufficientRamFailure() throws Exception {
     int numContainers = 2;
     int spoutParallelism = 4;
     int boltParallelism = 3;
@@ -82,6 +82,25 @@ public class RoundRobinPackingTest {
     ByteAmount containerRam = ByteAmount.fromGigabytes(0);
 
     topologyConfig.setContainerRamRequested(containerRam);
+
+    TopologyAPI.Topology topology =  getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    getRoundRobinPackingPlan(topology);
+  }
+
+  @Test(expected = PackingException.class)
+  public void testCheckInsufficientCpuFailure() throws Exception {
+    int numContainers = 2;
+    int spoutParallelism = 4;
+    int boltParallelism = 3;
+
+    // Set up the topology and its config
+    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
+    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+
+    // Explicit set insufficient CPU for container
+    double containerCpu = 1.0;
+
+    topologyConfig.setContainerCpuRequested(containerCpu);
 
     TopologyAPI.Topology topology =  getTopology(spoutParallelism, boltParallelism, topologyConfig);
     getRoundRobinPackingPlan(topology);
@@ -158,8 +177,12 @@ public class RoundRobinPackingTest {
       Assert.assertEquals(1, resources.size());
       int instancesCount = containerPlan.getInstances().size();
       Assert.assertEquals(containerRam
-          .minus(RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER).divide(instancesCount),
+              .minus(RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER).divide(instancesCount),
           resources.iterator().next().getRam());
+
+      Assert.assertEquals(
+          (containerCpu - RoundRobinPacking.DEFAULT_CPU_PADDING_PER_CONTAINER) / instancesCount,
+          resources.iterator().next().getCpu(), DELTA);
     }
   }
 
@@ -216,11 +239,15 @@ public class RoundRobinPackingTest {
       Assert.assertEquals(containerRam
               .minus(containerRamPadding).divide(instancesCount),
           resources.iterator().next().getRam());
+
+      Assert.assertEquals(
+          (containerCpu - RoundRobinPacking.DEFAULT_CPU_PADDING_PER_CONTAINER) / instancesCount,
+          resources.iterator().next().getCpu(), DELTA);
     }
   }
 
   /**
-   * Test the scenario RAM map config is partially set
+   * Test the scenario RAM map config is completely set
    */
   @Test
   public void testCompleteRamMapRequested() throws Exception {
@@ -256,6 +283,41 @@ public class RoundRobinPackingTest {
   }
 
   /**
+   * Test the scenario CPU map config is completely set
+   */
+  @Test
+  public void testCompleteCpuMapRequested() throws Exception {
+    int numContainers = 2;
+    int spoutParallelism = 4;
+    int boltParallelism = 3;
+    Integer totalInstances = spoutParallelism + boltParallelism;
+
+    // Set up the topology and its config
+    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
+    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+
+    // Explicit set resources for container
+    double containerCpu = 30;
+
+    // Explicit set component RAM map
+    double boltCpu = 4;
+    double spoutCpu = 4;
+
+    topologyConfig.setContainerCpuRequested(containerCpu);
+    topologyConfig.setComponentCpu(BOLT_NAME, boltCpu);
+    topologyConfig.setComponentCpu(SPOUT_NAME, spoutCpu);
+
+    TopologyAPI.Topology topologyExplicitCpuMap =
+        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    PackingPlan packingPlanExplicitCpuMap =
+        getRoundRobinPackingPlan(topologyExplicitCpuMap);
+
+    AssertPacking.assertContainers(packingPlanExplicitCpuMap.getContainers(),
+        BOLT_NAME, SPOUT_NAME, boltCpu, spoutCpu, containerCpu);
+    Assert.assertEquals(totalInstances, packingPlanExplicitCpuMap.getInstanceCount());
+  }
+
+  /**
    * Test the scenario RAM map config is partially set
    */
   @Test
@@ -285,8 +347,7 @@ public class RoundRobinPackingTest {
     Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
 
     // RAM for bolt should be the value in component RAM map
-    for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.getContainers()) {
+    for (PackingPlan.ContainerPlan containerPlan : packingPlanExplicitRamMap.getContainers()) {
       Assert.assertEquals(containerRam, containerPlan.getRequiredResource().getRam());
       int boltCount = 0;
       int instancesCount = containerPlan.getInstances().size();
@@ -308,6 +369,63 @@ public class RoundRobinPackingTest {
                   .minus(RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER)
                   .divide(spoutCount),
               instancePlan.getResource().getRam());
+        }
+      }
+    }
+  }
+
+  /**
+   * Test the scenario CPU map config is partially set
+   */
+  @Test
+  public void testPartialCpuMap() throws Exception {
+    int numContainers = 2;
+    int spoutParallelism = 4;
+    int boltParallelism = 3;
+    Integer totalInstances = spoutParallelism + boltParallelism;
+
+    // Set up the topology and its config
+    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
+    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+
+    // Explicit set resources for container
+    double containerCpu = 30;
+
+    // Explicit set component CPU map
+    double boltCpu = 4;
+
+    topologyConfig.setContainerCpuRequested(containerCpu);
+    topologyConfig.setComponentCpu(BOLT_NAME, boltCpu);
+
+    TopologyAPI.Topology topologyExplicitCpuMap =
+        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    PackingPlan packingPlanExplicitCpuMap =
+        getRoundRobinPackingPlan(topologyExplicitCpuMap);
+    Assert.assertEquals(totalInstances, packingPlanExplicitCpuMap.getInstanceCount());
+
+    // CPU for bolt should be the value in component CPU map
+    for (PackingPlan.ContainerPlan containerPlan : packingPlanExplicitCpuMap.getContainers()) {
+      Assert.assertEquals(containerCpu, containerPlan.getRequiredResource().getCpu(), DELTA);
+      int boltCount = 0;
+      int instancesCount = containerPlan.getInstances().size();
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
+        if (instancePlan.getComponentName().equals(BOLT_NAME)) {
+          Assert.assertEquals(boltCpu, instancePlan.getResource().getCpu(), DELTA);
+          boltCount++;
+        }
+      }
+
+      // CPU for spout should be:
+      // (containerCpu - all CPU for bolt - CPU for padding) / (# of spouts)
+      int spoutCount = instancesCount - boltCount;
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
+        if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
+          Assert.assertEquals(
+              (containerCpu
+                  - boltCpu * boltCount
+                  - RoundRobinPacking.DEFAULT_CPU_PADDING_PER_CONTAINER)
+                  / spoutCount,
+              instancePlan.getResource().getCpu(), DELTA);
         }
       }
     }


### PR DESCRIPTION
**This PR might break some mis-configured topologies in production**

This PR addresses some issues raised previously in the slack chat that the packing algorithm did not honor container-level and instance-level constraints on CPU resource. Additionally, we added resource constraint validation in RoundRobinPacking. Specifically:
- `topology.container.cpu` and `topology.container.ram` are honored and considered as the **hard cap** constraint for the corresponding resource in **one** container. 
- `topology.component.cpumap` and `topology.component.rammap` are honored and considered as the instance resource mapping in **one** container.
- The sum of instance resources in one container, plus padding, should not exceed the container-level constraint, otherwise the scheduling would fail. 