### PR TITLE
Add a spouts directory and README for spout implementations

### DIFF
--- a/contrib/bolts/README.md
+++ b/contrib/bolts/README.md
@@ -1,0 +1,36 @@
+
+This directory contains implementations of Heron bolts that can be used in user topologies.
+
+The bolt implementations are maintained by Heron community.
+
+## Bolt Development
+
+- https://apache.github.io/incubator-heron/docs/developers/python/bolts/
+- https://apache.github.io/incubator-heron/docs/developers/java/bolts/
+
+
+## Requirements
+
+### Directories and Files
+
+Bolt implementation files should be organized in this directory structure:
+
+`external/bolts/{bolt_name}/{language}`
+
+Language: java, python, scala, etc
+bolt name: reduce_bolt, filter_bolt, etc
+
+Files in each bolt should be organized into these subdirectories:
+
+- `src/main/`: source code
+- `src/test/`: unit tests
+- `doc/` : documentations
+
+
+### Documentation
+
+Each bolt should have a design doc as well as related information in the doc/ directory.
+
+### License
+
+All source code files should include a short Apache license header at the top.

--- a/contrib/spouts/README.md
+++ b/contrib/spouts/README.md
@@ -15,7 +15,7 @@ The spout implementations are maintained by Heron community.
 
 Spout implementation files should be organized in this directory structure:
 
-`spouts/{client_name}/{language}/{spout_name}`
+`external/spouts/{client_name}/{language}/{spout_name}`
 
 Client name: kafka, pulsar, etc
 Language: java, python, scala, etc
@@ -30,7 +30,7 @@ Files in each spout should be organized into these subdirectories:
 
 ### Documentation
 
-Each spout should have a design doc as well as related information in the doc/ directory in the project.
+Each spout should have a design doc as well as related information in the doc/ directory.
 
 ### License
 

--- a/spouts/README.md
+++ b/spouts/README.md
@@ -1,0 +1,37 @@
+
+This directory contains implementations of Heron spouts that can be used in user topologies.
+
+The spout implementations are maintained by Heron community.
+
+## Spout Development
+
+- https://apache.github.io/incubator-heron/docs/developers/python/spouts/
+- https://apache.github.io/incubator-heron/docs/developers/java/spouts/
+
+
+## Requirements
+
+### Directories and Files
+
+Spout implementation files should be organized in this directory structure:
+
+`spouts/{client_name}/{language}/{spout_name}`
+
+Client name: kafka, pulsar, etc
+Language: java, python, scala, etc
+Spout name: kafka_spout, stateful_kafka_spout, etc
+
+Files in each spout should be organized into these subdirectories:
+
+- `src/main/`: source code
+- `src/test/`: unit tests
+- `doc/` : documentations
+
+
+### Documentation
+
+Each spout should have a design doc as well as related information in the doc/ directory in the project.
+
+### License
+
+All source code files should include a short Apache license header at the top.


### PR DESCRIPTION
Heron community has been interested in maintaining spout implementations for users. There have been discussions in slack channel (#general) and dev@ mailing list.

There are multiple options and each has its own pros and cons. This PR is just a start of the effort to unblock contributors. The directory might be migrated to a different place after a final decision is made.

Please feel free to comment or join the discussion in dev@heron.apache.org.
