### PR TITLE
[Streamlet] Fix streamlet config to apply cpu and ram in topology

### DIFF
--- a/heron/api/src/java/org/apache/heron/streamlet/Config.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/Config.java
@@ -22,6 +22,7 @@ package org.apache.heron.streamlet;
 
 import java.io.Serializable;
 
+import org.apache.heron.common.basics.ByteAmount;
 import org.apache.heron.streamlet.impl.KryoSerializer;
 
 /**
@@ -33,7 +34,7 @@ import org.apache.heron.streamlet.impl.KryoSerializer;
 public final class Config implements Serializable {
   private static final long serialVersionUID = 6204498077403076352L;
   private final double cpu;
-  private final long ram;
+  private final ByteAmount ram;
   private final DeliverySemantics deliverySemantics;
   private final Serializer serializer;
   private org.apache.heron.api.Config heronConfig;
@@ -63,7 +64,7 @@ public final class Config implements Serializable {
     static final boolean USE_KRYO = true;
     static final org.apache.heron.api.Config CONFIG = new org.apache.heron.api.Config();
     static final double CPU = 1.0;
-    static final long RAM = 100 * MB;
+    static final ByteAmount RAM = ByteAmount.fromMegabytes(100);
     static final DeliverySemantics SEMANTICS = DeliverySemantics.ATMOST_ONCE;
     static final Serializer SERIALIZER = Serializer.KRYO;
   }
@@ -110,23 +111,7 @@ public final class Config implements Serializable {
    * @return the per-container RAM in bytes
    */
   public long getPerContainerRam() {
-    return ram;
-  }
-
-  /**
-   * Gets the RAM used per topology container as a number of gigabytes
-   * @return the per-container RAM in gigabytes
-   */
-  public long getPerContainerRamAsGigabytes() {
-    return Math.round((double) ram / GB);
-  }
-
-  /**
-   * Gets the RAM used per topology container as a number of megabytes
-   * @return the per-container RAM in megabytes
-   */
-  public long getPerContainerRamAsMegabytes() {
-    return Math.round((double) ram / MB);
+    return getPerContainerRamAsBytes();
   }
 
   /**
@@ -134,7 +119,23 @@ public final class Config implements Serializable {
    * @return the per-container RAM in bytes
    */
   public long getPerContainerRamAsBytes() {
-    return getPerContainerRam();
+    return ram.asBytes();
+  }
+
+  /**
+   * Gets the RAM used per topology container as a number of megabytes
+   * @return the per-container RAM in megabytes
+   */
+  public long getPerContainerRamAsMegabytes() {
+    return ram.asMegabytes();
+  }
+
+  /**
+   * Gets the RAM used per topology container as a number of gigabytes
+   * @return the per-container RAM in gigabytes
+   */
+  public long getPerContainerRamAsGigabytes() {
+    return ram.asGigabytes();
   }
 
   /**
@@ -170,7 +171,7 @@ public final class Config implements Serializable {
   public static final class Builder {
     private org.apache.heron.api.Config config;
     private double cpu;
-    private long ram;
+    private ByteAmount ram;
     private DeliverySemantics deliverySemantics;
     private Serializer serializer;
 
@@ -188,6 +189,9 @@ public final class Config implements Serializable {
      */
     public Builder setPerContainerCpu(double perContainerCpu) {
       this.cpu = perContainerCpu;
+      // Different packing algorithm might use different configs. Set all of them here.
+      config.setContainerCpuRequested(perContainerCpu);
+      config.setContainerMaxCpuHint(perContainerCpu);
       return this;
     }
 
