### PR TITLE
Add a release-yaml-file argument to CLI

### DIFF
--- a/heron/tools/cli/src/python/args.py
+++ b/heron/tools/cli/src/python/args.py
@@ -165,6 +165,18 @@ def add_extra_launch_classpath(parser):
       help='Additional JVM class path for launching topology')
   return parser
 
+def add_release_yaml_file(parser):
+  '''
+  :param parser:
+  :return:
+  '''
+  parser.add_argument(
+      '--release-yaml-file',
+      default="",
+      help='YAML file that contains release info. Default value is the '
+           'path of the release file in this CLI')
+  return parser
+
 def add_dry_run(parser):
   '''
   :param parser:

--- a/heron/tools/cli/src/python/submit.py
+++ b/heron/tools/cli/src/python/submit.py
@@ -75,6 +75,7 @@ def create_parser(subparsers):
   cli_args.add_deactive_deploy(parser)
   cli_args.add_dry_run(parser)
   cli_args.add_extra_launch_classpath(parser)
+  cli_args.add_release_yaml_file(parser)
   cli_args.add_service_url(parser)
   cli_args.add_system_property(parser)
   cli_args.add_verbose(parser)
@@ -98,7 +99,7 @@ def launch_a_topology(cl_args, tmp_dir, topology_file, topology_defn_file, topol
   topology_pkg_path = config.normalized_class_path(os.path.join(tmp_dir, 'topology.tar.gz'))
 
   # get the release yaml file
-  release_yaml_file = config.get_heron_release_file()
+  release_yaml_file = cl_args['release_yaml_file']
 
   # create a tar package with the cluster configuration and generated config files
   config_path = cl_args['config_path']
@@ -455,6 +456,9 @@ def run(command, parser, cl_args, unknown_args):
   opts.set_config('cmdline.topology.role', cl_args['role'])
   opts.set_config('cmdline.topology.environment', cl_args['environ'])
 
+  # Use CLI release yaml file if the release_yaml_file config is empty
+  if not cl_args['release_yaml_file']:
+    cl_args['release_yaml_file'] = config.get_heron_release_file()
 
   # check the extension of the file name to see if it is tar/jar file.
   if jar_type:

--- a/heron/tools/common/src/python/utils/config.py
+++ b/heron/tools/common/src/python/utils/config.py
@@ -211,7 +211,7 @@ def get_heron_lib_dir():
 def get_heron_release_file():
   """
   This will provide the path to heron release.yaml file
-  :return: absolute path of heron release.yaml file
+  :return: absolute path of heron release.yaml file in CLI
   """
   return os.path.join(get_heron_dir(), RELEASE_YAML)
 


### PR DESCRIPTION
In Heron UI, there is a "version" string for each topology. Currently the information is from a release.yaml file in CLI so it is just the CLI release information. The information is useful but users might want to have more in UI.

An extra "release-yaml-file" argument is added to CLI in this PR. User can generate a release info file and pass it to CLI and the version info will be displayed in UI.

~/.heron/bin/heron submit --release-yaml-file MY_OWN_RELEASE_INFO.yaml local   ~/.heron/examples/heron-streamlet-examples.jar   org.apache.heron.examples.streamlet.WindowedWordCountTopology   WindowedWordCountTopology

