### PR TITLE
Add target to generate packages for heron simulator

### DIFF
--- a/heron/simulator/src/java/BUILD
+++ b/heron/simulator/src/java/BUILD
@@ -17,3 +17,28 @@ java_library(
     srcs = glob(["**/*.java"]),
     deps = simulator_deps_files,
 )
+
+java_binary(
+    name = "simulator-unshaded",
+    srcs = glob(["org/apache/heron/simulator/**/*.java"]),
+    deps = simulator_deps_files + [
+        "//third_party/java:kryo-neverlink",
+        "@org_apache_commons_commons_lang3//jar"
+    ]
+)
+
+jarjar_binary(
+    name = "simulator-shaded",
+    src = ":simulator-unshaded_deploy.jar",
+    shade = "shade.conf",
+    deps = [
+        "@org_sonatype_plugins_jarjar_maven_plugin//jar"
+    ]
+)
+
+genrule(
+    name = "heron-simulator",
+    srcs = [":simulator-shaded"],
+    outs = ["heron-simulator.jar"],
+    cmd = "cp $< $@",
+)

--- a/heron/simulator/src/java/shade.conf
+++ b/heron/simulator/src/java/shade.conf
@@ -1,0 +1,18 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+rule com.google.protobuf** org.apache.heron.shaded.@0


### PR DESCRIPTION
Currently simulator packages (jar, etc) are not created and users cannot use it directly.

With this PR, to build the packages:

bazel build heron/simulator/src/java:all

The output:

$ ls -l bazel-bin/heron/simulator/src/java/
total 17032
drwxr-xr-x  4 nwang  wheel      128 Jan 18 09:49 _javac
-r-xr-xr-x  1 nwang  wheel      284 Jan 18 09:49 libsimulator-java-native-header.jar
-r-xr-xr-x  1 nwang  wheel    46566 Jan 18 09:49 libsimulator-java.jar
-r-xr-xr-x  1 nwang  wheel     7630 Jan 18 09:49 libsimulator-java.jar-2.params
-r-xr-xr-x  1 nwang  wheel     2291 Jan 18 09:49 libsimulator-java.jar_manifest_proto
-r-xr-xr-x  1 nwang  wheel     1453 Jan 18 09:49 libsimulator-java.jdeps
-r-xr-xr-x  1 nwang  wheel  3855925 Jan 18 09:50 simulator-shaded.jar
-r-xr-xr-x  1 nwang  wheel    13309 Jan 18 09:46 simulator-unshaded
-r-xr-xr-x  1 nwang  wheel    46570 Jan 18 09:49 simulator-unshaded.jar
-r-xr-xr-x  1 nwang  wheel     8386 Jan 18 09:49 simulator-unshaded.jar-2.params
-r-xr-xr-x  1 nwang  wheel     2291 Jan 18 09:49 simulator-unshaded.jar_manifest_proto
-r-xr-xr-x  1 nwang  wheel     1457 Jan 18 09:49 simulator-unshaded.jdeps
drwxr-xr-x  9 nwang  wheel      288 Jan 18 09:49 simulator-unshaded.runfiles
-r-xr-xr-x  1 nwang  wheel    55509 Jan 18 09:49 simulator-unshaded.runfiles_manifest
-r-xr-xr-x  1 nwang  wheel  3794019 Jan 18 09:50 simulator-unshaded_deploy.jar
-r-xr-xr-x  1 nwang  wheel     2864 Jan 18 09:48 simulator-unshaded_deploy.jar-2.params
