### PR TITLE
Consolidate Packing

### DIFF
--- a/heron/packing/src/java/org/apache/heron/packing/AbstractPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/AbstractPacking.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.packing;
+
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.apache.heron.api.generated.TopologyAPI;
+import org.apache.heron.api.utils.TopologyUtils;
+import org.apache.heron.common.basics.ByteAmount;
+import org.apache.heron.packing.utils.PackingUtils;
+import org.apache.heron.spi.common.Config;
+import org.apache.heron.spi.common.Context;
+import org.apache.heron.spi.packing.IPacking;
+import org.apache.heron.spi.packing.IRepacking;
+import org.apache.heron.spi.packing.Resource;
+
+import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_CPU_PADDING;
+import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED;
+import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED;
+import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_MAX_NUM_INSTANCES;
+import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_PADDING_PERCENTAGE;
+import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_RAM_PADDING;
+import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED;
+
+/**
+ * Common configuration finalization for packing algorithms
+ */
+public abstract class AbstractPacking implements IPacking, IRepacking {
+  private static final Logger LOG = Logger.getLogger(AbstractPacking.class.getName());
+  protected TopologyAPI.Topology topology;
+
+  // instance & container
+  protected Resource defaultInstanceResources;
+  protected Resource maxContainerResources;
+  protected int maxNumInstancesPerContainer;
+  protected Map<String, Resource> componentResourceMap;
+
+  // padding
+  protected Resource padding;
+
+  @Override
+  public void initialize(Config config, TopologyAPI.Topology inputTopology) {
+    this.topology = inputTopology;
+    setPackingConfigs(config);
+    LOG.info(String.format("Initalizing Packing: \n"
+            + "Max number of instances per container: %d \n"
+            + "Default instance CPU: %f, Default instance RAM: %s, Default instance DISK: %s \n"
+            + "Paddng: %s \n"
+            + "Container CPU: %f, Container RAM: %s, Container DISK: %s",
+        this.maxNumInstancesPerContainer,
+        this.defaultInstanceResources.getCpu(),
+        this.defaultInstanceResources.getRam().toString(),
+        this.defaultInstanceResources.getDisk().toString(),
+        this.padding.toString(),
+        this.maxContainerResources.getCpu(),
+        this.maxContainerResources.getRam().toString(),
+        this.maxContainerResources.getDisk().toString()));
+  }
+
+  /**
+   * Instatiate the packing algorithm parameters related to this topology.
+   */
+  private void setPackingConfigs(Config config) {
+    List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
+
+    // instance default resources are acquired from heron system level config
+    this.defaultInstanceResources = new Resource(
+        Context.instanceCpu(config),
+        Context.instanceRam(config),
+        Context.instanceDisk(config));
+
+    int paddingPercentage = TopologyUtils.getConfigWithDefault(topologyConfig,
+        TOPOLOGY_CONTAINER_PADDING_PERCENTAGE, PackingUtils.DEFAULT_CONTAINER_PADDING_PERCENTAGE);
+    ByteAmount ramPadding = TopologyUtils.getConfigWithDefault(topologyConfig,
+        TOPOLOGY_CONTAINER_RAM_PADDING, PackingUtils.DEFAULT_CONTAINER_RAM_PADDING);
+    double cpuPadding = TopologyUtils.getConfigWithDefault(topologyConfig,
+        TOPOLOGY_CONTAINER_CPU_PADDING, PackingUtils.DEFAULT_CONTAINER_CPU_PADDING);
+    Resource preliminaryPadding = new Resource(cpuPadding, ramPadding,
+        PackingUtils.DEFAULT_CONTAINER_DISK_PADDING);
+
+    this.maxNumInstancesPerContainer = TopologyUtils.getConfigWithDefault(topologyConfig,
+        TOPOLOGY_CONTAINER_MAX_NUM_INSTANCES, PackingUtils.DEFAULT_MAX_NUM_INSTANCES_PER_CONTAINER);
+
+    // container default resources are computed as:
+    // max number of instances per container * default instance resources
+    double containerDefaultCpu = this.defaultInstanceResources.getCpu()
+        * maxNumInstancesPerContainer;
+    ByteAmount containerDefaultRam = this.defaultInstanceResources.getRam()
+        .multiply(maxNumInstancesPerContainer);
+    ByteAmount containerDefaultDisk = this.defaultInstanceResources.getDisk()
+        .multiply(maxNumInstancesPerContainer);
+
+    double containerCpu = TopologyUtils.getConfigWithDefault(topologyConfig,
+        TOPOLOGY_CONTAINER_CPU_REQUESTED, containerDefaultCpu);
+    ByteAmount containerRam = TopologyUtils.getConfigWithDefault(topologyConfig,
+        TOPOLOGY_CONTAINER_RAM_REQUESTED, containerDefaultRam);
+    ByteAmount containerDisk = TopologyUtils.getConfigWithDefault(topologyConfig,
+        TOPOLOGY_CONTAINER_DISK_REQUESTED, containerDefaultDisk);
+    Resource containerResource = new Resource(containerCpu,
+        containerRam, containerDisk);
+
+    // finalize padding
+    this.padding = PackingUtils.finalizePadding(containerResource,
+        preliminaryPadding, paddingPercentage);
+
+    // finalize container resources
+    this.maxContainerResources = containerResource;
+
+    this.componentResourceMap = PackingUtils.getComponentResourceMap(
+        TopologyUtils.getComponentParallelism(topology),
+        TopologyUtils.getComponentRamMapConfig(topology),
+        TopologyUtils.getComponentCpuMapConfig(topology),
+        TopologyUtils.getComponentDiskMapConfig(topology),
+        defaultInstanceResources
+    );
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/heron/packing/src/java/org/apache/heron/packing/builder/Container.java
+++ b/heron/packing/src/java/org/apache/heron/packing/builder/Container.java
@@ -155,8 +155,7 @@ public class Container {
   public Resource getTotalUsedResources() {
     return getInstances().stream()
         .map(PackingPlan.InstancePlan::getResource)
-        .reduce(Resource::plus)
-        .orElse(Resource.EMPTY_RESOURCE)
+        .reduce(Resource.EMPTY_RESOURCE, Resource::plus)
         .plus(getPadding());
   }
 }

--- a/heron/packing/src/java/org/apache/heron/packing/builder/PackingPlanBuilder.java
+++ b/heron/packing/src/java/org/apache/heron/packing/builder/PackingPlanBuilder.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -37,32 +36,32 @@ import java.util.logging.Logger;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 
-import org.apache.heron.common.basics.ByteAmount;
 import org.apache.heron.packing.constraints.InstanceConstraint;
 import org.apache.heron.packing.constraints.PackingConstraint;
 import org.apache.heron.packing.exceptions.ConstraintViolationException;
 import org.apache.heron.packing.exceptions.ResourceExceededException;
-import org.apache.heron.packing.utils.PackingUtils;
 import org.apache.heron.spi.packing.InstanceId;
 import org.apache.heron.spi.packing.PackingException;
 import org.apache.heron.spi.packing.PackingPlan;
 import org.apache.heron.spi.packing.Resource;
 
 /**
- * Class the help with building packing plans.
+ * Class that helps with building packing plans.
  */
 public class PackingPlanBuilder {
   private static final Logger LOG = Logger.getLogger(PackingPlanBuilder.class.getName());
 
   private final String topologyId;
   private final PackingPlan existingPacking;
+
   private Resource defaultInstanceResource;
   private Resource maxContainerResource;
-  private Map<String, ByteAmount> componentRamMap;
-  private int requestedContainerPadding;
-  private int numContainers;
+  private Map<String, Resource> componentResourceMap;
+  private Resource requestedContainerPadding;
   private List<PackingConstraint> packingConstraints;
   private List<InstanceConstraint> instanceConstraints;
+
+  private int numContainers;
 
   private Map<Integer, Container> containers;
   private TreeSet<Integer> taskIds; // globally unique ids assigned to instances
@@ -76,10 +75,13 @@ public class PackingPlanBuilder {
     this.topologyId = topologyId;
     this.existingPacking = existingPacking;
     this.numContainers = 0;
-    this.requestedContainerPadding = 0;
-    this.componentRamMap = new HashMap<>();
+    this.requestedContainerPadding = Resource.EMPTY_RESOURCE;
     this.packingConstraints = new ArrayList<>();
     this.instanceConstraints = new ArrayList<>();
+  }
+
+  public Map<Integer, Container> getContainers() {
+    return containers;
   }
 
   // set resource settings
@@ -93,13 +95,13 @@ public class PackingPlanBuilder {
     return this;
   }
 
-  public PackingPlanBuilder setRequestedComponentRam(Map<String, ByteAmount> ramMap) {
-    this.componentRamMap = ramMap;
+  public PackingPlanBuilder setRequestedComponentResource(Map<String, Resource> resourceMap) {
+    this.componentResourceMap = resourceMap;
     return this;
   }
 
-  public PackingPlanBuilder setRequestedContainerPadding(int percent) {
-    this.requestedContainerPadding = percent;
+  public PackingPlanBuilder setRequestedContainerPadding(Resource padding) {
+    this.requestedContainerPadding = padding;
     return this;
   }
 
@@ -125,17 +127,16 @@ public class PackingPlanBuilder {
   // updateNumContainers method
   public PackingPlanBuilder addInstance(Integer containerId,
                                         String componentName) throws ConstraintViolationException {
+    // create container if not existed
     initContainer(containerId);
 
     Integer taskId = taskIds.isEmpty() ? 1 : taskIds.last() + 1;
-    Integer componentIndex = componentIndexes.get(componentName) != null
+    Integer componentIndex = componentIndexes.containsKey(componentName)
         ? componentIndexes.get(componentName).last() + 1 : 0;
-
     InstanceId instanceId = new InstanceId(componentName, taskId, componentIndex);
 
-    Resource instanceResource = PackingUtils.getResourceRequirement(
-        componentName, this.componentRamMap, this.defaultInstanceResource,
-        this.maxContainerResource, this.requestedContainerPadding);
+    Resource instanceResource = componentResourceMap.getOrDefault(componentName,
+        defaultInstanceResource);
 
     Container container = containers.get(containerId);
     PackingPlan.InstancePlan instancePlan
@@ -158,23 +159,23 @@ public class PackingPlanBuilder {
   /**
    * Add an instance to the first container possible ranked by score.
    * @return containerId of the container the instance was added to
-   * @throws org.apache.heron.packing.ResourceExceededException if the instance could not be added
+   * @throws ResourceExceededException if the instance could not be added
    */
   public int addInstance(Scorer<Container> scorer,
                          String componentName) throws ResourceExceededException {
     List<Scorer<Container>> scorers = new LinkedList<>();
     scorers.add(scorer);
-    return addInstance(scorers, componentName);
+    return addInstanceToExistingContainers(scorers, componentName);
   }
 
   @SuppressWarnings("JavadocMethod")
   /**
-   * Add an instance to the first container possible ranked by score. If a scoring tie exists,
-   * uses the next scorer in the scorers list to break the tie.
+   * Add an instance to the first container possible ranked by score.
+   * If a scoring tie exists, uses the next scorer in the scorers list to break the tie.
    * @return containerId of the container the instance was added to
-   * @throws org.apache.heron.packing.ResourceExceededException if the instance could not be added
+   * @throws ResourceExceededException if no existing container can accommodate the instance
    */
-  private int addInstance(List<Scorer<Container>> scorers, String componentName)
+  public int addInstanceToExistingContainers(List<Scorer<Container>> scorers, String componentName)
       throws ResourceExceededException {
     initContainers();
     for (Container container : sortContainers(scorers, this.containers.values())) {
@@ -203,7 +204,7 @@ public class PackingPlanBuilder {
         container.removeAnyInstanceOfComponent(componentName);
     if (instancePlan.isPresent()) {
       taskIds.remove(instancePlan.get().getTaskId());
-      if (componentIndexes.get(componentName) != null) {
+      if (componentIndexes.containsKey(componentName)) {
         componentIndexes.get(componentName).remove(instancePlan.get().getComponentIndex());
       }
     } else {
@@ -248,65 +249,52 @@ public class PackingPlanBuilder {
   // build container plan sets by summing up instance resources
   public PackingPlan build() {
     assertResourceSettings();
-    Set<PackingPlan.ContainerPlan> containerPlans = buildContainerPlans(
-        this.containers, this.componentRamMap,
-        this.defaultInstanceResource, this.requestedContainerPadding);
-
+    Set<PackingPlan.ContainerPlan> containerPlans = buildContainerPlans(this.containers);
     return new PackingPlan(topologyId, containerPlans);
   }
 
   private void initContainers() {
     assertResourceSettings();
-    Map<Integer, Container> newContainerMap = this.containers;
-    HashMap<String, TreeSet<Integer>> newComponentIndexes = this.componentIndexes;
-    TreeSet<Integer> newTaskIds = this.taskIds;
 
-    if (newComponentIndexes == null) {
-      newComponentIndexes = new HashMap<>();
+    if (this.componentIndexes == null) {
+      this.componentIndexes = new HashMap<>();
     }
 
-    if (newTaskIds == null) {
-      newTaskIds = new TreeSet<>();
+    if (this.taskIds == null) {
+      this.taskIds = new TreeSet<>();
     }
 
     // if this is the first time called, initialize container map with empty or existing containers
-    if (newContainerMap == null) {
+    if (this.containers == null) {
       if (this.existingPacking == null) {
-        newContainerMap = new HashMap<>();
+        this.containers = new HashMap<>();
         for (int containerId = 1; containerId <= numContainers; containerId++) {
-          newContainerMap.put(containerId, new Container(
+          this.containers.put(containerId, new Container(
               containerId, this.maxContainerResource, this.requestedContainerPadding));
         }
       } else {
-        try {
-          newContainerMap = getContainers(this.existingPacking, this.requestedContainerPadding,
-              newComponentIndexes, newTaskIds);
-        } catch (ResourceExceededException e) {
-          throw new PackingException(
-              "Could not initialize containers using existing packing plan", e);
-        }
+        this.containers = getContainers(this.existingPacking,
+            this.maxContainerResource,
+            this.requestedContainerPadding,
+            this.componentIndexes, this.taskIds);
       }
     }
 
-    if (this.numContainers > newContainerMap.size()) {
+    if (this.numContainers > this.containers.size()) {
       List<Scorer<Container>> scorers = new ArrayList<>();
       scorers.add(new ContainerIdScorer());
-      List<Container> sortedContainers = sortContainers(scorers, newContainerMap.values());
+      List<Container> sortedContainers = sortContainers(scorers, this.containers.values());
 
       int nextContainerId = sortedContainers.get(sortedContainers.size() - 1).getContainerId() + 1;
       Resource capacity =
-          newContainerMap.get(sortedContainers.get(0).getContainerId()).getCapacity();
+          this.containers.get(sortedContainers.get(0).getContainerId()).getCapacity();
 
-      for (int i = 0; i < numContainers - newContainerMap.size(); i++) {
-        newContainerMap.put(nextContainerId,
+      for (int i = 0; i < numContainers - this.containers.size(); i++) {
+        this.containers.put(nextContainerId,
             new Container(nextContainerId, capacity, this.requestedContainerPadding));
         nextContainerId++;
       }
     }
-
-    this.containers = newContainerMap;
-    this.componentIndexes = newComponentIndexes;
-    this.taskIds = newTaskIds;
   }
 
   private void initContainer(int containerId) {
@@ -335,10 +323,7 @@ public class PackingPlanBuilder {
    * @return container plans
    */
   private static Set<PackingPlan.ContainerPlan> buildContainerPlans(
-      Map<Integer, Container> containerInstances,
-      Map<String, ByteAmount> ramMap,
-      Resource instanceDefaults,
-      int paddingPercentage) {
+      Map<Integer, Container> containerInstances) {
     Set<PackingPlan.ContainerPlan> containerPlans = new LinkedHashSet<>();
 
     for (Integer containerId : containerInstances.keySet()) {
@@ -347,46 +332,13 @@ public class PackingPlanBuilder {
         continue;
       }
 
-      ByteAmount containerRam = ByteAmount.ZERO;
-      ByteAmount containerDiskInBytes = ByteAmount.ZERO;
-      double containerCpu = 0;
-
-      // Calculate the resource required for single instance
-      Set<PackingPlan.InstancePlan> instancePlans = new HashSet<>();
-
-      for (PackingPlan.InstancePlan instancePlan : container.getInstances()) {
-        InstanceId instanceId = new InstanceId(instancePlan.getComponentName(),
-            instancePlan.getTaskId(), instancePlan.getComponentIndex());
-        ByteAmount instanceRam;
-        if (ramMap.containsKey(instanceId.getComponentName())) {
-          instanceRam = ramMap.get(instanceId.getComponentName());
-        } else {
-          instanceRam = instanceDefaults.getRam();
-        }
-        containerRam = containerRam.plus(instanceRam);
-
-        // Currently not yet support disk or CPU config for different components,
-        // so just use the default value.
-        ByteAmount instanceDisk = instanceDefaults.getDisk();
-        containerDiskInBytes = containerDiskInBytes.plus(instanceDisk);
-
-        double instanceCpu = instanceDefaults.getCpu();
-        containerCpu += instanceCpu;
-
-        // Insert it into the map
-        instancePlans.add(new PackingPlan.InstancePlan(instanceId,
-            new Resource(instanceCpu, instanceRam, instanceDisk)));
-      }
-
-      containerCpu += (paddingPercentage * containerCpu) / 100;
-      containerRam = containerRam.increaseBy(paddingPercentage);
-      containerDiskInBytes = containerDiskInBytes.increaseBy(paddingPercentage);
-
-      Resource resource =
-          new Resource(Math.round(containerCpu), containerRam, containerDiskInBytes);
+      Resource totalUsedResources = container.getTotalUsedResources();
+      Resource resource = new Resource(
+          Math.round(totalUsedResources.getCpu()),
+          totalUsedResources.getRam(), totalUsedResources.getDisk());
 
       PackingPlan.ContainerPlan containerPlan =
-          new PackingPlan.ContainerPlan(containerId, instancePlans, resource);
+          new PackingPlan.ContainerPlan(containerId, container.getInstances(), resource);
 
       containerPlans.add(containerPlan);
     }
@@ -402,23 +354,16 @@ public class PackingPlanBuilder {
    */
   @VisibleForTesting
   static Map<Integer, Container> getContainers(
-      PackingPlan currentPackingPlan, int paddingPercentage,
-      Map<String, TreeSet<Integer>> componentIndexes, TreeSet<Integer> taskIds)
-      throws ResourceExceededException {
+      PackingPlan currentPackingPlan, Resource maxContainerResource, Resource padding,
+      Map<String, TreeSet<Integer>> componentIndexes, TreeSet<Integer> taskIds) {
     Map<Integer, Container> containers = new HashMap<>();
 
-    Resource capacity = currentPackingPlan.getMaxContainerResources();
+    Resource capacity = maxContainerResource;
     for (PackingPlan.ContainerPlan currentContainerPlan : currentPackingPlan.getContainers()) {
       Container container =
-          new Container(currentContainerPlan.getId(), capacity, paddingPercentage);
+          new Container(currentContainerPlan.getId(), capacity, padding);
       for (PackingPlan.InstancePlan instancePlan : currentContainerPlan.getInstances()) {
-        try {
-          addToContainer(container, instancePlan, componentIndexes, taskIds);
-        } catch (ResourceExceededException e) {
-          throw new ResourceExceededException(String.format(
-              "Insufficient container resources to add instancePlan %s to container %s",
-              instancePlan, container), e);
-        }
+        addToContainer(container, instancePlan, componentIndexes, taskIds);
       }
       containers.put(currentContainerPlan.getId(), container);
     }
@@ -439,7 +384,7 @@ public class PackingPlanBuilder {
   private static void addToContainer(Container container,
                                      PackingPlan.InstancePlan instancePlan,
                                      Map<String, TreeSet<Integer>> componentIndexes,
-                                     Set<Integer> taskIds) throws ResourceExceededException {
+                                     Set<Integer> taskIds) {
     container.add(instancePlan);
     String componentName = instancePlan.getComponentName();
 

--- a/heron/packing/src/java/org/apache/heron/packing/builder/RamRequirement.java
+++ b/heron/packing/src/java/org/apache/heron/packing/builder/RamRequirement.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.heron.packing;
+package org.apache.heron.packing.builder;
 
 import org.apache.heron.common.basics.ByteAmount;
 

--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -140,13 +140,7 @@ public class ResourceCompliantRRPacking extends AbstractPacking {
         LOG.finest(String.format(
             "%s Increasing the number of containers to %s and attempting to place again.",
             e.getMessage(), this.numContainers + 1));
-        increaseNumContainers(1);
-        resetToFirstContainer();
-
-        int totalInstances = TopologyUtils.getTotalInstance(topology);
-        if (numContainers > totalInstances) {
-          throw new PackingException("Cannot add to that container");
-        }
+        retryWithAdditionalContainer();
       }
     }
   }
@@ -178,18 +172,22 @@ public class ResourceCompliantRRPacking extends AbstractPacking {
         return planBuilder.build();
 
       } catch (ConstraintViolationException e) {
-        LOG.info(String.format(
-            "%s Increasing the number of containers to %s and attempting packing again.",
-            e.getMessage(), this.numContainers));
         //Not enough containers. Adjust the number of containers.
-        increaseNumContainers(1);
-        resetToFirstContainer();
-
-        int totalInstances = TopologyUtils.getTotalInstance(topology);
-        if (numContainers > totalInstances) {
-          throw new PackingException("Cannot add to that container");
-        }
+        LOG.info(String.format(
+            "%s Increasing the number of containers to %s and attempting to repack again.",
+            e.getMessage(), this.numContainers + 1));
+        retryWithAdditionalContainer();
       }
+    }
+  }
+
+  private void retryWithAdditionalContainer() {
+    increaseNumContainers(1);
+    resetToFirstContainer();
+
+    int totalInstances = TopologyUtils.getTotalInstance(topology);
+    if (numContainers > totalInstances) {
+      throw new PackingException("Cannot add to that container");
     }
   }
 

--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -27,7 +27,7 @@ import java.util.logging.Logger;
 
 import org.apache.heron.api.generated.TopologyAPI;
 import org.apache.heron.api.utils.TopologyUtils;
-import org.apache.heron.common.basics.ByteAmount;
+import org.apache.heron.packing.AbstractPacking;
 import org.apache.heron.packing.builder.Container;
 import org.apache.heron.packing.builder.ContainerIdScorer;
 import org.apache.heron.packing.builder.HomogeneityScorer;
@@ -40,17 +40,9 @@ import org.apache.heron.packing.exceptions.ConstraintViolationException;
 import org.apache.heron.packing.exceptions.ResourceExceededException;
 import org.apache.heron.packing.utils.PackingUtils;
 import org.apache.heron.spi.common.Config;
-import org.apache.heron.spi.common.Context;
-import org.apache.heron.spi.packing.IPacking;
-import org.apache.heron.spi.packing.IRepacking;
 import org.apache.heron.spi.packing.PackingException;
 import org.apache.heron.spi.packing.PackingPlan;
 import org.apache.heron.spi.packing.Resource;
-
-import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED;
-import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED;
-import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_PADDING_PERCENTAGE;
-import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED;
 
 /**
  * ResourceCompliantRoundRobin packing algorithm
@@ -95,15 +87,8 @@ import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED;
  * 10. The pack() return null if PackingPlan fails to pass the safe check, for instance,
  * the size of RAM for an instance is less than the minimal required value.
  */
-public class ResourceCompliantRRPacking implements IPacking, IRepacking {
-
-  static final int DEFAULT_CONTAINER_PADDING_PERCENTAGE = 10;
-  private static final int DEFAULT_NUMBER_INSTANCES_PER_CONTAINER = 4;
-
+public class ResourceCompliantRRPacking extends AbstractPacking {
   private static final Logger LOG = Logger.getLogger(ResourceCompliantRRPacking.class.getName());
-
-  private TopologyAPI.Topology topology;
-  private Resource defaultInstanceResources;
 
   private int numContainers;
   //ContainerId to examine next. It is set to 1 when the
@@ -124,52 +109,17 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
 
   @Override
   public void initialize(Config config, TopologyAPI.Topology inputTopology) {
-    this.topology = inputTopology;
+    super.initialize(config, inputTopology);
     this.numContainers = TopologyUtils.getNumContainers(topology);
-    this.defaultInstanceResources = new Resource(
-        Context.instanceCpu(config),
-        Context.instanceRam(config),
-        Context.instanceDisk(config));
     resetToFirstContainer();
-
-    LOG.info(String.format("Initializing ResourceCompliantRRPacking. "
-        + "CPU default: %f, RAM default: %s, DISK default: %s.",
-        this.defaultInstanceResources.getCpu(),
-        this.defaultInstanceResources.getRam().toString(),
-        this.defaultInstanceResources.getDisk().toString()));
   }
 
   private PackingPlanBuilder newPackingPlanBuilder(PackingPlan existingPackingPlan) {
-    List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
-
-    double defaultCpu = this.defaultInstanceResources.getCpu()
-        * DEFAULT_NUMBER_INSTANCES_PER_CONTAINER;
-    ByteAmount defaultRam = this.defaultInstanceResources.getRam()
-        .multiply(DEFAULT_NUMBER_INSTANCES_PER_CONTAINER);
-    ByteAmount defaultDisk = this.defaultInstanceResources.getDisk()
-        .multiply(DEFAULT_NUMBER_INSTANCES_PER_CONTAINER);
-    int paddingPercentage = TopologyUtils.getConfigWithDefault(topologyConfig,
-        TOPOLOGY_CONTAINER_PADDING_PERCENTAGE, DEFAULT_CONTAINER_PADDING_PERCENTAGE);
-
-    Resource maxContainerResources = new Resource(
-        TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_CPU_REQUESTED,
-            (double) Math.round(PackingUtils.increaseBy(defaultCpu, paddingPercentage))),
-        TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_RAM_REQUESTED,
-            defaultRam.increaseBy(paddingPercentage)),
-        TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_DISK_REQUESTED,
-            defaultDisk.increaseBy(paddingPercentage)));
-
-    LOG.info(String.format("ResourceCompliantRRPacking newPackingPlanBuilder. "
-        + "CPU max: %f, RAMmaxMax: %s, DISK max: %s, Padding percentage: %d.",
-        maxContainerResources.getCpu(),
-        maxContainerResources.getRam().toString(),
-        maxContainerResources.getDisk().toString(),
-        paddingPercentage));
     return new PackingPlanBuilder(topology.getId(), existingPackingPlan)
-        .setMaxContainerResource(maxContainerResources)
         .setDefaultInstanceResource(defaultInstanceResources)
-        .setRequestedContainerPadding(paddingPercentage)
-        .setRequestedComponentRam(TopologyUtils.getComponentRamMapConfig(topology))
+        .setMaxContainerResource(maxContainerResources)
+        .setRequestedContainerPadding(padding)
+        .setRequestedComponentResource(componentResourceMap)
         .setInstanceConstraints(Collections.singletonList(new MinRamConstraint()))
         .setPackingConstraints(Collections.singletonList(new ResourceConstraint()));
   }
@@ -192,6 +142,11 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
             e.getMessage(), this.numContainers + 1));
         increaseNumContainers(1);
         resetToFirstContainer();
+
+        int totalInstances = TopologyUtils.getTotalInstance(topology);
+        if (numContainers > totalInstances) {
+          throw new PackingException("Cannot add to that container");
+        }
       }
     }
   }
@@ -223,12 +178,17 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
         return planBuilder.build();
 
       } catch (ConstraintViolationException e) {
-        //Not enough containers. Adjust the number of containers.
-        increaseNumContainers(1);
-        resetToFirstContainer();
         LOG.info(String.format(
             "%s Increasing the number of containers to %s and attempting packing again.",
             e.getMessage(), this.numContainers));
+        //Not enough containers. Adjust the number of containers.
+        increaseNumContainers(1);
+        resetToFirstContainer();
+
+        int totalInstances = TopologyUtils.getTotalInstance(topology);
+        if (numContainers > totalInstances) {
+          throw new PackingException("Cannot add to that container");
+        }
       }
     }
   }
@@ -239,10 +199,6 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
       throws PackingException, UnsupportedOperationException {
     throw new UnsupportedOperationException("ResourceCompliantRRPacking does not "
         + "currently support creating a new packing plan with a new number of containers.");
-  }
-
-  @Override
-  public void close() {
   }
 
   /**

--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
@@ -36,7 +36,7 @@ import org.apache.heron.api.utils.TopologyUtils;
 import org.apache.heron.common.basics.ByteAmount;
 import org.apache.heron.common.basics.CPUShare;
 import org.apache.heron.common.basics.ResourceMeasure;
-import org.apache.heron.packing.RamRequirement;
+import org.apache.heron.packing.builder.RamRequirement;
 import org.apache.heron.spi.common.Config;
 import org.apache.heron.spi.common.Context;
 import org.apache.heron.spi.packing.IPacking;

--- a/heron/packing/src/java/org/apache/heron/packing/utils/PackingUtils.java
+++ b/heron/packing/src/java/org/apache/heron/packing/utils/PackingUtils.java
@@ -26,7 +26,6 @@ import java.util.logging.Logger;
 import org.apache.heron.api.generated.TopologyAPI;
 import org.apache.heron.api.utils.TopologyUtils;
 import org.apache.heron.common.basics.ByteAmount;
-import org.apache.heron.spi.packing.PackingException;
 import org.apache.heron.spi.packing.Resource;
 
 /**
@@ -34,66 +33,35 @@ import org.apache.heron.spi.packing.Resource;
  */
 public final class PackingUtils {
   private static final Logger LOG = Logger.getLogger(PackingUtils.class.getName());
-  private static final ByteAmount MIN_RAM_PER_INSTANCE = ByteAmount.fromMegabytes(192);
+
+  // default
+  public static final int DEFAULT_CONTAINER_PADDING_PERCENTAGE = 10;
+  public static final ByteAmount DEFAULT_CONTAINER_RAM_PADDING = ByteAmount.fromGigabytes(1);
+  public static final ByteAmount DEFAULT_CONTAINER_DISK_PADDING = ByteAmount.fromGigabytes(1);
+  public static final double DEFAULT_CONTAINER_CPU_PADDING = 1.0;
+  public static final int DEFAULT_MAX_NUM_INSTANCES_PER_CONTAINER = 4;
 
   private PackingUtils() {
   }
 
-  /**
-   * Verifies the Instance has enough RAM and that it can fit within the container limits.
-   *
-   * @param instanceResources The resources allocated to the instance
-   * @throws PackingException if the instance is invalid
-   */
-  private static void assertIsValidInstance(Resource instanceResources,
-                                            ByteAmount minInstanceRam,
-                                            Resource maxContainerResources,
-                                            int paddingPercentage) throws PackingException {
-
-    if (instanceResources.getRam().lessThan(minInstanceRam)) {
-      throw new PackingException(String.format(
-          "Instance requires RAM %s which is less than the minimum RAM per instance of %s",
-          instanceResources.getRam(), minInstanceRam));
+  public static Map<String, Resource> getComponentResourceMap(
+      Map<String, Integer> parallelismMap,
+      Map<String, ByteAmount> componentRamMap,
+      Map<String, Double> componentCpuMap,
+      Map<String, ByteAmount> componentDiskMap,
+      Resource defaultInstanceResource) {
+    Map<String, Resource> componentResourceMap = new HashMap<>();
+    for (String component : parallelismMap.keySet()) {
+      ByteAmount instanceRam = componentRamMap.getOrDefault(component,
+          defaultInstanceResource.getRam());
+      double instanceCpu = componentCpuMap.getOrDefault(component,
+          defaultInstanceResource.getCpu());
+      ByteAmount instanceDisk = componentDiskMap.getOrDefault(component,
+          defaultInstanceResource.getDisk());
+      componentResourceMap.put(component, new Resource(instanceCpu, instanceRam, instanceDisk));
     }
 
-    ByteAmount instanceRam = instanceResources.getRam().increaseBy(paddingPercentage);
-    if (instanceRam.greaterThan(maxContainerResources.getRam())) {
-      throw new PackingException(String.format(
-          "This instance requires containers of at least %s RAM. The current max container "
-              + "size is %s",
-          instanceRam, maxContainerResources.getRam()));
-    }
-
-    double instanceCpu = Math.round(PackingUtils.increaseBy(
-        instanceResources.getCpu(), paddingPercentage));
-    if (instanceCpu > maxContainerResources.getCpu()) {
-      throw new PackingException(String.format(
-          "This instance requires containers with at least %s CPU cores. The current max container"
-              + "size is %s cores",
-          instanceCpu, maxContainerResources.getCpu()));
-    }
-
-    ByteAmount instanceDisk = instanceResources.getDisk().increaseBy(paddingPercentage);
-    if (instanceDisk.greaterThan(maxContainerResources.getDisk())) {
-      throw new PackingException(String.format(
-          "This instance requires containers of at least %s disk. The current max container"
-              + "size is %s",
-          instanceDisk, maxContainerResources.getDisk()));
-    }
-  }
-
-  public static Resource getResourceRequirement(String component,
-                                                Map<String, ByteAmount> componentRamMap,
-                                                Resource defaultInstanceResource,
-                                                Resource maxContainerResource,
-                                                int paddingPercentage) {
-    ByteAmount instanceRam = defaultInstanceResource.getRam();
-    if (componentRamMap.containsKey(component)) {
-      instanceRam = componentRamMap.get(component);
-    }
-    assertIsValidInstance(defaultInstanceResource.cloneWithRam(instanceRam),
-        MIN_RAM_PER_INSTANCE, maxContainerResource, paddingPercentage);
-    return defaultInstanceResource.cloneWithRam(instanceRam);
+    return componentResourceMap;
   }
 
   public static long increaseBy(long value, int paddingPercentage) {
@@ -102,6 +70,17 @@ public final class PackingUtils {
 
   public static double increaseBy(double value, int paddingPercentage) {
     return value + (paddingPercentage * value) / 100;
+  }
+
+  public static Resource finalizePadding(
+      Resource containerResource, Resource padding, int paddingPercentage) {
+    double cpuPadding = Math.max(padding.getCpu(),
+        containerResource.getCpu() * paddingPercentage / 100);
+    ByteAmount ramPadding = ByteAmount.fromBytes(Math.max(padding.getRam().asBytes(),
+        containerResource.getRam().asBytes() * paddingPercentage / 100));
+    ByteAmount diskPadding = ByteAmount.fromBytes(Math.max(padding.getDisk().asBytes(),
+        containerResource.getDisk().asBytes() * paddingPercentage / 100));
+    return new Resource(cpuPadding, ramPadding, diskPadding);
   }
 
   /**

--- a/heron/packing/src/java/org/apache/heron/packing/utils/PackingUtils.java
+++ b/heron/packing/src/java/org/apache/heron/packing/utils/PackingUtils.java
@@ -21,6 +21,7 @@ package org.apache.heron.packing.utils;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 import org.apache.heron.api.generated.TopologyAPI;
@@ -44,14 +45,24 @@ public final class PackingUtils {
   private PackingUtils() {
   }
 
+  /**
+   * Compose the component resource map by reading from user configs or default
+   *
+   * @param components component names
+   * @param componentRamMap user configured component ram map
+   * @param componentCpuMap user configured component cpu map
+   * @param componentDiskMap user configured component disk map
+   * @param defaultInstanceResource default instance resources
+   * @return component resource map
+   */
   public static Map<String, Resource> getComponentResourceMap(
-      Map<String, Integer> parallelismMap,
+      Set<String> components,
       Map<String, ByteAmount> componentRamMap,
       Map<String, Double> componentCpuMap,
       Map<String, ByteAmount> componentDiskMap,
       Resource defaultInstanceResource) {
     Map<String, Resource> componentResourceMap = new HashMap<>();
-    for (String component : parallelismMap.keySet()) {
+    for (String component : components) {
       ByteAmount instanceRam = componentRamMap.getOrDefault(component,
           defaultInstanceResource.getRam());
       double instanceCpu = componentCpuMap.getOrDefault(component,
@@ -72,6 +83,14 @@ public final class PackingUtils {
     return value + (paddingPercentage * value) / 100;
   }
 
+  /**
+   * Finalize padding by taking Math.max(containerResource * paddingPercent, paddingValue)
+   *
+   * @param containerResource max container resource
+   * @param padding padding value
+   * @param paddingPercentage padding percent
+   * @return finalized padding amount
+   */
   public static Resource finalizePadding(
       Resource containerResource, Resource padding, int paddingPercentage) {
     double cpuPadding = Math.max(padding.getCpu(),
@@ -80,6 +99,7 @@ public final class PackingUtils {
         containerResource.getRam().asBytes() * paddingPercentage / 100));
     ByteAmount diskPadding = ByteAmount.fromBytes(Math.max(padding.getDisk().asBytes(),
         containerResource.getDisk().asBytes() * paddingPercentage / 100));
+
     return new Resource(cpuPadding, ramPadding, diskPadding);
   }
 

--- a/heron/packing/tests/java/org/apache/heron/packing/AssertPacking.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/AssertPacking.java
@@ -33,7 +33,6 @@ import org.apache.heron.spi.packing.InstanceId;
 import org.apache.heron.spi.packing.PackingPlan;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -51,50 +50,9 @@ public final class AssertPacking {
    * expectedBoltRam and likewise for spouts. If notExpectedContainerRam is not null, verifies that
    * the container RAM is not that.
    */
-  public static void assertContainers(Set<PackingPlan.ContainerPlan> containerPlans,
-                                      String boltName, String spoutName,
-                                      ByteAmount expectedBoltRam, ByteAmount expectedSpoutRam,
-                                      ByteAmount notExpectedContainerRam) {
-    boolean boltFound = false;
-    boolean spoutFound = false;
-    List<Integer> expectedInstanceIndices = new ArrayList<>();
-    List<Integer> foundInstanceIndices = new ArrayList<>();
-    int expectedInstanceIndex = 1;
-    // RAM for bolt should be the value in component RAM map
-    for (PackingPlan.ContainerPlan containerPlan : containerPlans) {
-      if (notExpectedContainerRam != null) {
-        assertNotEquals(notExpectedContainerRam, containerPlan.getRequiredResource().getRam());
-      }
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-        expectedInstanceIndices.add(expectedInstanceIndex++);
-        foundInstanceIndices.add(instancePlan.getTaskId());
-        if (instancePlan.getComponentName().equals(boltName)) {
-          assertEquals("Unexpected bolt RAM", expectedBoltRam, instancePlan.getResource().getRam());
-          boltFound = true;
-        }
-        if (instancePlan.getComponentName().equals(spoutName)) {
-          assertEquals(
-              "Unexpected spout RAM", expectedSpoutRam, instancePlan.getResource().getRam());
-          spoutFound = true;
-        }
-      }
-    }
-    assertTrue("Bolt not found in any of the container plans: " + boltName, boltFound);
-    assertTrue("Spout not found in any of the container plans: " + spoutName, spoutFound);
-
-    Collections.sort(foundInstanceIndices);
-    assertEquals("Unexpected instance global id set found.",
-        expectedInstanceIndices, foundInstanceIndices);
-  }
-
-  /**
-   * Verifies that the containerPlan has at least one bolt named boltName with RAM equal to
-   * expectedBoltRam and likewise for spouts. If notExpectedContainerRam is not null, verifies that
-   * the container RAM is not that.
-   */
   public static void assertInstanceRam(Set<PackingPlan.ContainerPlan> containerPlans,
-                                       String boltName, String spoutName,
-                                       ByteAmount expectedBoltRam, ByteAmount expectedSpoutRam) {
+                                      String boltName, String spoutName,
+                                      ByteAmount expectedBoltRam, ByteAmount expectedSpoutRam) {
     // RAM for bolt should be the value in component RAM map
     for (PackingPlan.ContainerPlan containerPlan : containerPlans) {
       for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
@@ -246,10 +204,7 @@ public final class AssertPacking {
                 instance.getComponentIndex() != instancePlan.getComponentIndex());
           }
         }
-        if (componentInstances.get(instancePlan.getComponentName()) == null) {
-          componentInstances.put(instancePlan.getComponentName(),
-              new HashSet<PackingPlan.InstancePlan>());
-        }
+        componentInstances.computeIfAbsent(instancePlan.getComponentName(), k -> new HashSet<>());
         componentInstances.get(instancePlan.getComponentName()).add(instancePlan);
       }
     }

--- a/heron/packing/tests/java/org/apache/heron/packing/CommonPackingTests.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/CommonPackingTests.java
@@ -46,8 +46,8 @@ import static org.apache.heron.packing.AssertPacking.DELTA;
  * There is some common functionality in multiple packing plans. This class contains common tests.
  */
 public abstract class CommonPackingTests {
-  protected static final String BOLT_NAME = "B";
-  protected static final String SPOUT_NAME = "A";
+  protected static final String BOLT_NAME = "bolt";
+  protected static final String SPOUT_NAME = "spout";
   protected static final int DEFAULT_CONTAINER_PADDING_PERCENT = 10;
   protected int spoutParallelism;
   protected int boltParallelism;

--- a/heron/packing/tests/java/org/apache/heron/packing/PackingTestHelper.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/PackingTestHelper.java
@@ -19,10 +19,17 @@
 
 package org.apache.heron.packing;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.heron.common.basics.ByteAmount;
 import org.apache.heron.common.basics.Pair;
 import org.apache.heron.packing.builder.PackingPlanBuilder;
+import org.apache.heron.packing.constraints.MinRamConstraint;
+import org.apache.heron.packing.constraints.ResourceConstraint;
 import org.apache.heron.packing.exceptions.ConstraintViolationException;
+import org.apache.heron.packing.utils.PackingUtils;
 import org.apache.heron.spi.packing.InstanceId;
 import org.apache.heron.spi.packing.PackingPlan;
 import org.apache.heron.spi.packing.Resource;
@@ -81,15 +88,21 @@ public final class PackingTestHelper {
     // use basic default resource to allow all instances to fit on a single container, if that's
     // what the tester desired. We can extend this to permit passing custom resource requirements
     // as needed.
-    builder.setDefaultInstanceResource(
-        new Resource(1, ByteAmount.fromMegabytes(192), ByteAmount.fromMegabytes(1)));
+    Resource defaultInstanceResource = new Resource(1,
+        ByteAmount.fromMegabytes(192), ByteAmount.fromMegabytes(1));
+
+    Map<String, Resource> componentResourceMap = PackingUtils.getComponentResourceMap(
+        toParallelismMap(previousPackingPlan, addInstances, removeInstances),
+        new HashMap<>(), new HashMap<>(), new HashMap<>(), defaultInstanceResource);
+
+    builder.setDefaultInstanceResource(defaultInstanceResource);
+    builder.setRequestedComponentResource(componentResourceMap);
     builder.setMaxContainerResource(new Resource(
         instanceCount,
         ByteAmount.fromMegabytes(192).multiply(instanceCount),
         ByteAmount.fromMegabytes(instanceCount)));
-
-    // This setting is important, see https://github.com/apache/incubator-heron/issues/1577
-    builder.setRequestedContainerPadding(containerPadding);
+    builder.setInstanceConstraints(Collections.singletonList(new MinRamConstraint()));
+    builder.setPackingConstraints(Collections.singletonList(new ResourceConstraint()));
 
     if (addInstances != null) {
       for (Pair<Integer, String> componentInstance : addInstances) {
@@ -116,5 +129,31 @@ public final class PackingTestHelper {
           containerIdInstanceId.first, containerIdInstanceId.second.getComponentName());
     }
     return containerIdComponentNames;
+  }
+
+  public static Map<String, Integer> toParallelismMap(
+      PackingPlan packingPlan,
+      Pair<Integer, String>[] containerIdInstanceIdsToAdd,
+      Pair<Integer, String>[] containerIdInstanceIdsToRemove) {
+    Map<String, Integer> parallelismMap = new HashMap<>();
+    if (packingPlan != null) {
+      parallelismMap = new HashMap<>(packingPlan.getComponentCounts());
+    }
+    if (containerIdInstanceIdsToAdd != null) {
+      for (Pair<Integer, String> containerIdInstanceId : containerIdInstanceIdsToAdd) {
+        String componentName = containerIdInstanceId.second;
+        parallelismMap.put(componentName, parallelismMap.getOrDefault(componentName, 0) + 1);
+      }
+    }
+    if (containerIdInstanceIdsToRemove != null) {
+      for (Pair<Integer, String> containerIdInstanceId : containerIdInstanceIdsToRemove) {
+        String componentName = containerIdInstanceId.second;
+        if (parallelismMap.containsKey(componentName)) {
+          parallelismMap.put(componentName, parallelismMap.get(componentName) - 1);
+        }
+      }
+    }
+
+    return parallelismMap;
   }
 }

--- a/heron/packing/tests/java/org/apache/heron/packing/PackingTestHelper.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/PackingTestHelper.java
@@ -92,7 +92,7 @@ public final class PackingTestHelper {
         ByteAmount.fromMegabytes(192), ByteAmount.fromMegabytes(1));
 
     Map<String, Resource> componentResourceMap = PackingUtils.getComponentResourceMap(
-        toParallelismMap(previousPackingPlan, addInstances, removeInstances),
+        toParallelismMap(previousPackingPlan, addInstances, removeInstances).keySet(),
         new HashMap<>(), new HashMap<>(), new HashMap<>(), defaultInstanceResource);
 
     builder.setDefaultInstanceResource(defaultInstanceResource);

--- a/heron/packing/tests/java/org/apache/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
@@ -27,10 +27,8 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
-import org.apache.heron.api.generated.TopologyAPI;
 import org.apache.heron.common.basics.ByteAmount;
 import org.apache.heron.common.basics.Pair;
-import org.apache.heron.packing.AssertPacking;
 import org.apache.heron.packing.CommonPackingTests;
 import org.apache.heron.packing.utils.PackingUtils;
 import org.apache.heron.spi.packing.IPacking;
@@ -53,8 +51,14 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
   }
 
   @Test (expected = PackingException.class)
-  public void testFailureInsufficientContainerRamHint() throws Exception {
-    topologyConfig.setContainerMaxRamHint(ByteAmount.ZERO);
+  public void testFailureInsufficientContainerRam() throws Exception {
+    topologyConfig.setContainerRamRequested(ByteAmount.ZERO);
+    pack(getTopology(spoutParallelism, boltParallelism, topologyConfig));
+  }
+
+  @Test (expected = PackingException.class)
+  public void testFailureInsufficientContainerCpu() throws Exception {
+    topologyConfig.setContainerCpuRequested(1.0);
     pack(getTopology(spoutParallelism, boltParallelism, topologyConfig));
   }
 
@@ -63,17 +67,10 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
    */
   @Test
   public void testDefaultContainerSize() throws Exception {
-    int defaultNumInstancesperContainer = 4;
-    PackingPlan packingPlan = pack(topology);
-
-    Assert.assertEquals(2, packingPlan.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlan.getInstanceCount());
-    ByteAmount defaultRam = instanceDefaultResources.getRam()
-        .multiply(defaultNumInstancesperContainer).increaseBy(DEFAULT_CONTAINER_PADDING);
-
-    AssertPacking.assertContainerRam(packingPlan.getContainers(), defaultRam);
-    AssertPacking.assertNumInstances(packingPlan.getContainers(), BOLT_NAME, 3);
-    AssertPacking.assertNumInstances(packingPlan.getContainers(), SPOUT_NAME, 4);
+    doPackingTest(topology,
+        instanceDefaultResources, boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        3, getDefaultMaxContainerResource());
   }
 
   /**
@@ -82,21 +79,14 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
   @Test
   public void testDefaultContainerSizeWithPadding() throws Exception {
     int padding = 50;
-    int defaultNumInstancesperContainer = 4;
 
     topologyConfig.setContainerPaddingPercentage(padding);
-    TopologyAPI.Topology newTopology =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlan = pack(newTopology);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    Assert.assertEquals(2, packingPlan.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlan.getInstanceCount());
-    ByteAmount defaultRam = instanceDefaultResources.getRam()
-        .multiply(defaultNumInstancesperContainer).increaseBy(padding);
-    AssertPacking.assertContainerRam(packingPlan.getContainers(),
-        defaultRam);
-    AssertPacking.assertNumInstances(packingPlan.getContainers(), BOLT_NAME, 3);
-    AssertPacking.assertNumInstances(packingPlan.getContainers(), SPOUT_NAME, 4);
+    doPackingTest(topology,
+        instanceDefaultResources, boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        4, getDefaultMaxContainerResource());
   }
 
   /**
@@ -108,36 +98,38 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
     ByteAmount containerRam = ByteAmount.fromGigabytes(10);
     ByteAmount containerDisk = ByteAmount.fromGigabytes(20);
     double containerCpu = 30;
+    Resource containerResource = new Resource(containerCpu, containerRam, containerDisk);
 
-    topologyConfig.setContainerMaxRamHint(containerRam);
-    topologyConfig.setContainerMaxDiskHint(containerDisk);
-    topologyConfig.setContainerMaxCpuHint(containerCpu);
+    Resource padding = PackingUtils.finalizePadding(
+        new Resource(containerCpu, containerRam, containerDisk),
+        new Resource(PackingUtils.DEFAULT_CONTAINER_CPU_PADDING,
+            PackingUtils.DEFAULT_CONTAINER_RAM_PADDING,
+            PackingUtils.DEFAULT_CONTAINER_RAM_PADDING),
+        PackingUtils.DEFAULT_CONTAINER_PADDING_PERCENTAGE);
 
-    TopologyAPI.Topology topologyExplicitResourcesConfig =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitResourcesConfig = pack(topologyExplicitResourcesConfig);
+    topologyConfig.setContainerRamRequested(containerRam);
+    topologyConfig.setContainerDiskRequested(containerDisk);
+    topologyConfig.setContainerCpuRequested(containerCpu);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    Assert.assertEquals(1, packingPlanExplicitResourcesConfig.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlanExplicitResourcesConfig.getInstanceCount());
-    AssertPacking.assertNumInstances(packingPlanExplicitResourcesConfig.getContainers(),
-        BOLT_NAME, 3);
-    AssertPacking.assertNumInstances(packingPlanExplicitResourcesConfig.getContainers(),
-        SPOUT_NAME, 4);
+    PackingPlan packingPlan = doPackingTest(topology,
+        instanceDefaultResources, boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        1, containerResource);
 
-    for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.getContainers()) {
-      Assert.assertEquals(Math.round(PackingUtils.increaseBy(
-          totalInstances * instanceDefaultResources.getCpu(), DEFAULT_CONTAINER_PADDING)),
+    for (PackingPlan.ContainerPlan containerPlan : packingPlan.getContainers()) {
+      Assert.assertEquals(Math.round(totalInstances * instanceDefaultResources.getCpu()
+              + padding.getCpu()),
           (long) containerPlan.getRequiredResource().getCpu());
 
       Assert.assertEquals(instanceDefaultResources.getRam()
               .multiply(totalInstances)
-              .increaseBy(DEFAULT_CONTAINER_PADDING),
+              .plus(padding.getRam()),
           containerPlan.getRequiredResource().getRam());
 
       Assert.assertEquals(instanceDefaultResources.getDisk()
               .multiply(totalInstances)
-              .increaseBy(DEFAULT_CONTAINER_PADDING),
+              .plus(padding.getDisk()),
           containerPlan.getRequiredResource().getDisk());
 
       // All instances' resource requirement should be equal
@@ -159,32 +151,26 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
   public void testCompleteRamMapRequested() throws Exception {
     // Explicit set max resources for container
     // the value should be ignored, since we set the complete component RAM map
-    ByteAmount maxContainerRam = ByteAmount.fromGigabytes(15);
-    ByteAmount maxContainerDisk = ByteAmount.fromGigabytes(20);
-    double maxContainerCpu = 30;
+    ByteAmount containerRam = ByteAmount.fromGigabytes(15);
+    ByteAmount containerDisk = ByteAmount.fromGigabytes(20);
+    double containerCpu = 30;
+    Resource containerResource = new Resource(containerCpu, containerRam, containerDisk);
 
     // Explicit set component RAM map
     ByteAmount boltRam = ByteAmount.fromGigabytes(1);
     ByteAmount spoutRam = ByteAmount.fromGigabytes(2);
 
-    topologyConfig.setContainerMaxRamHint(maxContainerRam);
-    topologyConfig.setContainerMaxDiskHint(maxContainerDisk);
-    topologyConfig.setContainerMaxCpuHint(maxContainerCpu);
+    topologyConfig.setContainerRamRequested(containerRam);
+    topologyConfig.setContainerDiskRequested(containerDisk);
+    topologyConfig.setContainerCpuRequested(containerCpu);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
     topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
-
-    Assert.assertEquals(1, packingPlanExplicitRamMap.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), BOLT_NAME, 3);
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), SPOUT_NAME, 4);
-    AssertPacking.assertContainers(packingPlanExplicitRamMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, spoutRam, maxContainerRam);
-    AssertPacking.assertContainerRam(packingPlanExplicitRamMap.getContainers(),
-        maxContainerRam);
+    doPackingTest(topology,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources.cloneWithRam(spoutRam), spoutParallelism,
+        1, containerResource);
   }
 
   /**
@@ -198,23 +184,15 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
     ByteAmount boltRam = ByteAmount.fromGigabytes(1);
     ByteAmount spoutRam = ByteAmount.fromGigabytes(2);
 
-    topologyConfig.setContainerMaxRamHint(maxContainerRam);
+    topologyConfig.setContainerRamRequested(maxContainerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
     topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
-
-    Assert.assertEquals(2, packingPlanExplicitRamMap.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), BOLT_NAME, 3);
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), SPOUT_NAME, 4);
-
-    AssertPacking.assertContainers(packingPlanExplicitRamMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, spoutRam, maxContainerRam);
-    AssertPacking.assertContainerRam(packingPlanExplicitRamMap.getContainers(),
-        maxContainerRam);
+    doPackingTest(topology,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources.cloneWithRam(spoutRam), spoutParallelism,
+        3, getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   /**
@@ -228,22 +206,14 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
     // Explicit set component RAM map
     ByteAmount boltRam = ByteAmount.fromGigabytes(4);
 
-    topologyConfig.setContainerMaxRamHint(maxContainerRam);
+    topologyConfig.setContainerRamRequested(maxContainerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
-
-    Assert.assertEquals(2, packingPlanExplicitRamMap.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), BOLT_NAME, 3);
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), SPOUT_NAME, 4);
-
-    AssertPacking.assertContainers(packingPlanExplicitRamMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, instanceDefaultResources.getRam(), maxContainerRam);
-    AssertPacking.assertContainerRam(packingPlanExplicitRamMap.getContainers(),
-        maxContainerRam);
+    doPackingTest(topology,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        3, getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   /**
@@ -258,27 +228,14 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
     // Explicit set component RAM map
     ByteAmount boltRam = ByteAmount.fromGigabytes(4);
 
-    topologyConfig.setContainerMaxRamHint(maxContainerRam);
+    topologyConfig.setContainerRamRequested(maxContainerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
-
-    Assert.assertEquals(2, packingPlanExplicitRamMap.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), BOLT_NAME, 3);
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), SPOUT_NAME, 4);
-
-    AssertPacking.assertContainers(packingPlanExplicitRamMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, instanceDefaultResources.getRam(), null);
-    AssertPacking.assertContainerRam(packingPlanExplicitRamMap.getContainers(),
-        maxContainerRam);
-  }
-
-  @Test
-  public void testContainersRequestedExceedsInstanceCount() throws Exception {
-    doTestContainerCountRequested(8, 2); // instances will fit into 2 containers
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    doPackingTest(topology,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        3, getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   /**
@@ -287,34 +244,13 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
    */
   @Test
   public void testDefaultContainerSizeRepack() throws Exception {
-    int defaultNumInstancesperContainer = 4;
     int numScalingInstances = 5;
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(BOLT_NAME, numScalingInstances);
-    int numContainersBeforeRepack = 2;
-    PackingPlan newPackingPlan = doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
-    Assert.assertEquals(3, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + numScalingInstances),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertContainers(newPackingPlan.getContainers(),
-        BOLT_NAME, SPOUT_NAME, instanceDefaultResources.getRam(),
-        instanceDefaultResources.getRam(), null);
-    for (PackingPlan.ContainerPlan containerPlan
-        : newPackingPlan.getContainers()) {
-      Assert.assertEquals(Math.round(PackingUtils.increaseBy(
-          defaultNumInstancesperContainer * instanceDefaultResources.getCpu(),
-          DEFAULT_CONTAINER_PADDING)), (long) containerPlan.getRequiredResource().getCpu());
-
-      Assert.assertEquals(instanceDefaultResources.getRam()
-          .multiply(defaultNumInstancesperContainer)
-          .increaseBy(DEFAULT_CONTAINER_PADDING),
-          containerPlan.getRequiredResource().getRam());
-
-      Assert.assertEquals(instanceDefaultResources.getDisk()
-          .multiply(defaultNumInstancesperContainer)
-          .increaseBy(DEFAULT_CONTAINER_PADDING),
-          containerPlan.getRequiredResource().getDisk());
-    }
+    int numContainersBeforeRepack = 3;
+    int numContainersAfterRepack = 4;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource());
   }
 
   /**
@@ -328,39 +264,21 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
     ByteAmount boltRam = ByteAmount.fromGigabytes(4);
     ByteAmount maxContainerRam = ByteAmount.fromGigabytes(10);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
-    topologyConfig.setContainerMaxRamHint(maxContainerRam);
-
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    topologyConfig.setContainerRamRequested(maxContainerRam);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
     int numScalingInstances = 3;
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(BOLT_NAME, numScalingInstances);
 
-    int numContainersBeforeRepack = 3;
-    PackingPlan newPackingPlan =
-        doScalingTest(topologyExplicitRamMap, componentChanges, boltRam,
-            boltParallelism, instanceDefaultResources.getRam(), spoutParallelism,
-            numContainersBeforeRepack, totalInstances);
+    int numContainersBeforeRepack = 4;
+    int numContainersAfterRepack = 6;
 
-    Assert.assertEquals(6, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + numScalingInstances),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertContainers(newPackingPlan.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, instanceDefaultResources.getRam(), null);
-
-    for (PackingPlan.ContainerPlan containerPlan : newPackingPlan.getContainers()) {
-      //Each container either contains a single bolt or 1 bolt and 2 spouts
-      if (containerPlan.getInstances().size() == 1) {
-        Assert.assertEquals(boltRam.increaseBy(paddingPercentage),
-            containerPlan.getRequiredResource().getRam());
-      }
-      if (containerPlan.getInstances().size() == 3) {
-        ByteAmount resourceRam = boltRam.plus(instanceDefaultResources.getRam().multiply(2));
-        Assert.assertEquals(resourceRam.increaseBy(paddingPercentage),
-            containerPlan.getRequiredResource().getRam());
-      }
-    }
+    doPackingAndScalingTest(topology, componentChanges,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   /**
@@ -368,29 +286,24 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
    */
   @Test
   public void testPartialRamMapScaling() throws Exception {
-
     ByteAmount boltRam = ByteAmount.fromGigabytes(4);
     ByteAmount maxContainerRam = ByteAmount.fromGigabytes(10);
-    topologyConfig.setContainerMaxRamHint(maxContainerRam);
+    topologyConfig.setContainerRamRequested(maxContainerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
     int numScalingInstances = 3;
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(BOLT_NAME, numScalingInstances);
 
-    int numContainersBeforeRepack = 2;
-    PackingPlan newPackingPlan = doScalingTest(topologyExplicitRamMap, componentChanges, boltRam,
-        boltParallelism, instanceDefaultResources.getRam(), spoutParallelism,
-        numContainersBeforeRepack, totalInstances);
-
-    Assert.assertEquals(4, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + numScalingInstances),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertContainers(newPackingPlan.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, instanceDefaultResources.getRam(), null);
+    int numContainersBeforeRepack = 3;
+    int numContainersAfterRepack = 4;
+    doPackingAndScalingTest(topology, componentChanges,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   /**
@@ -400,20 +313,13 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
   public void testScaleDown() throws Exception {
     int spoutScalingDown = -3;
     int boltScalingDown = -2;
-
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingDown); //leave 1 spout
     componentChanges.put(BOLT_NAME, boltScalingDown); //leave 1 bolt
-    int numContainersBeforeRepack = 2;
-    PackingPlan newPackingPlan = doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
-
-    Assert.assertEquals(2, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + spoutScalingDown + boltScalingDown),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        BOLT_NAME, 1);
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        SPOUT_NAME, 1);
+    int numContainersBeforeRepack = 3;
+    int numContainersAfterRepack = 1;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource());
   }
 
   /**
@@ -421,21 +327,13 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
    */
   @Test
   public void removeFirstContainer() throws Exception {
-    /* The packing plan consists of two containers. The first one contains 4 spouts and
-       the second one contains 3 bolts. During scaling we remove 4 spouts and thus the f
-       first container is removed.
-     */
     int spoutScalingDown = -4;
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingDown);
-    int numContainersBeforeRepack = 2;
-    PackingPlan newPackingPlan = doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
-
-    Assert.assertEquals(1, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + spoutScalingDown),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(), BOLT_NAME, 3);
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(), SPOUT_NAME, 0);
+    int numContainersBeforeRepack = 3;
+    int numContainersAfterRepack = 2;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource());
   }
 
   /**
@@ -448,14 +346,12 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
     topologyConfig.setContainerPaddingPercentage(paddingPercentage);
     ByteAmount spoutRam = ByteAmount.fromGigabytes(2);
     ByteAmount maxContainerRam = ByteAmount.fromGigabytes(12);
-    topologyConfig.setContainerMaxRamHint(maxContainerRam);
+    topologyConfig.setContainerRamRequested(maxContainerRam);
     topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
 
-    int noBolts = 2;
-    int noSpouts = 1;
-
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(noSpouts, noBolts, topologyConfig);
+    boltParallelism = 2;
+    spoutParallelism = 1;
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
     int spoutScalingUp = 1;
     int boltScalingDown = -2;
@@ -463,18 +359,14 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingUp); // 2 spouts
     componentChanges.put(BOLT_NAME, boltScalingDown); // 0 bolts
-    int numContainersBeforeRepack = 1;
-    PackingPlan newPackingPlan = doScalingTest(topologyExplicitRamMap, componentChanges,
-        instanceDefaultResources.getRam(), noBolts, spoutRam, noSpouts,
-        numContainersBeforeRepack, noSpouts + noBolts);
+    int numContainersBeforeRepack = 2;
+    int numContainersAfterRepack = 1;
 
-    Assert.assertEquals(1, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (noSpouts + noBolts + spoutScalingUp + boltScalingDown),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        BOLT_NAME, noBolts + boltScalingDown);
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        SPOUT_NAME, noSpouts + spoutScalingUp);
+    doPackingAndScalingTest(topology, componentChanges,
+        instanceDefaultResources, boltParallelism,
+        instanceDefaultResources.cloneWithRam(spoutRam), spoutParallelism,
+        numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   /**
@@ -487,14 +379,13 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
     topologyConfig.setContainerPaddingPercentage(paddingPercentage);
     ByteAmount spoutRam = ByteAmount.fromGigabytes(4);
     ByteAmount maxContainerRam = ByteAmount.fromGigabytes(12);
-    topologyConfig.setContainerMaxRamHint(maxContainerRam);
+    topologyConfig.setContainerRamRequested(maxContainerRam);
     topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
 
-    int noBolts = 3;
-    int noSpouts = 1;
+    boltParallelism = 3;
+    spoutParallelism = 1;
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(noSpouts, noBolts, topologyConfig);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
     int spoutScalingUp = 1;
     int boltScalingDown = -1;
@@ -502,107 +393,14 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingUp); // 2 spouts
     componentChanges.put(BOLT_NAME, boltScalingDown); // 2 bolts
-    int numContainersBeforeRepack = 1;
-    PackingPlan newPackingPlan = doScalingTest(topologyExplicitRamMap, componentChanges,
-        instanceDefaultResources.getRam(), noBolts, spoutRam, noSpouts,
-        numContainersBeforeRepack, noSpouts + noBolts);
+    int numContainersBeforeRepack = 2;
+    int numContainersAfterRepack = 2;
 
-    Assert.assertEquals(2, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (noSpouts + noBolts + spoutScalingUp + boltScalingDown),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        BOLT_NAME, noBolts + boltScalingDown);
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        SPOUT_NAME, noSpouts + spoutScalingUp);
-  }
-
-  /**
-   * Test the scenario where scaling down removes instances from containers that are most imbalanced
-   * (i.e., tending towards homogeneity) first. If there is a tie (e.g. AABB, AB), chooses from the
-   * container with the fewest instances, to favor ultimately removing  containers. If there is
-   * still a tie, favor removing from higher numbered containers
-   */
-  @Test
-  public void testScaleDownOneComponentRemoveContainer() throws Exception {
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
-        new Pair<>(1, new InstanceId(A, 1, 0)),
-        new Pair<>(1, new InstanceId(A, 2, 1)),
-        new Pair<>(1, new InstanceId(B, 3, 0)),
-        new Pair<>(3, new InstanceId(B, 4, 1)),
-        new Pair<>(3, new InstanceId(B, 5, 2)),
-        new Pair<>(4, new InstanceId(B, 6, 3)),
-        new Pair<>(4, new InstanceId(B, 7, 4))
-    };
-
-    Map<String, Integer> componentChanges = new HashMap<>();
-    componentChanges.put(B, -2);
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
-        new Pair<>(1, new InstanceId(A, 1, 0)),
-        new Pair<>(1, new InstanceId(A, 2, 1)),
-        new Pair<>(1, new InstanceId(B, 3, 0)),
-        new Pair<>(3, new InstanceId(B, 4, 1)),
-        new Pair<>(3, new InstanceId(B, 5, 2)),
-    };
-
-    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
-  }
-
-  @Test
-  public void testScaleDownTwoComponentsRemoveContainer() throws Exception {
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
-        new Pair<>(1, new InstanceId(A, 1, 0)),
-        new Pair<>(1, new InstanceId(A, 2, 1)),
-        new Pair<>(1, new InstanceId(B, 3, 0)),
-        new Pair<>(1, new InstanceId(B, 4, 1)),
-        new Pair<>(3, new InstanceId(A, 5, 2)),
-        new Pair<>(3, new InstanceId(A, 6, 3)),
-        new Pair<>(3, new InstanceId(B, 7, 2)),
-        new Pair<>(3, new InstanceId(B, 8, 3))
-    };
-
-    Map<String, Integer> componentChanges = new HashMap<>();
-    componentChanges.put(A, -2);
-    componentChanges.put(B, -2);
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
-        new Pair<>(1, new InstanceId(A, 1, 0)),
-        new Pair<>(1, new InstanceId(A, 2, 1)),
-        new Pair<>(1, new InstanceId(B, 3, 0)),
-        new Pair<>(1, new InstanceId(B, 4, 1)),
-    };
-
-    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
-  }
-
-  @Test
-  public void testScaleDownHomogenousFirst() throws Exception {
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
-        new Pair<>(1, new InstanceId(A, 1, 0)),
-        new Pair<>(1, new InstanceId(A, 2, 1)),
-        new Pair<>(1, new InstanceId(B, 3, 0)),
-        new Pair<>(3, new InstanceId(B, 4, 1)),
-        new Pair<>(3, new InstanceId(B, 5, 2)),
-        new Pair<>(3, new InstanceId(B, 6, 3)),
-        new Pair<>(3, new InstanceId(B, 7, 4))
-    };
-
-    Map<String, Integer> componentChanges = new HashMap<>();
-    componentChanges.put(B, -4);
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
-        new Pair<>(1, new InstanceId(A, 1, 0)),
-        new Pair<>(1, new InstanceId(A, 2, 1)),
-        new Pair<>(1, new InstanceId(B, 3, 0))
-    };
-
-    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
+    doPackingAndScalingTest(topology, componentChanges,
+        instanceDefaultResources, boltParallelism,
+        instanceDefaultResources.cloneWithRam(spoutRam), spoutParallelism,
+        numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   /**
@@ -616,36 +414,32 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingDown); // 0 spouts
     componentChanges.put(BOLT_NAME, boltScalingUp); // 9 bolts
-    int numContainersBeforeRepack = 2;
-    PackingPlan newPackingPlan = doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
-
-    Assert.assertEquals(3, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + spoutScalingDown + boltScalingUp),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        BOLT_NAME, 9);
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        SPOUT_NAME, 0);
+    int numContainersBeforeRepack = 3;
+    int numContainersAfterRepack = 3;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource());
   }
 
   @Test(expected = PackingException.class)
   public void testScaleDownInvalidScaleFactor() throws Exception {
-
     //try to remove more spout instances than possible
     int spoutScalingDown = -5;
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingDown);
 
-    int numContainersBeforeRepack = 2;
-    doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
+    int numContainersBeforeRepack = 3;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersBeforeRepack,
+        getDefaultMaxContainerResource());
   }
 
   @Test(expected = PackingException.class)
   public void testScaleDownInvalidComponent() throws Exception {
+    //try to remove a component that does not exist
     Map<String, Integer> componentChanges = new HashMap<>();
-    componentChanges.put("SPOUT_FAKE", -10); //try to remove a component that does not exist
-    int numContainersBeforeRepack = 2;
-    doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
+    componentChanges.put("SPOUT_FAKE", -10);
+    int numContainersBeforeRepack = 3;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersBeforeRepack,
+        getDefaultMaxContainerResource());
   }
 
   /**
@@ -654,55 +448,103 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
   @Test(expected = PackingException.class)
   public void testInvalidRamInstance() throws Exception {
     ByteAmount maxContainerRam = ByteAmount.fromGigabytes(10);
-    int defaultNumInstancesperContainer = 4;
-
-    // Explicit set component RAM map
     ByteAmount boltRam = ByteAmount.ZERO;
-
-    topologyConfig.setContainerMaxRamHint(maxContainerRam);
+    topologyConfig.setContainerRamRequested(maxContainerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), BOLT_NAME, 3);
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), SPOUT_NAME, 4);
-    AssertPacking.assertContainerRam(packingPlanExplicitRamMap.getContainers(),
-        instanceDefaultResources.getRam().multiply(defaultNumInstancesperContainer));
-  }
-
-  @Test
-  public void testTwoContainersRequested() throws Exception {
-    doTestContainerCountRequested(2, 2);
+    doPackingTest(topology,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        0, getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   /**
-   * Test the scenario where container level resource config are set
+   * Test the scenario where scaling down removes instances from containers that are most imbalanced
+   * (i.e., tending towards homogeneity) first. If there is a tie (e.g. AABB, AB), chooses from the
+   * container with the fewest instances, to favor ultimately removing  containers. If there is
+   * still a tie, favor removing from higher numbered containers
    */
-  protected void doTestContainerCountRequested(int requestedContainers,
-                                               int expectedContainer) throws Exception {
+  @Test
+  public void testScaleDownOneComponentRemoveContainer() throws Exception {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 1, 0)),
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 2, 1)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 3, 0)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 4, 1)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 5, 2)),
+        new Pair<>(4, new InstanceId(BOLT_NAME, 6, 3)),
+        new Pair<>(4, new InstanceId(BOLT_NAME, 7, 4))
+    };
 
-    // Explicit set resources for container
-    topologyConfig.setContainerRamRequested(ByteAmount.fromGigabytes(10));
-    topologyConfig.setContainerDiskRequested(ByteAmount.fromGigabytes(20));
-    topologyConfig.setContainerCpuRequested(30);
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, requestedContainers);
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(BOLT_NAME, -2);
 
-    TopologyAPI.Topology topologyExplicitResourcesConfig =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitResourcesConfig = pack(topologyExplicitResourcesConfig);
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 1, 0)),
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 2, 1)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 3, 0)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 4, 1)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 5, 2)),
+    };
 
-    Assert.assertEquals(expectedContainer,
-        packingPlanExplicitResourcesConfig.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlanExplicitResourcesConfig.getInstanceCount());
+    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
+  }
 
-    // RAM for bolt/spout should be the value in component RAM map
-    for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.getContainers()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-        Assert.assertEquals(instanceDefaultResources, instancePlan.getResource());
-      }
-    }
+  @Test
+  public void testScaleDownTwoComponentsRemoveContainer() throws Exception {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 1, 0)),
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 2, 1)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 3, 0)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 4, 1)),
+        new Pair<>(3, new InstanceId(SPOUT_NAME, 5, 2)),
+        new Pair<>(3, new InstanceId(SPOUT_NAME, 6, 3)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 7, 2)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 8, 3))
+    };
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(SPOUT_NAME, -2);
+    componentChanges.put(BOLT_NAME, -2);
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 1, 0)),
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 2, 1)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 3, 0)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 4, 1)),
+    };
+
+    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
+  }
+
+  @Test
+  public void testScaleDownHomogenousFirst() throws Exception {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 1, 0)),
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 2, 1)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 3, 0)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 4, 1)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 5, 2)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 6, 3)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 7, 4))
+    };
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(BOLT_NAME, -4);
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 1, 0)),
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 2, 1)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 3, 0))
+    };
+
+    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
   }
 }

