### PR TITLE
Yaoli/fix dockerfiles

### DIFF
--- a/docker/dist/Dockerfile.dist.centos7
+++ b/docker/dist/Dockerfile.dist.centos7
@@ -37,11 +37,20 @@ WORKDIR /heron
 # run heron installer
 RUN /heron/heron-install.sh
 
-RUN mkdir -p /opt/heron && \
-    tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
+RUN ln -s /usr/local/heron/dist/heron-core /heron
+
+RUN mkdir -p /heron/heron-tools
+RUN ln -s /usr/local/heron/bin /heron/heron-tools
+RUN ln -s /usr/local/heron/conf /heron/heron-tools
+RUN ln -s /usr/local/heron/dist /heron/heron-tools
+RUN ln -s /usr/local/heron/lib /heron/heron-tools
+RUN ln -s /usr/local/heron/release.yaml /heron/heron-tools
+
+RUN ln -s /usr/local/heron/examples /heron
+
+RUN ln -s /usr/local/heron/release.yaml /heron
 
 RUN rm -f /heron/heron-install.sh
-RUN rm -f /heron/heron-core.tar.gz
 
 ENV HERON_HOME /heron/heron-core/
 RUN export HERON_HOME

--- a/docker/dist/Dockerfile.dist.centos7
+++ b/docker/dist/Dockerfile.dist.centos7
@@ -35,22 +35,18 @@ ADD artifacts /heron
 WORKDIR /heron
 
 # run heron installer
-RUN /heron/heron-install.sh
+RUN /heron/heron-install.sh \
+    && rm -f /heron/heron-install.sh
 
-RUN ln -s /usr/local/heron/dist/heron-core /heron
-
-RUN mkdir -p /heron/heron-tools
-RUN ln -s /usr/local/heron/bin /heron/heron-tools
-RUN ln -s /usr/local/heron/conf /heron/heron-tools
-RUN ln -s /usr/local/heron/dist /heron/heron-tools
-RUN ln -s /usr/local/heron/lib /heron/heron-tools
-RUN ln -s /usr/local/heron/release.yaml /heron/heron-tools
-
-RUN ln -s /usr/local/heron/examples /heron
-
-RUN ln -s /usr/local/heron/release.yaml /heron
-
-RUN rm -f /heron/heron-install.sh
+RUN ln -s /usr/local/heron/dist/heron-core /heron \
+    && mkdir -p /heron/heron-tools \
+    && ln -s /usr/local/heron/bin /heron/heron-tools \
+    && ln -s /usr/local/heron/conf /heron/heron-tools \
+    && ln -s /usr/local/heron/dist /heron/heron-tools \
+    && ln -s /usr/local/heron/lib /heron/heron-tools \
+    && ln -s /usr/local/heron/release.yaml /heron/heron-tools \
+    && ln -s /usr/local/heron/examples /heron \
+    && ln -s /usr/local/heron/release.yaml /heron
 
 ENV HERON_HOME /heron/heron-core/
 RUN export HERON_HOME

--- a/docker/dist/Dockerfile.dist.debian9
+++ b/docker/dist/Dockerfile.dist.debian9
@@ -31,8 +31,6 @@ ADD artifacts /heron
 
 WORKDIR /heron
 
-RUN chmod 755 heron-install.sh
-
 # run heron installer
 RUN /heron/heron-install.sh && \
     rm -rf /heron/heron-install.sh && \

--- a/docker/dist/Dockerfile.dist.debian9
+++ b/docker/dist/Dockerfile.dist.debian9
@@ -31,15 +31,27 @@ ADD artifacts /heron
 
 WORKDIR /heron
 
+RUN chmod 755 heron-install.sh
 
 # run heron installer
 RUN /heron/heron-install.sh && \
-    tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron && \
-    rm -rf /heron/heron-core.tar.gz && \
     rm -rf /heron/heron-install.sh && \
     rm -rf /opt/heron/heron-core/lib/scheduler/heron-local-scheduler.jar && \
     rm -rf /opt/heron/heron-core/lib/scheduler/heron-mesos-scheduler.jar && \
     rm -rf /opt/heron/heron-core/lib/scheduler/heron-slurm-scheduler.jar
