### PR TITLE
[UI] Move reset view button to left and change plan graph listener fr…

### DIFF
--- a/heron/tools/ui/resources/static/css/visstyle.css
+++ b/heron/tools/ui/resources/static/css/visstyle.css
@@ -29,7 +29,7 @@
 .reset {
   position: absolute;
   top: 1em;
-  right: 1em;
+  left: 1em;
   z-index: 100;
 }
 

--- a/heron/tools/ui/resources/static/js/logical-plan.js
+++ b/heron/tools/ui/resources/static/js/logical-plan.js
@@ -393,6 +393,7 @@
           return d.color;
         })
         .on("click", planController.logicalComponentClicked)
+        .on("dblclick", planController.logicalComponentClicked)
         .on("mouseover", planController.logicalComponentHoverOver)
         .on("mouseout", planController.logicalComponentHoverOut);
 
@@ -402,6 +403,7 @@
         .attr("y", function (d) { return d.cy - d.r - 10; })
         .attr("class", "fade")
         .style("text-anchor", "middle")
+        .style("user-select", "all")
         .text(function (d) {
           if (d.isReal) {
             return d.name;

--- a/heron/tools/ui/resources/static/js/plan-controller.js
+++ b/heron/tools/ui/resources/static/js/plan-controller.js
@@ -184,8 +184,8 @@ function PlanController(baseUrl, cluster, environ, toponame, physicalPlan, logic
     highlightFocusedElements();
   };
 
-  // treat any click that bubbles up unhandled as intent to clear the focus
-  $(document).on('click', ".plans .graphics", function () {
+  // treat double click as intent to clear the focus
+  $(document).on('dblclick', ".plans .graphics", function () {
     window.location.hash = "/";
   });
   $(document).on('click', ".reset", function () {


### PR DESCRIPTION
…om click to dblclick

Motivation:
- "Reset View" button is hard to notice when it is aligned to the right side.
- click event is used to reset view but it is quite easy to mis-click, which is not intuitive. Also it is hard to select text on the page because the reset view is triggered on mouse up. Change the event to double click to avoid mis-click.