--- a/heron/packing/tests/java/org/apache/heron/packing/builder/ScorerTest.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/builder/ScorerTest.java
@@ -41,9 +41,9 @@ public class ScorerTest {
     Resource containerCapacity
         = new Resource(1000, ByteAmount.fromGigabytes(100), ByteAmount.fromGigabytes(100));
     testContainers = new Container[] {
-        new Container(1, containerCapacity, 0),
-        new Container(3, containerCapacity, 0),
-        new Container(4, containerCapacity, 0),
+        new Container(1, containerCapacity, Resource.EMPTY_RESOURCE),
+        new Container(3, containerCapacity, Resource.EMPTY_RESOURCE),
+        new Container(4, containerCapacity, Resource.EMPTY_RESOURCE),
     };
 
     addInstance(testContainers[0], "A", 0);

--- a/heron/packing/tests/java/org/apache/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
@@ -28,10 +28,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.heron.api.generated.TopologyAPI;
-import org.apache.heron.api.utils.TopologyUtils;
 import org.apache.heron.common.basics.ByteAmount;
 import org.apache.heron.common.basics.Pair;
-import org.apache.heron.packing.AssertPacking;
 import org.apache.heron.packing.CommonPackingTests;
 import org.apache.heron.packing.utils.PackingUtils;
 import org.apache.heron.spi.packing.IPacking;
@@ -53,19 +51,15 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     return new ResourceCompliantRRPacking();
   }
 