+
+RUN ln -s /usr/local/heron/dist/heron-core /heron
+
+RUN mkdir -p /heron/heron-tools
+RUN ln -s /usr/local/heron/bin /heron/heron-tools
+RUN ln -s /usr/local/heron/conf /heron/heron-tools
+RUN ln -s /usr/local/heron/dist /heron/heron-tools
+RUN ln -s /usr/local/heron/lib /heron/heron-tools
+RUN ln -s /usr/local/heron/release.yaml /heron/heron-tools
+
+RUN ln -s /usr/local/heron/examples /heron
+
+RUN ln -s /usr/local/heron/release.yaml /heron
 
 ENV HERON_HOME /heron/heron-core/
 

--- a/docker/dist/Dockerfile.dist.debian9
+++ b/docker/dist/Dockerfile.dist.debian9
@@ -38,18 +38,15 @@ RUN /heron/heron-install.sh && \
     rm -rf /opt/heron/heron-core/lib/scheduler/heron-mesos-scheduler.jar && \
     rm -rf /opt/heron/heron-core/lib/scheduler/heron-slurm-scheduler.jar
 
-RUN ln -s /usr/local/heron/dist/heron-core /heron
-
-RUN mkdir -p /heron/heron-tools
-RUN ln -s /usr/local/heron/bin /heron/heron-tools
-RUN ln -s /usr/local/heron/conf /heron/heron-tools
-RUN ln -s /usr/local/heron/dist /heron/heron-tools
-RUN ln -s /usr/local/heron/lib /heron/heron-tools
-RUN ln -s /usr/local/heron/release.yaml /heron/heron-tools
-
-RUN ln -s /usr/local/heron/examples /heron
-
-RUN ln -s /usr/local/heron/release.yaml /heron
+RUN ln -s /usr/local/heron/dist/heron-core /heron \
+    && mkdir -p /heron/heron-tools \
+    && ln -s /usr/local/heron/bin /heron/heron-tools \
+    && ln -s /usr/local/heron/conf /heron/heron-tools \
+    && ln -s /usr/local/heron/dist /heron/heron-tools \
+    && ln -s /usr/local/heron/lib /heron/heron-tools \
+    && ln -s /usr/local/heron/release.yaml /heron/heron-tools \
+    && ln -s /usr/local/heron/examples /heron \
+    && ln -s /usr/local/heron/release.yaml /heron
 
 ENV HERON_HOME /heron/heron-core/
 

--- a/docker/dist/Dockerfile.dist.ubuntu14.04
+++ b/docker/dist/Dockerfile.dist.ubuntu14.04
@@ -37,18 +37,15 @@ WORKDIR /heron
 # run heron installer
 RUN /heron/heron-install.sh
 
-RUN ln -s /usr/local/heron/dist/heron-core /heron
-
-RUN mkdir -p /heron/heron-tools
-RUN ln -s /usr/local/heron/bin /heron/heron-tools
-RUN ln -s /usr/local/heron/conf /heron/heron-tools
-RUN ln -s /usr/local/heron/dist /heron/heron-tools
-RUN ln -s /usr/local/heron/lib /heron/heron-tools
-RUN ln -s /usr/local/heron/release.yaml /heron/heron-tools
-
-RUN ln -s /usr/local/heron/examples /heron
-
-RUN ln -s /usr/local/heron/release.yaml /heron
+RUN ln -s /usr/local/heron/dist/heron-core /heron \
+    && mkdir -p /heron/heron-tools \
+    && ln -s /usr/local/heron/bin /heron/heron-tools \
+    && ln -s /usr/local/heron/conf /heron/heron-tools \
+    && ln -s /usr/local/heron/dist /heron/heron-tools \
+    && ln -s /usr/local/heron/lib /heron/heron-tools \
+    && ln -s /usr/local/heron/release.yaml /heron/heron-tools \
+    && ln -s /usr/local/heron/examples /heron \
+    && ln -s /usr/local/heron/release.yaml /heron
 
 ENV HERON_HOME /heron/heron-core/
 

