### PR TITLE
create a symbolic link for kubernetes conf after loading docker image

### DIFF
--- a/heron/downloaders/src/shell/BUILD
+++ b/heron/downloaders/src/shell/BUILD
@@ -6,6 +6,6 @@ sh_binary(
 )
 
 sh_binary(
-  name = "heron-downloader-config-kubernetes",
-  srcs = ["heron-downloader-config-kubernetes.sh"],
+  name = "heron-downloader-config",
+  srcs = ["heron-downloader-config.sh"],
 )

--- a/heron/downloaders/src/shell/BUILD
+++ b/heron/downloaders/src/shell/BUILD
@@ -4,3 +4,8 @@ sh_binary(
   name = "heron-downloader",
   srcs = ["heron-downloader.sh"],
 )
+
+sh_binary(
+  name = "heron-downloader-config-kubernetes",
+  srcs = ["heron-downloader-config-kubernetes.sh"],
+)

--- a/heron/downloaders/src/shell/heron-downloader-config-kubernetes.sh
+++ b/heron/downloaders/src/shell/heron-downloader-config-kubernetes.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ln -s /usr/local/heron/conf/kubernetes /heron
+mv /heron/kubernetes /heron/heron-conf

--- a/heron/downloaders/src/shell/heron-downloader-config.sh
+++ b/heron/downloaders/src/shell/heron-downloader-config.sh
@@ -16,5 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ln -s /usr/local/heron/conf/kubernetes /heron
-mv /heron/kubernetes /heron/heron-conf
+if [ $1 = "kubernetes" ]; then
+   ln -s /usr/local/heron/conf/kubernetes /heron
+   mv /heron/kubernetes /heron/heron-conf
+fi

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/AppsV1beta1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/AppsV1beta1Controller.java
@@ -257,7 +257,8 @@ public class AppsV1beta1Controller extends KubernetesController {
     return Arrays.asList(
         "sh",
         "-c",
-        KubernetesUtils.getFetchCommand(configuration, runtimeConfiguration)
+        KubernetesUtils.getConfCommand(configuration)
+            + " && " + KubernetesUtils.getFetchCommand(configuration, runtimeConfiguration)
             + " && " + setShardIdEnvironmentVariableCommand()
             + " && " + String.join(" ", executorCommand)
     );

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesUtils.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesUtils.java
@@ -35,11 +35,13 @@ import io.kubernetes.client.ApiException;
 
 final class KubernetesUtils {
 
+  private static final String CONTAINER = "kubernetes";
+
   private KubernetesUtils() {
   }
 
   static String getConfCommand(Config config) {
-    return String.format("%s", Context.downloaderConfKubernetes(config));
+    return String.format("%s %s", Context.downloaderConfKubernetes(config), CONTAINER);
   }
 
   static String getFetchCommand(Config config, Config runtime) {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesUtils.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesUtils.java
@@ -38,6 +38,10 @@ final class KubernetesUtils {
   private KubernetesUtils() {
   }
 
+  static String getConfCommand(Config config) {
+    return String.format("%s", Context.downloaderConfKubernetes(config));
+  }
+
   static String getFetchCommand(Config config, Config runtime) {
     return String.format("%s %s .", Context.downloaderBinary(config),
         Runtime.topologyPackageUri(runtime).toString());

--- a/heron/spi/src/java/org/apache/heron/spi/common/Context.java
+++ b/heron/spi/src/java/org/apache/heron/spi/common/Context.java
@@ -346,6 +346,10 @@ public class Context {
     return cfg.getStringValue(Key.DOWNLOADER_BINARY);
   }
 
+  public static String downloaderConfKubernetes(Config cfg) {
+    return cfg.getStringValue(Key.DOWNLOADER_CONF_KUBERNETES);
+  }
+
   public static String updatePrompt(Config cfg) {
     return cfg.getStringValue(Key.UPDATE_PROMPT);
   }

--- a/heron/spi/src/java/org/apache/heron/spi/common/Context.java
+++ b/heron/spi/src/java/org/apache/heron/spi/common/Context.java
@@ -347,7 +347,7 @@ public class Context {
   }
 
   public static String downloaderConfKubernetes(Config cfg) {
-    return cfg.getStringValue(Key.DOWNLOADER_CONF_KUBERNETES);
+    return cfg.getStringValue(Key.DOWNLOADER_CONF);
   }
 
   public static String updatePrompt(Config cfg) {

--- a/heron/spi/src/java/org/apache/heron/spi/common/Key.java
+++ b/heron/spi/src/java/org/apache/heron/spi/common/Key.java
@@ -187,7 +187,7 @@ public enum Key {
   PYTHON_INSTANCE_BINARY("heron.binaries.python.instance", "${HERON_BIN}/heron-python-instance"),
   CPP_INSTANCE_BINARY   ("heron.binaries.cpp.instance",    "${HERON_BIN}/heron-cpp-instance"),
   DOWNLOADER_BINARY     ("heron.binaries.downloader",      "${HERON_BIN}/heron-downloader"),
-  DOWNLOADER_CONF_KUBERNETES ("heron.binaries.downloader-conf-kubernetes",  "${HERON_BIN}/heron-downloader-config-kubernetes"),
+  DOWNLOADER_CONF       ("heron.binaries.downloader-conf", "${HERON_BIN}/heron-downloader-config"),
 
   // keys for `heron` command line.
   // Prompt user when more containers are required so that

--- a/heron/spi/src/java/org/apache/heron/spi/common/Key.java
+++ b/heron/spi/src/java/org/apache/heron/spi/common/Key.java
@@ -187,6 +187,7 @@ public enum Key {
   PYTHON_INSTANCE_BINARY("heron.binaries.python.instance", "${HERON_BIN}/heron-python-instance"),
   CPP_INSTANCE_BINARY   ("heron.binaries.cpp.instance",    "${HERON_BIN}/heron-cpp-instance"),
   DOWNLOADER_BINARY     ("heron.binaries.downloader",      "${HERON_BIN}/heron-downloader"),
+  DOWNLOADER_CONF_KUBERNETES ("heron.binaries.downloader-conf-kubernetes",  "${HERON_BIN}/heron-downloader-config-kubernetes"),
 
   // keys for `heron` command line.
   // Prompt user when more containers are required so that

--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -73,7 +73,7 @@ pkg_tar(
     srcs = [
         "//heron/executor/src/python:heron-executor",
         "//heron/downloaders/src/shell:heron-downloader",
-        "//heron/downloaders/src/shell:heron-downloader-config-kubernetes",
+        "//heron/downloaders/src/shell:heron-downloader-config",
         "//heron/instance/src/python:heron-python-instance",
         "//heron/instance/src/cpp:heron-cpp-instance",
         "//heron/shell/src/python:heron-shell",
@@ -265,7 +265,7 @@ pkg_tar(
     package_dir = "bin",
     srcs = [
         "//heron/downloaders/src/shell:heron-downloader",
-        "//heron/downloaders/src/shell:heron-downloader-config-kubernetes",
+        "//heron/downloaders/src/shell:heron-downloader-config",
         "//heron/tools/cli/src/python:heron",
         "//heron/tools/explorer/src/python:heron-explorer",
         "//heron/tools/admin/src/python:heron-admin",

--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -73,6 +73,7 @@ pkg_tar(
     srcs = [
         "//heron/executor/src/python:heron-executor",
         "//heron/downloaders/src/shell:heron-downloader",
+        "//heron/downloaders/src/shell:heron-downloader-config-kubernetes",
         "//heron/instance/src/python:heron-python-instance",
         "//heron/instance/src/cpp:heron-cpp-instance",
         "//heron/shell/src/python:heron-shell",
@@ -264,6 +265,7 @@ pkg_tar(
     package_dir = "bin",
     srcs = [
         "//heron/downloaders/src/shell:heron-downloader",
+        "//heron/downloaders/src/shell:heron-downloader-config-kubernetes",
         "//heron/tools/cli/src/python:heron",
         "//heron/tools/explorer/src/python:heron-explorer",
         "//heron/tools/admin/src/python:heron-admin",


### PR DESCRIPTION
We observed missing conf files when submitting topologies to k8s. The conf files are required by the Downloader which is in turn used to download conf files and topology jar. A solution in this PR is to generate a symbolic link from /usr/local/heron/conf/kubernetes to /heron/heron-conf in containers right before the Downloader is executed. A shell script is added and passed to container commands for this purpose.

@nwangtw @nlu90 @huijunwu ping for review.