-  private int countComponent(String component, Set<PackingPlan.InstancePlan> instances) {
-    int count = 0;
-    for (PackingPlan.InstancePlan instancePlan : instances) {
-      if (component.equals(instancePlan.getComponentName())) {
-        count++;
-      }
-    }
-    return count;
+  @Test (expected = PackingException.class)
+  public void testFailureInsufficientContainerRam() throws Exception {
+    topologyConfig.setContainerRamRequested(ByteAmount.ZERO);
+    pack(getTopology(spoutParallelism, boltParallelism, topologyConfig));
   }
 
-  @Test(expected = PackingException.class)
-  public void testFailureInsufficientContainerRamRequested() throws Exception {
-    topologyConfig.setContainerRamRequested(ByteAmount.ZERO);
+  @Test (expected = PackingException.class)
+  public void testFailureInsufficientContainerCpu() throws Exception {
+    topologyConfig.setContainerCpuRequested(1.0);
     pack(getTopology(spoutParallelism, boltParallelism, topologyConfig));
   }
 
@@ -74,11 +68,10 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
    */
   @Test
   public void testDefaultResources() throws Exception {
-    int numContainers = 2;
-    PackingPlan packingPlanNoExplicitResourcesConfig = pack(topology);
-
-    Assert.assertEquals(numContainers, packingPlanNoExplicitResourcesConfig.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlanNoExplicitResourcesConfig.getInstanceCount());
+    doPackingTest(topology,
+        instanceDefaultResources, boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        3, getDefaultMaxContainerResource());
   }
 
   /**
@@ -86,16 +79,14 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
    */
   @Test
   public void testDefaultContainerSizeWithPadding() throws Exception {
-    int numContainers = 2;
     int padding = 50;
     topologyConfig.setContainerPaddingPercentage(padding);
-    TopologyAPI.Topology newTopology = getTopology(spoutParallelism, boltParallelism,
-        topologyConfig);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    PackingPlan packingPlan = pack(newTopology);
-
-    Assert.assertEquals(numContainers, packingPlan.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlan.getInstanceCount());
+    doPackingTest(topology,
+        instanceDefaultResources, boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        4, getDefaultMaxContainerResource());
   }
 
   /**
@@ -106,36 +97,43 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     int numContainers = 1;
 
     // Set up the topology and its config
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+    topologyConfig.setNumStmgrs(numContainers);
     // Explicit set resources for container
     ByteAmount containerRam = ByteAmount.fromGigabytes(10);
     ByteAmount containerDisk = ByteAmount.fromGigabytes(20);
     double containerCpu = 30;
+    Resource containerResource = new Resource(containerCpu, containerRam, containerDisk);
+
+    Resource padding = PackingUtils.finalizePadding(
+        new Resource(containerCpu, containerRam, containerDisk),
+        new Resource(PackingUtils.DEFAULT_CONTAINER_CPU_PADDING,
+            PackingUtils.DEFAULT_CONTAINER_RAM_PADDING,
+            PackingUtils.DEFAULT_CONTAINER_RAM_PADDING),
+        PackingUtils.DEFAULT_CONTAINER_PADDING_PERCENTAGE);
 
     topologyConfig.setContainerRamRequested(containerRam);
     topologyConfig.setContainerDiskRequested(containerDisk);
     topologyConfig.setContainerCpuRequested(containerCpu);
-    TopologyAPI.Topology topologyExplicitResourcesConfig =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitResourcesConfig = pack(topologyExplicitResourcesConfig);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    Assert.assertEquals(numContainers, packingPlanExplicitResourcesConfig.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlanExplicitResourcesConfig.getInstanceCount());
+    PackingPlan packingPlan = doPackingTest(topology,
+        instanceDefaultResources, boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        numContainers, containerResource);
 
-    for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.getContainers()) {
-      Assert.assertEquals(Math.round(PackingUtils.increaseBy(totalInstances
-              * instanceDefaultResources.getCpu(), DEFAULT_CONTAINER_PADDING)),
+    for (PackingPlan.ContainerPlan containerPlan : packingPlan.getContainers()) {
+      Assert.assertEquals(Math.round(totalInstances * instanceDefaultResources.getCpu()
+              + padding.getCpu()),
           (long) containerPlan.getRequiredResource().getCpu());
 
       Assert.assertEquals(instanceDefaultResources.getRam()
               .multiply(totalInstances)
-              .increaseBy(DEFAULT_CONTAINER_PADDING),
+              .plus(padding.getRam()),
           containerPlan.getRequiredResource().getRam());
 
       Assert.assertEquals(instanceDefaultResources.getDisk()
-                    .multiply(totalInstances)
-                    .increaseBy(DEFAULT_CONTAINER_PADDING),
+              .multiply(totalInstances)
+              .plus(padding.getDisk()),
           containerPlan.getRequiredResource().getDisk());
 
       // All instances' resource requirement should be equal
@@ -151,7 +149,8 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
 
   @Test
   public void testContainersRequestedExceedsInstanceCount() throws Exception {
-    doTestContainerCountRequested(8, 7); // each of the 7 instances will get their own container
+    // each of the 7 instances will get their own container
+    doTestContainerCountRequested(8, 7);
   }
 
   /**
@@ -159,7 +158,7 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
    */
   @Test
   public void testCompleteRamMapRequested() throws Exception {
-    int numContainers = 2;
+    int numContainers = 3;
 
     // Explicit set resources for container
     // the value should be ignored, since we set the complete component RAM map
@@ -171,14 +170,12 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     topologyConfig.setContainerRamRequested(containerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
-    Assert.assertEquals(numContainers, packingPlanExplicitRamMap.getContainers().size());
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    AssertPacking.assertContainers(packingPlanExplicitRamMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, instanceDefaultResources.getRam(), containerRam);
+    doPackingTest(topology,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        numContainers, getDefaultMaxContainerResource().cloneWithRam(containerRam));
   }
 
   /**
@@ -186,7 +183,7 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
    */
   @Test
   public void testPartialRamMap() throws Exception {
-    int numContainers = 2;
+    int numContainers = 3;
 
     // Explicit set resources for container
     ByteAmount containerRam = ByteAmount.fromGigabytes(10);
@@ -199,14 +196,12 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
     topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
-    Assert.assertEquals(numContainers, packingPlanExplicitRamMap.getContainers().size());
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    AssertPacking.assertContainers(packingPlanExplicitRamMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, spoutRam, containerRam);
+    doPackingTest(topology,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources.cloneWithRam(spoutRam), spoutParallelism,
+        numContainers, getDefaultMaxContainerResource().cloneWithRam(containerRam));
   }
 
   /**
@@ -217,18 +212,17 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     int numContainers = 1;
 
     // Set up the topology and its config
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+    topologyConfig.setNumStmgrs(numContainers);
 
     // Explicit set resources for container
     ByteAmount containerRam = ByteAmount.fromGigabytes(2);
-
     topologyConfig.setContainerRamRequested(containerRam);
 
-    TopologyAPI.Topology newTopology =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlan = pack(newTopology);
-    Assert.assertEquals(7, packingPlan.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlan.getInstanceCount());
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    doPackingTest(topology,
+        instanceDefaultResources, boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        7, getDefaultMaxContainerResource().cloneWithRam(containerRam));
   }
 
   /**
@@ -239,7 +233,7 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     int numContainers = 1;
 
     // Set up the topology and its config
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+    topologyConfig.setNumStmgrs(numContainers);
 
     // Explicit set resources for container
     ByteAmount containerRam = ByteAmount.fromGigabytes(3);
@@ -252,11 +246,11 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
     topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlan = pack(topologyExplicitRamMap);
-    Assert.assertEquals(7, packingPlan.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlan.getInstanceCount());
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    doPackingTest(topology,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources.cloneWithRam(spoutRam), spoutParallelism,
+        7, getDefaultMaxContainerResource().cloneWithRam(containerRam));
   }
 
   /**
@@ -264,27 +258,18 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
    */
   @Test
   public void testEvenPacking() throws Exception {
-    int numContainers = 2;
+    int numContainers = 3;
     int componentParallelism = 4;
-
+    boltParallelism = componentParallelism;
+    spoutParallelism = componentParallelism;
     // Set up the topology and its config
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+    topologyConfig.setNumStmgrs(numContainers);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology newTopology =
-        getTopology(componentParallelism, componentParallelism, topologyConfig);
-
-    int numInstance = TopologyUtils.getTotalInstance(newTopology);
-    // Two components
-    Assert.assertEquals(2 * componentParallelism, numInstance);
-    PackingPlan output = pack(newTopology);
-    Assert.assertEquals(numContainers, output.getContainers().size());
-    Assert.assertEquals((Integer) numInstance, output.getInstanceCount());
-
-    for (PackingPlan.ContainerPlan container : output.getContainers()) {
-      Assert.assertEquals(numInstance / numContainers, container.getInstances().size());
-      Assert.assertEquals(2, countComponent("spout", container.getInstances()));
-      Assert.assertEquals(2, countComponent("bolt", container.getInstances()));
-    }
+    doPackingTest(topology,
+        instanceDefaultResources, boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        numContainers, getDefaultMaxContainerResource());
   }
 
   /**
@@ -296,30 +281,11 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     int numScalingInstances = 5;
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(BOLT_NAME, numScalingInstances);
-    int numContainersBeforeRepack = 2;
-    PackingPlan newPackingPlan = doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
-    Assert.assertEquals(4, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + numScalingInstances),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertContainers(newPackingPlan.getContainers(),
-        BOLT_NAME, SPOUT_NAME, instanceDefaultResources.getRam(),
-        instanceDefaultResources.getRam(), null);
-    for (PackingPlan.ContainerPlan containerPlan
-        : newPackingPlan.getContainers()) {
-      Assert.assertEquals(Math.round(PackingUtils.increaseBy(
-          containerPlan.getInstances().size() * instanceDefaultResources.getCpu(),
-          DEFAULT_CONTAINER_PADDING)), (long) containerPlan.getRequiredResource().getCpu());
+    int numContainersBeforeRepack = 3;
+    int numContainersAfterRepack = 5;
 
-      Assert.assertEquals(instanceDefaultResources.getRam()
-              .multiply(containerPlan.getInstances().size())
-              .increaseBy(DEFAULT_CONTAINER_PADDING),
-          containerPlan.getRequiredResource().getRam());
-
-      Assert.assertEquals(instanceDefaultResources.getDisk()
-              .multiply(containerPlan.getInstances().size())
-              .increaseBy(DEFAULT_CONTAINER_PADDING),
-          containerPlan.getRequiredResource().getDisk());
-    }
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource());
   }
 
   /**
@@ -334,42 +300,20 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     ByteAmount maxContainerRam = ByteAmount.fromGigabytes(10);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
     topologyConfig.setContainerRamRequested(maxContainerRam);
-
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
     int numScalingInstances = 3;
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(BOLT_NAME, numScalingInstances);
 
-    int numContainersBeforeRepack = 3;
-    PackingPlan newPackingPlan =
-        doScalingTest(topologyExplicitRamMap, componentChanges, boltRam,
-            boltParallelism, instanceDefaultResources.getRam(), spoutParallelism,
-            numContainersBeforeRepack, totalInstances);
-    Assert.assertEquals(6, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + numScalingInstances),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertContainers(newPackingPlan.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, instanceDefaultResources.getRam(), null);
+    int numContainersBeforeRepack = 4;
+    int numContainersAfterRepack = 6;
 
-    for (PackingPlan.ContainerPlan containerPlan : newPackingPlan.getContainers()) {
-      //Each container either contains a single bolt or 1 bolt and 2 spouts or 1 bolt and 1 spout
-      if (containerPlan.getInstances().size() == 1) {
-        Assert.assertEquals(boltRam.increaseBy(paddingPercentage),
-            containerPlan.getRequiredResource().getRam());
-      }
-      if (containerPlan.getInstances().size() == 2) {
-        Assert.assertEquals(boltRam.plus(instanceDefaultResources.getRam())
-                .increaseBy(paddingPercentage),
-            containerPlan.getRequiredResource().getRam());
-      }
-      if (containerPlan.getInstances().size() == 3) {
-        Assert.assertEquals(boltRam.plus(instanceDefaultResources.getRam().multiply(2))
-                .increaseBy(paddingPercentage),
-            containerPlan.getRequiredResource().getRam());
-      }
-    }
+    doPackingAndScalingTest(topology, componentChanges,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   /**
@@ -377,7 +321,6 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
    */
   @Test
   public void testPartialRamMapScaling() throws Exception {
-
     // Explicit set resources for container
     ByteAmount maxContainerRam = ByteAmount.fromGigabytes(10);
     // Explicit set component RAM map
@@ -385,23 +328,19 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     topologyConfig.setContainerRamRequested(maxContainerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
     int numScalingInstances = 3;
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(BOLT_NAME, numScalingInstances);
 
     int numContainersBeforeRepack = 3;
-    PackingPlan newPackingPlan = doScalingTest(topologyExplicitRamMap, componentChanges, boltRam,
-        boltParallelism, instanceDefaultResources.getRam(), spoutParallelism,
-        numContainersBeforeRepack, totalInstances);
-
-    Assert.assertEquals(6, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + numScalingInstances),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertContainers(newPackingPlan.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, instanceDefaultResources.getRam(), null);
+    int numContainersAfterRepack = 4;
+    doPackingAndScalingTest(topology, componentChanges,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   /**
@@ -415,15 +354,10 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingDown); //leave 2 spouts
     componentChanges.put(BOLT_NAME, boltScalingDown); //leave 2 bolts
-    int numContainersBeforeRepack = 2;
-    PackingPlan newPackingPlan = doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
-    Assert.assertEquals(1, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + spoutScalingDown + boltScalingDown),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        BOLT_NAME, 2);
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        SPOUT_NAME, 2);
+    int numContainersBeforeRepack = 3;
+    int numContainersAfterRepack = 2;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource());
   }
 
   /**
@@ -441,15 +375,10 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingDown); //leave 1 spout
     componentChanges.put(BOLT_NAME, boltScalingDown); //leave 1 bolt
-    int numContainersBeforeRepack = 2;
-    PackingPlan newPackingPlan = doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
-    Assert.assertEquals(1, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + spoutScalingDown + boltScalingDown),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        BOLT_NAME, 0);
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        SPOUT_NAME, 1);
+    int numContainersBeforeRepack = 3;
+    int numContainersAfterRepack = 1;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource());
   }
 
   /**
@@ -459,7 +388,7 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
   @Test
   public void scaleDownAndUpWithExtraPadding() throws Exception {
     int paddingPercentage = 50;
-    int numContainers = 1;
+    int numContainers = 2;
     topologyConfig.setContainerPaddingPercentage(paddingPercentage);
     // Explicit set resources for container
     ByteAmount maxContainerRam = ByteAmount.fromGigabytes(12);
@@ -469,11 +398,10 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
     topologyConfig.setNumStmgrs(numContainers);
 
-    int noBolts = 2;
-    int noSpouts = 1;
+    boltParallelism = 2;
+    spoutParallelism = 1;
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(noSpouts, noBolts, topologyConfig);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
     int spoutScalingUp = 1;
     int boltScalingDown = -2;
@@ -481,18 +409,14 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingUp); // 2 spouts
     componentChanges.put(BOLT_NAME, boltScalingDown); // 0 bolts
-    int numContainersBeforeRepack = 1;
-    PackingPlan newPackingPlan = doScalingTest(topologyExplicitRamMap, componentChanges,
-        instanceDefaultResources.getRam(), noBolts, spoutRam, noSpouts,
-        numContainersBeforeRepack, noSpouts + noBolts);
+    int numContainersBeforeRepack = 2;
+    int numContainersAfterRepack = 1;
 
-    Assert.assertEquals(1, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (noSpouts + noBolts + spoutScalingUp + boltScalingDown),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        BOLT_NAME, noBolts + boltScalingDown);
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        SPOUT_NAME, noSpouts + spoutScalingUp);
+    doPackingAndScalingTest(topology, componentChanges,
+        instanceDefaultResources, boltParallelism,
+        instanceDefaultResources.cloneWithRam(spoutRam), spoutParallelism,
+        numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   /**
@@ -513,11 +437,10 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
     topologyConfig.setNumStmgrs(numContainers);
 
-    int noBolts = 3;
-    int noSpouts = 1;
+    boltParallelism = 3;
+    spoutParallelism = 1;
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(noSpouts, noBolts, topologyConfig);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
     int spoutScalingUp = 1;
     int boltScalingDown = -1;
@@ -525,18 +448,14 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingUp); // 2 spouts
     componentChanges.put(BOLT_NAME, boltScalingDown); // 2 bolts
-    int numContainersBeforeRepack = 1;
-    PackingPlan newPackingPlan = doScalingTest(topologyExplicitRamMap, componentChanges,
-        instanceDefaultResources.getRam(), noBolts, spoutRam, noSpouts,
-        numContainersBeforeRepack, noSpouts + noBolts);
+    int numContainersBeforeRepack = 2;
+    int numContainersAfterRepack = 2;
 
-    Assert.assertEquals(2, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (noSpouts + noBolts + spoutScalingUp + boltScalingDown),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        BOLT_NAME, noBolts + boltScalingDown);
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        SPOUT_NAME, noSpouts + spoutScalingUp);
+    doPackingAndScalingTest(topology, componentChanges,
+        instanceDefaultResources, boltParallelism,
+        instanceDefaultResources.cloneWithRam(spoutRam), spoutParallelism,
+        numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   @Test
@@ -547,104 +466,10 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingUp); // 8 spouts
     componentChanges.put(BOLT_NAME, boltScalingUp); // 8 bolts
-    int numContainersBeforeRepack = 2;
-    PackingPlan newPackingPlan = doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
-    Assert.assertEquals(4, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + spoutScalingUp + boltScalingUp),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        BOLT_NAME, boltParallelism + boltScalingUp);
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        SPOUT_NAME, spoutParallelism + spoutScalingUp);
-  }
-
-  /**
-   * Test the scenario where scaling down removes instances from containers that are most imbalanced
-   * (i.e., tending towards homogeneity) first. If there is a tie (e.g. AABB, AB), chooses from the
-   * container with the fewest instances, to favor ultimately removing  containers. If there is
-   * still a tie, favor removing from higher numbered containers
-   */
-  @Test
-  public void testScaleDownOneComponentRemoveContainer() throws Exception {
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
-        new Pair<>(1, new InstanceId(A, 1, 0)),
-        new Pair<>(1, new InstanceId(A, 2, 1)),
-        new Pair<>(1, new InstanceId(B, 3, 0)),
-        new Pair<>(3, new InstanceId(B, 4, 1)),
-        new Pair<>(3, new InstanceId(B, 5, 2)),
-        new Pair<>(4, new InstanceId(B, 6, 3)),
-        new Pair<>(4, new InstanceId(B, 7, 4))
-    };
-
-    Map<String, Integer> componentChanges = new HashMap<>();
-    componentChanges.put(B, -2);
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
-        new Pair<>(1, new InstanceId(A, 1, 0)),
-        new Pair<>(1, new InstanceId(A, 2, 1)),
-        new Pair<>(1, new InstanceId(B, 3, 0)),
-        new Pair<>(3, new InstanceId(B, 4, 1)),
-        new Pair<>(3, new InstanceId(B, 5, 2)),
-    };
-
-    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
-  }
-
-  @Test
-  public void testScaleDownTwoComponentsRemoveContainer() throws Exception {
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
-        new Pair<>(1, new InstanceId(A, 1, 0)),
-        new Pair<>(1, new InstanceId(A, 2, 1)),
-        new Pair<>(1, new InstanceId(B, 3, 0)),
-        new Pair<>(1, new InstanceId(B, 4, 1)),
-        new Pair<>(3, new InstanceId(A, 5, 2)),
-        new Pair<>(3, new InstanceId(A, 6, 3)),
-        new Pair<>(3, new InstanceId(B, 7, 2)),
-        new Pair<>(3, new InstanceId(B, 8, 3))
-    };
-
-    Map<String, Integer> componentChanges = new HashMap<>();
-    componentChanges.put(A, -2);
-    componentChanges.put(B, -2);
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
-        new Pair<>(1, new InstanceId(A, 1, 0)),
-        new Pair<>(1, new InstanceId(A, 2, 1)),
-        new Pair<>(1, new InstanceId(B, 3, 0)),
-        new Pair<>(1, new InstanceId(B, 4, 1)),
-    };
-
-    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
-  }
-
-  @Test
-  public void testScaleDownHomogenousFirst() throws Exception {
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
-        new Pair<>(1, new InstanceId(A, 1, 0)),
-        new Pair<>(1, new InstanceId(A, 2, 1)),
-        new Pair<>(1, new InstanceId(B, 3, 0)),
-        new Pair<>(3, new InstanceId(B, 4, 1)),
-        new Pair<>(3, new InstanceId(B, 5, 2)),
-        new Pair<>(3, new InstanceId(B, 6, 3)),
-        new Pair<>(3, new InstanceId(B, 7, 4))
-    };
-
-    Map<String, Integer> componentChanges = new HashMap<>();
-    componentChanges.put(B, -4);
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
-        new Pair<>(1, new InstanceId(A, 1, 0)),
-        new Pair<>(1, new InstanceId(A, 2, 1)),
-        new Pair<>(1, new InstanceId(B, 3, 0))
-    };
-
-    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
+    int numContainersBeforeRepack = 3;
+    int numContainersAfterRepack = 5;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource());
   }
 
   /**
@@ -658,36 +483,32 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingDown); // 0 spouts
     componentChanges.put(BOLT_NAME, boltScalingUp); // 9 bolts
-    int numContainersBeforeRepack = 2;
-    PackingPlan newPackingPlan = doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
-
-    Assert.assertEquals(3, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + spoutScalingDown + boltScalingUp),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        BOLT_NAME, 9);
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        SPOUT_NAME, 0);
+    int numContainersBeforeRepack = 3;
+    int numContainersAfterRepack = 4;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersAfterRepack,
+        getDefaultMaxContainerResource());
   }
 
   @Test(expected = PackingException.class)
   public void testScaleDownInvalidScaleFactor() throws Exception {
-
     //try to remove more spout instances than possible
     int spoutScalingDown = -5;
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, spoutScalingDown);
 
-    int numContainersBeforeRepack = 2;
-    doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
+    int numContainersBeforeRepack = 3;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersBeforeRepack,
+        getDefaultMaxContainerResource());
   }
 
   @Test(expected = PackingException.class)
   public void testScaleDownInvalidComponent() throws Exception {
+    //try to remove a component that does not exist
     Map<String, Integer> componentChanges = new HashMap<>();
-    componentChanges.put("SPOUT_FAKE", -10); //try to remove a component that does not exist
-    int numContainersBeforeRepack = 2;
-    doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
+    componentChanges.put("SPOUT_FAKE", -10);
+    int numContainersBeforeRepack = 3;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack, numContainersBeforeRepack,
+        getDefaultMaxContainerResource());
   }
 
   /**
@@ -696,22 +517,15 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
   @Test(expected = PackingException.class)
   public void testInvalidRamInstance() throws Exception {
     ByteAmount maxContainerRam = ByteAmount.fromGigabytes(10);
-    int defaultNumInstancesperContainer = 4;
-
-    // Explicit set component RAM map
     ByteAmount boltRam = ByteAmount.ZERO;
-
-    topologyConfig.setContainerMaxRamHint(maxContainerRam);
+    topologyConfig.setContainerRamRequested(maxContainerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), BOLT_NAME, 3);
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), SPOUT_NAME, 4);
-    AssertPacking.assertContainerRam(packingPlanExplicitRamMap.getContainers(),
-        instanceDefaultResources.getRam().multiply(defaultNumInstancesperContainer));
+    doPackingTest(topology,
+        instanceDefaultResources.cloneWithRam(boltRam), boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        0, getDefaultMaxContainerResource().cloneWithRam(maxContainerRam));
   }
 
   @Test
@@ -729,7 +543,7 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     topologyConfig.setContainerRamRequested(ByteAmount.fromGigabytes(10));
     topologyConfig.setContainerDiskRequested(ByteAmount.fromGigabytes(20));
     topologyConfig.setContainerCpuRequested(30);
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, requestedContainers);
+    topologyConfig.setNumStmgrs(requestedContainers);
 
     TopologyAPI.Topology topologyExplicitResourcesConfig =
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
@@ -746,5 +560,94 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
         Assert.assertEquals(instanceDefaultResources, instancePlan.getResource());
       }
     }
+  }
+
+  /**
+   * Test the scenario where scaling down removes instances from containers that are most imbalanced
+   * (i.e., tending towards homogeneity) first. If there is a tie (e.g. AABB, AB), chooses from the
+   * container with the fewest instances, to favor ultimately removing  containers. If there is
+   * still a tie, favor removing from higher numbered containers
+   */
+  @Test
+  public void testScaleDownOneComponentRemoveContainer() throws Exception {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 1, 0)),
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 2, 1)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 3, 0)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 4, 1)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 5, 2)),
+        new Pair<>(4, new InstanceId(BOLT_NAME, 6, 3)),
+        new Pair<>(4, new InstanceId(BOLT_NAME, 7, 4))
+    };
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(BOLT_NAME, -2);
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 1, 0)),
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 2, 1)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 3, 0)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 4, 1)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 5, 2)),
+    };
+
+    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
+  }
+
+  @Test
+  public void testScaleDownTwoComponentsRemoveContainer() throws Exception {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 1, 0)),
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 2, 1)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 3, 0)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 4, 1)),
+        new Pair<>(3, new InstanceId(SPOUT_NAME, 5, 2)),
+        new Pair<>(3, new InstanceId(SPOUT_NAME, 6, 3)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 7, 2)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 8, 3))
+    };
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(SPOUT_NAME, -2);
+    componentChanges.put(BOLT_NAME, -2);
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 1, 0)),
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 2, 1)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 3, 0)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 4, 1)),
+    };
+
+    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
+  }
+
+  @Test
+  public void testScaleDownHomogenousFirst() throws Exception {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 1, 0)),
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 2, 1)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 3, 0)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 4, 1)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 5, 2)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 6, 3)),
+        new Pair<>(3, new InstanceId(BOLT_NAME, 7, 4))
+    };
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(BOLT_NAME, -4);
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 1, 0)),
+        new Pair<>(1, new InstanceId(SPOUT_NAME, 2, 1)),
+        new Pair<>(1, new InstanceId(BOLT_NAME, 3, 0))
+    };
+
+    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
   }
 }

