### PR TITLE
Fix docker build artifacts script to have the correct version string

### DIFF
--- a/scripts/release/status.sh
+++ b/scripts/release/status.sh
@@ -59,8 +59,7 @@ then
     build_version=${HERON_BUILD_VERSION}
   fi
 else
-  current_dir=$(pwd)
-  build_version=$(basename "$current_dir")
+  build_version=${HERON_BUILD_VERSION}
 fi
 echo "HERON_BUILD_VERSION ${build_version}"
 


### PR DESCRIPTION
The current docker script doesn't keep the correct version number. This PR is another way to fix the issue. Previous try is here: https://github.com/apache/incubator-heron/pull/3154.

In the generated image from this command:
./docker/scripts/build-artifacts.sh debian9 my_test_build ~/heron-release

"heron version" shows:
heron.build.git.revision : scratch
heron.build.git.status : Clean
heron.build.host : tw-mbp-nwang
heron.build.time : Tue Jan 8 19:46:48 PST 2019
heron.build.timestamp : 1547005860000
heron.build.user : nwang
heron.build.version : scratch

Note that the version string is "scratch" although the version string in argument is "my_test_build"

After the fix, the new "heron version" output has the correct version string.
TO-ADD