### PR TITLE
remove heron-core.tar.gz from docker image

### DIFF
--- a/docker/dist/Dockerfile.dist.centos7
+++ b/docker/dist/Dockerfile.dist.centos7
@@ -36,7 +36,8 @@ WORKDIR /heron
 
 # run heron installer
 RUN /heron/heron-install.sh \
-    && rm -f /heron/heron-install.sh
+    && rm -f /heron/heron-install.sh \
+    && rm -f /usr/local/heron/dist/heron-core.tar.gz
 
 RUN ln -s /usr/local/heron/dist/heron-core /heron \
     && mkdir -p /heron/heron-tools \

--- a/docker/dist/Dockerfile.dist.debian9
+++ b/docker/dist/Dockerfile.dist.debian9
@@ -34,6 +34,7 @@ WORKDIR /heron
 # run heron installer
 RUN /heron/heron-install.sh && \
     rm -rf /heron/heron-install.sh && \
+    rm -rf /usr/local/heron/dist/heron-core.tar.gz && \
     rm -rf /opt/heron/heron-core/lib/scheduler/heron-local-scheduler.jar && \
     rm -rf /opt/heron/heron-core/lib/scheduler/heron-mesos-scheduler.jar && \
     rm -rf /opt/heron/heron-core/lib/scheduler/heron-slurm-scheduler.jar

--- a/docker/dist/Dockerfile.dist.ubuntu14.04
+++ b/docker/dist/Dockerfile.dist.ubuntu14.04
@@ -35,7 +35,8 @@ ADD artifacts /heron
 WORKDIR /heron
 
 # run heron installer
-RUN /heron/heron-install.sh
+RUN /heron/heron-install.sh \
+    && rm -f /usr/local/heron/dist/heron-core.tar.gz
 
 RUN ln -s /usr/local/heron/dist/heron-core /heron \
     && mkdir -p /heron/heron-tools \

--- a/docker/dist/Dockerfile.dist.ubuntu16.04
+++ b/docker/dist/Dockerfile.dist.ubuntu16.04
@@ -36,7 +36,8 @@ WORKDIR /heron
 
 # run heron installer
 RUN /heron/heron-install.sh \
-    && rm -f /heron/heron-install.sh
+    && rm -f /heron/heron-install.sh \
+    && rm -f /usr/local/heron/dist/heron-core.tar.gz
 
 RUN ln -s /usr/local/heron/dist/heron-core /heron \
     && mkdir -p /heron/heron-tools \

--- a/docker/dist/Dockerfile.dist.ubuntu18.04
+++ b/docker/dist/Dockerfile.dist.ubuntu18.04
@@ -13,7 +13,8 @@ WORKDIR /heron
 
 # run heron installers
 RUN /heron/heron-install.sh \
-    && rm -f /heron/heron-install.sh
+    && rm -f /heron/heron-install.sh \
+    && rm -f /usr/local/heron/dist/heron-core.tar.gz
 
 RUN ln -s /usr/local/heron/dist/heron-core /heron \
     && mkdir -p /heron/heron-tools \


### PR DESCRIPTION
Remove /usr/local/heron/dist/heron-core.tar.gz from docker images to reduce image size.

@nwangtw @nlu90 @huijunwu ping for review.