### PR TITLE
Fix docker build artifacts script to have the correct version string

### DIFF
--- a/docker/scripts/compile-docker.sh
+++ b/docker/scripts/compile-docker.sh
@@ -51,7 +51,7 @@ echo "Running build in container"
 docker run \
     --rm \
     -e TARGET_PLATFORM=$TARGET_PLATFORM \
-    -e SCRATCH_DIR="/scratch" \
+    -e SCRATCH_DIR="/$HERON_VERSION" \
     -e SOURCE_TARBALL="/src.tar.gz" \
     -e OUTPUT_DIRECTORY="/dist" \
     -e HERON_VERSION=$HERON_VERSION \


### PR DESCRIPTION
The current docker script doesn't keep the correct version number.

In the generated image from this command:
 ./docker/scripts/build-artifacts.sh debian9 my_test_build ~/heron-release

"heron version" shows:
heron.build.git.revision : scratch
heron.build.git.status : Clean
heron.build.host : tw-mbp-nwang
heron.build.time : Tue Jan 8 19:46:48 PST 2019
heron.build.timestamp : 1547005860000
heron.build.user : nwang
heron.build.version : scratch

Note that the version string is "scratch" although the version string in argument is "my_test_build"

After the fix, the new "heron version" output has the correct version string.
heron.build.git.revision : my_test_build
heron.build.git.status : Clean
heron.build.host : tw-mbp-nwang
heron.build.time : Fri Jan 11 23:58:55 PST 2019
heron.build.timestamp : 1547280101000
heron.build.user : nwang
heron.build.version : my_test_build