@@ -196,8 +200,7 @@ public final class Config implements Serializable {
      * @param perContainerRam Per-container (per-instance) RAM expressed as a Long.
      */
     public Builder setPerContainerRam(long perContainerRam) {
-      this.ram = perContainerRam;
-      return this;
+      return setPerContainerRamInBytes(perContainerRam);
     }
 
     /**
@@ -205,7 +208,10 @@ public final class Config implements Serializable {
      * @param perContainerRam Per-container (per-instance) RAM expressed as a Long.
      */
     public Builder setPerContainerRamInBytes(long perContainerRam) {
-      this.ram = perContainerRam;
+      this.ram = ByteAmount.fromBytes(perContainerRam);
+      // Different packing algorithm might use different configs. Set all of them here.
+      config.setContainerRamRequested(ram);
+      config.setContainerMaxRamHint(ram);
       return this;
     }
 
@@ -214,8 +220,7 @@ public final class Config implements Serializable {
      * @param perContainerRamMB Per-container (per-instance) RAM expressed as a Long.
      */
     public Builder setPerContainerRamInMegabytes(long perContainerRamMB) {
-      this.ram = perContainerRamMB * MB;
-      return this;
+      return setPerContainerRam(perContainerRamMB * MB);
     }
 
     /**
@@ -223,8 +228,7 @@ public final class Config implements Serializable {
      * @param perContainerRamGB Per-container (per-instance) RAM expressed as a Long.
      */
     public Builder setPerContainerRamInGigabytes(long perContainerRamGB) {
-      this.ram = perContainerRamGB * GB;
-      return this;
+      return setPerContainerRam(perContainerRamGB * GB);
     }
 
     /**

--- a/heron/api/src/java/org/apache/heron/streamlet/Config.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/Config.java
@@ -62,7 +62,6 @@ public final class Config implements Serializable {
 
   private static class Defaults {
     static final boolean USE_KRYO = true;
-    static final org.apache.heron.api.Config CONFIG = new org.apache.heron.api.Config();
     static final double CPU = -1.0;                             // -1 means undefined
     static final ByteAmount RAM = ByteAmount.fromBytes(-1);     // -1 means undefined
     static final DeliverySemantics SEMANTICS = DeliverySemantics.ATMOST_ONCE;
@@ -176,7 +175,7 @@ public final class Config implements Serializable {
     private Serializer serializer;
 
     private Builder() {
-      config = Defaults.CONFIG;
+      config = new org.apache.heron.api.Config();
       cpu = Defaults.CPU;
       ram = Defaults.RAM;
       deliverySemantics = Defaults.SEMANTICS;

--- a/heron/api/src/java/org/apache/heron/streamlet/Config.java
+++ b/heron/api/src/java/org/apache/heron/streamlet/Config.java
@@ -63,8 +63,8 @@ public final class Config implements Serializable {
   private static class Defaults {
     static final boolean USE_KRYO = true;
     static final org.apache.heron.api.Config CONFIG = new org.apache.heron.api.Config();
-    static final double CPU = 1.0;
-    static final ByteAmount RAM = ByteAmount.fromMegabytes(100);
+    static final double CPU = -1.0;                             // -1 means undefined
+    static final ByteAmount RAM = ByteAmount.fromBytes(-1);     // -1 means undefined
     static final DeliverySemantics SEMANTICS = DeliverySemantics.ATMOST_ONCE;
     static final Serializer SERIALIZER = Serializer.KRYO;
   }


### PR DESCRIPTION
Currently it seems like the CPU and RAM config in Streamlet Config is not applied.  After the fix, IntegerProcessingTopology example shows correct resource allocation:

```
Container 1
CPU: 1.5, RAM: 8192 MB, Disk: 15360 MB
========================================================================
|     component | task ID |                 CPU | RAM (MB) | disk (MB) |
------------------------------------------------------------------------
| unify-streams |       1 | 0.16666666666666666 |     2048 |      1024 |
|   random-ints |       5 | 0.16666666666666666 |     2048 |      1024 |
|       add-one |       3 | 0.16666666666666666 |     2048 |      1024 |
========================================================================

Container 2
CPU: 1.5, RAM: 8192 MB, Disk: 15360 MB
======================================================================
|   component | task ID |                 CPU | RAM (MB) | disk (MB) |
----------------------------------------------------------------------
|   supplier1 |       4 | 0.16666666666666666 |     2048 |      1024 |
| remove-twos |       2 | 0.16666666666666666 |     2048 |      1024 |
|     logger1 |       6 | 0.16666666666666666 |     2048 |      1024 |
======================================================================
```