--- a/docker/dist/Dockerfile.dist.ubuntu14.04
+++ b/docker/dist/Dockerfile.dist.ubuntu14.04
@@ -37,7 +37,18 @@ WORKDIR /heron
 # run heron installer
 RUN /heron/heron-install.sh
 
-RUN tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
+RUN ln -s /usr/local/heron/dist/heron-core /heron
+
+RUN mkdir -p /heron/heron-tools
+RUN ln -s /usr/local/heron/bin /heron/heron-tools
+RUN ln -s /usr/local/heron/conf /heron/heron-tools
+RUN ln -s /usr/local/heron/dist /heron/heron-tools
+RUN ln -s /usr/local/heron/lib /heron/heron-tools
+RUN ln -s /usr/local/heron/release.yaml /heron/heron-tools
+
+RUN ln -s /usr/local/heron/examples /heron
+
+RUN ln -s /usr/local/heron/release.yaml /heron
 
 ENV HERON_HOME /heron/heron-core/
 

--- a/docker/dist/Dockerfile.dist.ubuntu16.04
+++ b/docker/dist/Dockerfile.dist.ubuntu16.04
@@ -35,22 +35,18 @@ ADD artifacts /heron
 WORKDIR /heron
 
 # run heron installer
-RUN /heron/heron-install.sh
+RUN /heron/heron-install.sh \
+    && rm -f /heron/heron-install.sh
 
-RUN ln -s /usr/local/heron/dist/heron-core /heron
-
-RUN mkdir -p /heron/heron-tools
-RUN ln -s /usr/local/heron/bin /heron/heron-tools
-RUN ln -s /usr/local/heron/conf /heron/heron-tools
-RUN ln -s /usr/local/heron/dist /heron/heron-tools
-RUN ln -s /usr/local/heron/lib /heron/heron-tools
-RUN ln -s /usr/local/heron/release.yaml /heron/heron-tools
-
-RUN ln -s /usr/local/heron/examples /heron
-
-RUN ln -s /usr/local/heron/release.yaml /heron
-
-RUN rm -f /heron/heron-install.sh
+RUN ln -s /usr/local/heron/dist/heron-core /heron \
+    && mkdir -p /heron/heron-tools \
+    && ln -s /usr/local/heron/bin /heron/heron-tools \
+    && ln -s /usr/local/heron/conf /heron/heron-tools \
+    && ln -s /usr/local/heron/dist /heron/heron-tools \
+    && ln -s /usr/local/heron/lib /heron/heron-tools \
+    && ln -s /usr/local/heron/release.yaml /heron/heron-tools \
+    && ln -s /usr/local/heron/examples /heron \
+    && ln -s /usr/local/heron/release.yaml /heron \
 
 ENV HERON_HOME /heron/heron-core/
 RUN export HERON_HOME

--- a/docker/dist/Dockerfile.dist.ubuntu16.04
+++ b/docker/dist/Dockerfile.dist.ubuntu16.04
@@ -37,10 +37,20 @@ WORKDIR /heron
 # run heron installer
 RUN /heron/heron-install.sh
 
-RUN tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
+RUN ln -s /usr/local/heron/dist/heron-core /heron
+
+RUN mkdir -p /heron/heron-tools
+RUN ln -s /usr/local/heron/bin /heron/heron-tools
+RUN ln -s /usr/local/heron/conf /heron/heron-tools
+RUN ln -s /usr/local/heron/dist /heron/heron-tools
+RUN ln -s /usr/local/heron/lib /heron/heron-tools
+RUN ln -s /usr/local/heron/release.yaml /heron/heron-tools
+
+RUN ln -s /usr/local/heron/examples /heron
+
+RUN ln -s /usr/local/heron/release.yaml /heron
 
 RUN rm -f /heron/heron-install.sh
-RUN rm -f /heron/heron-core.tar.gz
 
 ENV HERON_HOME /heron/heron-core/
 RUN export HERON_HOME

