### PR TITLE
Update topology UI to make topology info more consistent across pages

### DIFF
--- a/heron/tools/ui/resources/static/js/alltopologies.js
+++ b/heron/tools/ui/resources/static/js/alltopologies.js
@@ -54,8 +54,8 @@ var TopologyItem = React.createClass({
          <td className="col-md-3 break-all"><a className="toponame" href={'./topologies/' + topology.cluster + '/' + topology.environ + '/' + topology.name}>{topology.name}</a></td>
          <td className="col-md-1 topostatus">{topology.status}</td>
          <td className="col-md-1 topocluster">{displaycluster}</td>
-         <td className="col-md-1 topoenviron">{displayenv}</td>
          <td className="col-md-1 toporunrole break-all">{topology.role}</td>
+         <td className="col-md-1 topoenviron">{displayenv}</td>
          <td className="col-md-1 toporeleaseversion">{topology.release_version}</td>
          <td className="col-md-1 toposubmittedby break-all">{topology.submission_user}</td>
          <td className="col-md-2 toposubmittedat no-break">{display_time}</td>
@@ -182,11 +182,11 @@ var TopologyTable = React.createClass({
               <th onClick={sortBy("cluster")} className={sortClass("cluster")}>
                 Cluster
               </th>
-              <th onClick={sortBy("environ")} className={sortClass("environ")}>
-                Environ
-              </th>
               <th onClick={sortBy("role")} className={sortClass("role")}>
                 Role
+              </th>
+              <th onClick={sortBy("environ")} className={sortClass("environ")}>
+                Environ
               </th>
               <th onClick={sortBy("release_version")} className={sortClass("release_version")}>
                 Version

--- a/heron/tools/ui/resources/templates/topology.html
+++ b/heron/tools/ui/resources/templates/topology.html
@@ -127,11 +127,12 @@ under the License.
       <thead>
         <th>Topology name</th>
         <th>Status</th>
-        <th>DC</th>
+        <th>Cluster</th>
         <th>Role</th>
         <th>Environment</th>
+        <th>Version</th>
         <th>Launched at</th>
-        <th>Launched by</th>
+        <th>Submitted by</th>
         <th>Links</th>
       </thead>
 
@@ -142,6 +143,7 @@ under the License.
           <td>{{cluster}}</td>
           <td>{{execution_state['role']}}</td>
           <td>{{environ}}</td>
+          <td>{{execution_state['release_version']}}</td>
           <td>{{launched}}</td>
           <td>{{execution_state['submission_user']}}</td>
           <td>


### PR DESCRIPTION
Currently the "all topologies" page and "topology" page are not consistent:
- it is "cluster" in one page and "dc" in the other
- there is no version info in the "topology" page
- "submitted by" vs "launched by"
- column order is different. I think "cluster" -> "role" -> "env" is the correct order.