### PR TITLE
Joshfischer/aws helm fix

### DIFF
--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -144,7 +144,7 @@ spec:
             - name: data-disk
               mountPath: /bookkeeper/data/ledgers
 
-{{- if or (eq .Values.platform "aws") (eq .Values.platform "baremetal") }}baremetal
+{{- if or (eq .Values.platform "aws") (eq .Values.platform "baremetal") }}
       volumes:
           # Mount local disks
         - name: journal-disk

--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -144,15 +144,15 @@ spec:
             - name: data-disk
               mountPath: /bookkeeper/data/ledgers
 
-{{- if eq .Values.platform "baremetal" }}
+{{- if or (eq .Values.platform "aws") (eq .Values.platform "baremetal") }}baremetal
       volumes:
           # Mount local disks
         - name: journal-disk
           hostPath:
-            path: {{ $bookieJournalHostPath | quote }}
+            path: /bookkeeper/data/journal
         - name: ledgers-disk
           hostPath:
-            path: {{ $bookieStorageHostPath | quote }}
+            path: /bookkeeper/data/ledgers
 {{- end }}
 
 {{- if or (eq .Values.platform "gke") (eq .Values.platform "minikube") }}

--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -27,7 +27,6 @@
 {{- $bookieDirectMemory := .Values.bookieDirectMemory }}
 {{- $bookieJournalCapacity := .Values.bookieJournalCapacity }}
 {{- $bookieStorageCapacity := .Values.bookieStorageCapacity }}
-{{- $bookieJournalHostPath := .Values.bookieJournalHostPath }}
 {{- $bookieStorageHostPath := .Values.bookieStorageHostPath }}
 
 apiVersion: v1


### PR DESCRIPTION
This fixes the helm chart configuration for deploying Heron on AWS.  There were some values that were coming back blank and mounts were not being provisioned causing bookeeper pods to fail.  There is still more to do but this gets it back to a working state.

@nwangtw @kramasamy 