--- a/heron/packing/tests/java/org/apache/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -133,7 +133,7 @@ public class RoundRobinPackingTest extends CommonPackingTests {
       Assert.assertEquals(1, differentResources.size());
       int instancesCount = containerPlan.getInstances().size();
       Assert.assertEquals(containerRam
-              .minus(RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER).divide(instancesCount),
+          .minus(RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER).divide(instancesCount),
           differentResources.iterator().next().getRam());
 
       Assert.assertEquals(

--- a/heron/scheduler-core/tests/java/org/apache/heron/scheduler/RuntimeManagerMainTest.java
+++ b/heron/scheduler-core/tests/java/org/apache/heron/scheduler/RuntimeManagerMainTest.java
@@ -31,7 +31,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.apache.heron.api.generated.TopologyAPI;
 import org.apache.heron.common.basics.ByteAmount;
 import org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking;
-import org.apache.heron.packing.roundrobin.RoundRobinPacking;
 import org.apache.heron.proto.system.ExecutionEnvironment;
 import org.apache.heron.proto.system.PackingPlans;
 import org.apache.heron.scheduler.client.ISchedulerClient;
@@ -307,7 +306,7 @@ public class RuntimeManagerMainTest {
     SchedulerStateManagerAdaptor manager = mock(SchedulerStateManagerAdaptor.class);
     PowerMockito.when(Runtime.schedulerStateManagerAdaptor(any(Config.class))).thenReturn(manager);
 
-    RoundRobinPacking packing = new RoundRobinPacking();
+    ResourceCompliantRRPacking packing = new ResourceCompliantRRPacking();
     PackingPlans.PackingPlan currentPlan =
         PackingTestUtils.testProtoPackingPlan(TOPOLOGY_NAME, packing);
 

--- a/heron/spi/src/java/org/apache/heron/spi/packing/Resource.java
+++ b/heron/spi/src/java/org/apache/heron/spi/packing/Resource.java
@@ -29,6 +29,9 @@ public class Resource {
   private ByteAmount ram;
   private ByteAmount disk;
 
+  public static final Resource EMPTY_RESOURCE
+      = new Resource(0.0, ByteAmount.ZERO, ByteAmount.ZERO);
+
   public Resource(double cpu, ByteAmount ram, ByteAmount disk) {
     this.cpu = cpu;
     this.ram = ram;


### PR DESCRIPTION
Currently, different packing algorithms assume different things and follow different semantics for the user-set configs. Because of it, there exist some code duplicates and it's not friendly for new packing algorithms. This PR is an attempt to address this issue and consolidate the three existing packing algorithms. 

Major behavior changes are:
- `FirstFitDecreasingPacking` and `ResourceCompliantRoundRobinPacking` now take container-level resource constraints from `topology.container.cpu`, `topology.container.ram`, and `topology.container.disk` instead of from hints. 
- `FirstFitDecreasingPacking` and `ResourceCompliantRoundRobinPacking` now determine padding resource by taking `max(containerResource * padding%, paddingAmount)`
- More details can be found in `AbstractPacking` class

This PR also revamp tests and code reuse. Changed packing tests to all extend from `CommonPackingTest` and uses helper methods for each test scenarios. Assertion expectations are changed accordingly due to the behavior changes introduced by the new determination of padding resource amount. 