--- a/docker/dist/Dockerfile.dist.ubuntu18.04
+++ b/docker/dist/Dockerfile.dist.ubuntu18.04
@@ -12,22 +12,18 @@ ADD artifacts /heron
 WORKDIR /heron
 
 # run heron installers
-RUN /heron/heron-install.sh
+RUN /heron/heron-install.sh \
+    && rm -f /heron/heron-install.sh
 
-RUN ln -s /usr/local/heron/dist/heron-core /heron
-
-RUN mkdir -p /heron/heron-tools
-RUN ln -s /usr/local/heron/bin /heron/heron-tools
-RUN ln -s /usr/local/heron/conf /heron/heron-tools
-RUN ln -s /usr/local/heron/dist /heron/heron-tools
-RUN ln -s /usr/local/heron/lib /heron/heron-tools
-RUN ln -s /usr/local/heron/release.yaml /heron/heron-tools
-
-RUN ln -s /usr/local/heron/examples /heron
-
-RUN ln -s /usr/local/heron/release.yaml /heron
-
-RUN rm -f /heron/heron-install.sh
+RUN ln -s /usr/local/heron/dist/heron-core /heron \
+    && mkdir -p /heron/heron-tools \
+    && ln -s /usr/local/heron/bin /heron/heron-tools \
+    && ln -s /usr/local/heron/conf /heron/heron-tools \
+    && ln -s /usr/local/heron/dist /heron/heron-tools \
+    && ln -s /usr/local/heron/lib /heron/heron-tools \
+    && ln -s /usr/local/heron/release.yaml /heron/heron-tools \
+    && ln -s /usr/local/heron/examples /heron \
+    && ln -s /usr/local/heron/release.yaml /heron
 
 ENV HERON_HOME /heron/heron-core/
 RUN export HERON_HOME

--- a/docker/dist/Dockerfile.dist.ubuntu18.04
+++ b/docker/dist/Dockerfile.dist.ubuntu18.04
@@ -14,10 +14,20 @@ WORKDIR /heron
 # run heron installers
 RUN /heron/heron-install.sh
 
-RUN tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
+RUN ln -s /usr/local/heron/dist/heron-core /heron
+
+RUN mkdir -p /heron/heron-tools
+RUN ln -s /usr/local/heron/bin /heron/heron-tools
+RUN ln -s /usr/local/heron/conf /heron/heron-tools
+RUN ln -s /usr/local/heron/dist /heron/heron-tools
+RUN ln -s /usr/local/heron/lib /heron/heron-tools
+RUN ln -s /usr/local/heron/release.yaml /heron/heron-tools
+
+RUN ln -s /usr/local/heron/examples /heron
+
+RUN ln -s /usr/local/heron/release.yaml /heron
 
 RUN rm -f /heron/heron-install.sh
-RUN rm -f /heron/heron-core.tar.gz
 
 ENV HERON_HOME /heron/heron-core/
 RUN export HERON_HOME

--- a/docker/scripts/build-docker.sh
+++ b/docker/scripts/build-docker.sh
@@ -54,14 +54,9 @@ run_build() {
 
   setup_scratch_dir $SCRATCH_DIR
 
-  # need to copy artifacts locally
-  CORE_FILE="$OUTPUT_DIRECTORY/heron-core-$HERON_VERSION-$TARGET_PLATFORM.tar.gz"
-  CORE_OUT_FILE="$SCRATCH_DIR/artifacts/heron-core.tar.gz"
-
   ALL_FILE="$OUTPUT_DIRECTORY/heron-install-$HERON_VERSION-$TARGET_PLATFORM.sh"
   ALL_OUT_FILE="$SCRATCH_DIR/artifacts/heron-install.sh"
 
-  cp $CORE_FILE $CORE_OUT_FILE
   cp $ALL_FILE $ALL_OUT_FILE
   export HERON_VERSION
 


### PR DESCRIPTION
Heron-install.sh contains everything needed for building Heron docker images. There is no need to copy heron-core.tar.gz into images, which will increase the image size.

@nwangtw @nlu90 @huijunw ping for review.