### PR TITLE
Revamp Packing tests

### DIFF
--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
@@ -46,6 +46,10 @@ import org.apache.heron.spi.packing.PackingException;
 import org.apache.heron.spi.packing.PackingPlan;
 import org.apache.heron.spi.packing.Resource;
 
+import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED;
+import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED;
+import static org.apache.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED;
+
 /**
  * Round-robin packing algorithm
  * <p>
@@ -143,16 +147,14 @@ public class RoundRobinPacking implements IPacking, IRepacking {
     Map<Integer, List<InstanceId>> roundRobinAllocation =
         getRoundRobinAllocation(numContainer, parallelismMap);
 
-    ByteAmount containerDiskInBytes = getContainerDiskHint(roundRobinAllocation);
-    double containerCpuHint = getContainerCpuHint(roundRobinAllocation);
-    ByteAmount containerRamHint = getContainerRamHint(roundRobinAllocation);
+    Resource containerResourceHint = getContainerResourceHint(roundRobinAllocation);
 
     // Get the RAM map for every instance
     Map<Integer, Map<InstanceId, ByteAmount>> instancesRamMap =
         calculateInstancesResourceMapInContainer(
         roundRobinAllocation,
         TopologyUtils.getComponentRamMapConfig(topology),
-        containerRamHint,
+        containerResourceHint.getRam(),
         instanceRamDefault,
         containerRamPadding,
         ByteAmount.ZERO,
@@ -164,7 +166,7 @@ public class RoundRobinPacking implements IPacking, IRepacking {
         calculateInstancesResourceMapInContainer(
         roundRobinAllocation,
         CPUShare.convertDoubleMapToCpuShareMap(TopologyUtils.getComponentCpuMapConfig(topology)),
-        CPUShare.fromDouble(containerCpuHint),
+        CPUShare.fromDouble(containerResourceHint.getCpu()),
         CPUShare.fromDouble(instanceCpuDefault),
         CPUShare.fromDouble(containerCpuPadding),
         CPUShare.fromDouble(0.0),
@@ -172,9 +174,9 @@ public class RoundRobinPacking implements IPacking, IRepacking {
         CPU);
 
     LOG.info(String.format("Pack internal: container CPU hint: %.3f, RAM hint: %s, disk hint: %s.",
-        containerCpuHint,
-        containerRamHint.toString(),
-        containerDiskInBytes.toString()));
+        containerResourceHint.getCpu(),
+        containerResourceHint.getRam().toString(),
+        containerResourceHint.getDisk().toString()));
 
     // Construct the PackingPlan
     Set<PackingPlan.ContainerPlan> containerPlans = new HashSet<>();
@@ -202,21 +204,22 @@ public class RoundRobinPacking implements IPacking, IRepacking {
       }
 
       // finalize container resource
-      if (!containerRamHint.equals(NOT_SPECIFIED_BYTE_AMOUNT)) {
+      if (!containerResourceHint.getRam().equals(NOT_SPECIFIED_BYTE_AMOUNT)) {
         containerRam = ByteAmount.fromBytes(
-            Math.min(containerRam.plus(containerRamPadding).asBytes(), containerRamHint.asBytes()));
+            Math.min(containerRam.plus(containerRamPadding).asBytes(),
+                containerResourceHint.getRam().asBytes()));
       } else {
         containerRam = containerRam.plus(containerRamPadding);
       }
 
-      if (containerCpuHint != NOT_SPECIFIED_CPU_SHARE) {
-        containerCpu = Math.min(containerCpu + containerCpuPadding, containerCpuHint);
+      if (containerResourceHint.getCpu() != NOT_SPECIFIED_CPU_SHARE) {
+        containerCpu = Math.min(containerCpu + containerCpuPadding, containerResourceHint.getCpu());
       } else {
         containerCpu += containerCpuPadding;
       }
 
-      Resource resource = new Resource(Math.max(containerCpu, containerCpuHint),
-          containerRam, containerDiskInBytes);
+      Resource resource = new Resource(Math.max(containerCpu, containerResourceHint.getCpu()),
+          containerRam, containerResourceHint.getDisk());
       PackingPlan.ContainerPlan containerPlan = new PackingPlan.ContainerPlan(
           containerId, new HashSet<>(instancePlanMap.values()), resource);
 
@@ -420,58 +423,18 @@ public class RoundRobinPacking implements IPacking, IRepacking {
     return max;
   }
 
-  /**
-   * Provide CPU per container.
-   *
-   * @param allocation packing output.
-   * @return CPU per container.
-   */
-  private double getContainerCpuHint(Map<Integer, List<InstanceId>> allocation) {
+  private Resource getContainerResourceHint(Map<Integer, List<InstanceId>> allocation) {
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
-    double defaultContainerCpu =
-        DEFAULT_CPU_PADDING_PER_CONTAINER + getLargestContainerSize(allocation);
+    int largestContainerSize = getLargestContainerSize(allocation);
 
-    String cpuHint = TopologyUtils.getConfigWithDefault(
-        topologyConfig, org.apache.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED,
-        Double.toString(defaultContainerCpu));
-
-    return Double.parseDouble(cpuHint);
-  }
-
-  /**
-   * Provide disk per container.
-   *
-   * @param allocation packing output.
-   * @return disk per container.
-   */
-  private ByteAmount getContainerDiskHint(Map<Integer, List<InstanceId>> allocation) {
-    ByteAmount defaultContainerDisk = instanceDiskDefault
-        .multiply(getLargestContainerSize(allocation))
-        .plus(DEFAULT_DISK_PADDING_PER_CONTAINER);
-
-    List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
-
-    return TopologyUtils.getConfigWithDefault(topologyConfig,
-        org.apache.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED,
-        defaultContainerDisk);
-  }
-
-  /**
-   * Provide RAM per container.
-   *
-   * @param allocation packing
-   * @return Container RAM requirement
-   */
-  private ByteAmount getContainerRamHint(Map<Integer, List<InstanceId>> allocation) {
-    ByteAmount defaultContainerRam = instanceRamDefault
-        .multiply(getLargestContainerSize(allocation))
-        .plus(DEFAULT_RAM_PADDING_PER_CONTAINER);
-
-    List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
-
-    return TopologyUtils.getConfigWithDefault(
-        topologyConfig, org.apache.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED,
-        defaultContainerRam);
+    return new Resource(
+        TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_CPU_REQUESTED,
+            (double) Math.round(instanceCpuDefault * largestContainerSize + containerCpuPadding)),
+        TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_RAM_REQUESTED,
+            instanceRamDefault.multiply(largestContainerSize).plus(containerRamPadding)),
+        TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_DISK_REQUESTED,
+            instanceDiskDefault.multiply(largestContainerSize)
+                .plus(DEFAULT_DISK_PADDING_PER_CONTAINER)));
   }
 
   /**

--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
@@ -463,11 +463,15 @@ public class RoundRobinPacking implements IPacking, IRepacking {
    * @return Container RAM requirement
    */
   private ByteAmount getContainerRamHint(Map<Integer, List<InstanceId>> allocation) {
+    ByteAmount defaultContainerRam = instanceRamDefault
+        .multiply(getLargestContainerSize(allocation))
+        .plus(DEFAULT_RAM_PADDING_PER_CONTAINER);
+
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
 
     return TopologyUtils.getConfigWithDefault(
         topologyConfig, org.apache.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED,
-        NOT_SPECIFIED_BYTE_AMOUNT);
+        defaultContainerRam);
   }
 
   /**

--- a/heron/packing/tests/java/org/apache/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
@@ -29,11 +29,13 @@ import org.junit.Test;
 
 import org.apache.heron.api.generated.TopologyAPI;
 import org.apache.heron.common.basics.ByteAmount;
+import org.apache.heron.common.basics.Pair;
 import org.apache.heron.packing.AssertPacking;
 import org.apache.heron.packing.CommonPackingTests;
 import org.apache.heron.packing.utils.PackingUtils;
 import org.apache.heron.spi.packing.IPacking;
 import org.apache.heron.spi.packing.IRepacking;
+import org.apache.heron.spi.packing.InstanceId;
 import org.apache.heron.spi.packing.PackingException;
 import org.apache.heron.spi.packing.PackingPlan;
 import org.apache.heron.spi.packing.Resource;
@@ -512,5 +514,195 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
         BOLT_NAME, noBolts + boltScalingDown);
     AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
         SPOUT_NAME, noSpouts + spoutScalingUp);
+  }
+
+  /**
+   * Test the scenario where scaling down removes instances from containers that are most imbalanced
+   * (i.e., tending towards homogeneity) first. If there is a tie (e.g. AABB, AB), chooses from the
+   * container with the fewest instances, to favor ultimately removing  containers. If there is
+   * still a tie, favor removing from higher numbered containers
+   */
+  @Test
+  public void testScaleDownOneComponentRemoveContainer() throws Exception {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(A, 1, 0)),
+        new Pair<>(1, new InstanceId(A, 2, 1)),
+        new Pair<>(1, new InstanceId(B, 3, 0)),
+        new Pair<>(3, new InstanceId(B, 4, 1)),
+        new Pair<>(3, new InstanceId(B, 5, 2)),
+        new Pair<>(4, new InstanceId(B, 6, 3)),
+        new Pair<>(4, new InstanceId(B, 7, 4))
+    };
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(B, -2);
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(A, 1, 0)),
+        new Pair<>(1, new InstanceId(A, 2, 1)),
+        new Pair<>(1, new InstanceId(B, 3, 0)),
+        new Pair<>(3, new InstanceId(B, 4, 1)),
+        new Pair<>(3, new InstanceId(B, 5, 2)),
+    };
+
+    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
+  }
+
+  @Test
+  public void testScaleDownTwoComponentsRemoveContainer() throws Exception {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(A, 1, 0)),
+        new Pair<>(1, new InstanceId(A, 2, 1)),
+        new Pair<>(1, new InstanceId(B, 3, 0)),
+        new Pair<>(1, new InstanceId(B, 4, 1)),
+        new Pair<>(3, new InstanceId(A, 5, 2)),
+        new Pair<>(3, new InstanceId(A, 6, 3)),
+        new Pair<>(3, new InstanceId(B, 7, 2)),
+        new Pair<>(3, new InstanceId(B, 8, 3))
+    };
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(A, -2);
+    componentChanges.put(B, -2);
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(A, 1, 0)),
+        new Pair<>(1, new InstanceId(A, 2, 1)),
+        new Pair<>(1, new InstanceId(B, 3, 0)),
+        new Pair<>(1, new InstanceId(B, 4, 1)),
+    };
+
+    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
+  }
+
+  @Test
+  public void testScaleDownHomogenousFirst() throws Exception {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(A, 1, 0)),
+        new Pair<>(1, new InstanceId(A, 2, 1)),
+        new Pair<>(1, new InstanceId(B, 3, 0)),
+        new Pair<>(3, new InstanceId(B, 4, 1)),
+        new Pair<>(3, new InstanceId(B, 5, 2)),
+        new Pair<>(3, new InstanceId(B, 6, 3)),
+        new Pair<>(3, new InstanceId(B, 7, 4))
+    };
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(B, -4);
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(A, 1, 0)),
+        new Pair<>(1, new InstanceId(A, 2, 1)),
+        new Pair<>(1, new InstanceId(B, 3, 0))
+    };
+
+    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
+  }
+
+  /**
+   * Test the scenario where scaling down and up is simultaneously requested
+   */
+  @Test
+  public void scaleDownAndUp() throws Exception {
+    int spoutScalingDown = -4;
+    int boltScalingUp = 6;
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(SPOUT_NAME, spoutScalingDown); // 0 spouts
+    componentChanges.put(BOLT_NAME, boltScalingUp); // 9 bolts
+    int numContainersBeforeRepack = 2;
+    PackingPlan newPackingPlan = doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
+
+    Assert.assertEquals(3, newPackingPlan.getContainers().size());
+    Assert.assertEquals((Integer) (totalInstances + spoutScalingDown + boltScalingUp),
+        newPackingPlan.getInstanceCount());
+    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
+        BOLT_NAME, 9);
+    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
+        SPOUT_NAME, 0);
+  }
+
+  @Test(expected = PackingException.class)
+  public void testScaleDownInvalidScaleFactor() throws Exception {
+
+    //try to remove more spout instances than possible
+    int spoutScalingDown = -5;
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(SPOUT_NAME, spoutScalingDown);
+
+    int numContainersBeforeRepack = 2;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
+  }
+
+  @Test(expected = PackingException.class)
+  public void testScaleDownInvalidComponent() throws Exception {
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put("SPOUT_FAKE", -10); //try to remove a component that does not exist
+    int numContainersBeforeRepack = 2;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
+  }
+
+  /**
+   * Test invalid RAM for instance
+   */
+  @Test(expected = PackingException.class)
+  public void testInvalidRamInstance() throws Exception {
+    ByteAmount maxContainerRam = ByteAmount.fromGigabytes(10);
+    int defaultNumInstancesperContainer = 4;
+
+    // Explicit set component RAM map
+    ByteAmount boltRam = ByteAmount.ZERO;
+
+    topologyConfig.setContainerMaxRamHint(maxContainerRam);
+    topologyConfig.setComponentRam(BOLT_NAME, boltRam);
+
+    TopologyAPI.Topology topologyExplicitRamMap =
+        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
+    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
+    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), BOLT_NAME, 3);
+    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), SPOUT_NAME, 4);
+    AssertPacking.assertContainerRam(packingPlanExplicitRamMap.getContainers(),
+        instanceDefaultResources.getRam().multiply(defaultNumInstancesperContainer));
+  }
+
+  @Test
+  public void testTwoContainersRequested() throws Exception {
+    doTestContainerCountRequested(2, 2);
+  }
+
+  /**
+   * Test the scenario where container level resource config are set
+   */
+  protected void doTestContainerCountRequested(int requestedContainers,
+                                               int expectedContainer) throws Exception {
+
+    // Explicit set resources for container
+    topologyConfig.setContainerRamRequested(ByteAmount.fromGigabytes(10));
+    topologyConfig.setContainerDiskRequested(ByteAmount.fromGigabytes(20));
+    topologyConfig.setContainerCpuRequested(30);
+    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, requestedContainers);
+
+    TopologyAPI.Topology topologyExplicitResourcesConfig =
+        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    PackingPlan packingPlanExplicitResourcesConfig = pack(topologyExplicitResourcesConfig);
+
+    Assert.assertEquals(expectedContainer,
+        packingPlanExplicitResourcesConfig.getContainers().size());
+    Assert.assertEquals(totalInstances, packingPlanExplicitResourcesConfig.getInstanceCount());
+
+    // RAM for bolt/spout should be the value in component RAM map
+    for (PackingPlan.ContainerPlan containerPlan
+        : packingPlanExplicitResourcesConfig.getContainers()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
+        Assert.assertEquals(instanceDefaultResources, instancePlan.getResource());
+      }
+    }
   }
 }

--- a/heron/packing/tests/java/org/apache/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -22,110 +22,83 @@ package org.apache.heron.packing.roundrobin;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.heron.api.generated.TopologyAPI;
-import org.apache.heron.api.utils.TopologyUtils;
 import org.apache.heron.common.basics.ByteAmount;
-import org.apache.heron.common.utils.topology.TopologyTests;
-import org.apache.heron.packing.AssertPacking;
-import org.apache.heron.spi.common.Config;
+import org.apache.heron.packing.CommonPackingTests;
+import org.apache.heron.spi.packing.IPacking;
+import org.apache.heron.spi.packing.IRepacking;
 import org.apache.heron.spi.packing.PackingException;
 import org.apache.heron.spi.packing.PackingPlan;
 import org.apache.heron.spi.packing.Resource;
-import org.apache.heron.spi.utils.PackingTestUtils;
 
-public class RoundRobinPackingTest {
-  private static final String BOLT_NAME = "bolt";
-  private static final String SPOUT_NAME = "spout";
-  private static final double DELTA = 0.1;
+import static org.apache.heron.packing.AssertPacking.DELTA;
 
-  private TopologyAPI.Topology getTopology(
-      int spoutParallelism, int boltParallelism,
-      org.apache.heron.api.Config topologyConfig) {
-    return TopologyTests.createTopology("testTopology", topologyConfig, SPOUT_NAME, BOLT_NAME,
-        spoutParallelism, boltParallelism);
+public class RoundRobinPackingTest extends CommonPackingTests {
+  @Override
+  protected IPacking getPackingImpl() {
+    return new RoundRobinPacking();
   }
 
-  private PackingPlan getRoundRobinPackingPlan(TopologyAPI.Topology topology) {
-    Config config = PackingTestUtils.newTestConfig(topology);
-
-    RoundRobinPacking packing = new RoundRobinPacking();
-    packing.initialize(config, topology);
-    return packing.pack();
+  @Override
+  protected IRepacking getRepackingImpl() {
+    return new RoundRobinPacking();
   }
 
-  private PackingPlan getRoundRobinRePackingPlan(
-      TopologyAPI.Topology topology, Map<String, Integer> componentChanges) {
-    Config config = PackingTestUtils.newTestConfig(topology);
+  private Resource getDefaultPadding() {
+    return new Resource(RoundRobinPacking.DEFAULT_CPU_PADDING_PER_CONTAINER,
+        RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER, ByteAmount.ZERO);
+  }
 
-    RoundRobinPacking packing = new RoundRobinPacking();
-    packing.initialize(config, topology);
-    PackingPlan pp = packing.pack();
-    return packing.repack(pp, componentChanges);
+  @Before
+  public void setUp() {
+    super.setUp();
+    numContainers = 2;
+    topologyConfig.setNumStmgrs(numContainers);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
   }
 
   @Test(expected = PackingException.class)
   public void testCheckInsufficientRamFailure() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
     // Explicit set insufficient RAM for container
-    ByteAmount containerRam = ByteAmount.fromGigabytes(0);
-
+    ByteAmount containerRam = ByteAmount.ZERO;
     topologyConfig.setContainerRamRequested(containerRam);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topology =  getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    getRoundRobinPackingPlan(topology);
+    doPackingTest(topology, instanceDefaultResources, boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        numContainers,
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithRam(containerRam));
   }
 
   @Test(expected = PackingException.class)
   public void testCheckInsufficientCpuFailure() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
     // Explicit set insufficient CPU for container
     double containerCpu = 1.0;
-
     topologyConfig.setContainerCpuRequested(containerCpu);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topology =  getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    getRoundRobinPackingPlan(topology);
+    doPackingTest(topology, instanceDefaultResources, boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        numContainers,
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithCpu(containerCpu));
   }
 
   @Test
   public void testDefaultResources() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-    Integer totalInstances = spoutParallelism + boltParallelism;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
-    // No explicit resources required
-    TopologyAPI.Topology topologyNoExplicitResourcesConfig =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanNoExplicitResourcesConfig =
-        getRoundRobinPackingPlan(topologyNoExplicitResourcesConfig);
-
-    Assert.assertEquals(numContainers,
-        packingPlanNoExplicitResourcesConfig.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlanNoExplicitResourcesConfig.getInstanceCount());
+    doPackingTestWithPartialResource(topology,
+        Optional.empty(), Optional.empty(), boltParallelism,
+        Optional.empty(), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()));
   }
 
   /**
@@ -133,56 +106,39 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testContainerRequestedResources() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-    Integer totalInstances = spoutParallelism + boltParallelism;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
     // Explicit set resources for container
     ByteAmount containerRam = ByteAmount.fromGigabytes(10);
     ByteAmount containerDisk = ByteAmount.fromGigabytes(20);
     double containerCpu = 30;
+    Resource containerResource = new Resource(containerCpu, containerRam, containerDisk);
 
     topologyConfig.setContainerRamRequested(containerRam);
     topologyConfig.setContainerDiskRequested(containerDisk);
     topologyConfig.setContainerCpuRequested(containerCpu);
-    TopologyAPI.Topology topologyExplicitResourcesConfig =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitResourcesConfig =
-        getRoundRobinPackingPlan(topologyExplicitResourcesConfig);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    Assert.assertEquals(numContainers,
-        packingPlanExplicitResourcesConfig.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlanExplicitResourcesConfig.getInstanceCount());
+    PackingPlan packingPlan = doPackingTestWithPartialResource(topology,
+        Optional.empty(), Optional.empty(), boltParallelism,
+        Optional.empty(), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(), containerResource);
 
-    for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.getContainers()) {
-      Assert.assertEquals(containerCpu, containerPlan.getRequiredResource().getCpu(), DELTA);
-      Assert.assertTrue(String.format(// due to round-off when using divide()
-          "expected: %s but was: %s", containerRam, containerPlan.getRequiredResource().getRam()),
-          Math.abs(
-              containerRam.minus(containerPlan.getRequiredResource().getRam()).asBytes()) <= 1);
-      Assert.assertEquals(containerDisk, containerPlan.getRequiredResource().getDisk());
-
+    for (PackingPlan.ContainerPlan containerPlan : packingPlan.getContainers()) {
       // All instances' resource requirement should be equal
       // So the size of set should be 1
-      Set<Resource> resources = new HashSet<>();
+      Set<Resource> differentResources = new HashSet<>();
       for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-        resources.add(instancePlan.getResource());
+        differentResources.add(instancePlan.getResource());
       }
 
-      Assert.assertEquals(1, resources.size());
+      Assert.assertEquals(1, differentResources.size());
       int instancesCount = containerPlan.getInstances().size();
       Assert.assertEquals(containerRam
-          .minus(RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER).divide(instancesCount),
-          resources.iterator().next().getRam());
+              .minus(RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER).divide(instancesCount),
+          differentResources.iterator().next().getRam());
 
       Assert.assertEquals(
           (containerCpu - RoundRobinPacking.DEFAULT_CPU_PADDING_PER_CONTAINER) / instancesCount,
-          resources.iterator().next().getCpu(), DELTA);
+          differentResources.iterator().next().getCpu(), DELTA);
     }
   }
 
@@ -191,42 +147,25 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testContainerRequestedResourcesWhenRamPaddingSet() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-    Integer totalInstances = spoutParallelism + boltParallelism;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
     // Explicit set resources for container
     ByteAmount containerRam = ByteAmount.fromGigabytes(10);
     ByteAmount containerDisk = ByteAmount.fromGigabytes(20);
-    ByteAmount containerRamPadding = ByteAmount.fromMegabytes(512);
     double containerCpu = 30;
+    ByteAmount containerRamPadding = ByteAmount.fromMegabytes(512);
+    Resource containerResource = new Resource(containerCpu, containerRam, containerDisk);
 
     topologyConfig.setContainerRamRequested(containerRam);
     topologyConfig.setContainerDiskRequested(containerDisk);
     topologyConfig.setContainerCpuRequested(containerCpu);
     topologyConfig.setContainerRamPadding(containerRamPadding);
-    TopologyAPI.Topology topologyExplicitResourcesConfig =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitResourcesConfig =
-        getRoundRobinPackingPlan(topologyExplicitResourcesConfig);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    Assert.assertEquals(numContainers,
-        packingPlanExplicitResourcesConfig.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlanExplicitResourcesConfig.getInstanceCount());
+    PackingPlan packingPlan = doPackingTestWithPartialResource(topology,
+        Optional.empty(), Optional.empty(), boltParallelism,
+        Optional.empty(), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding().cloneWithRam(containerRamPadding), containerResource);
 
-    for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.getContainers()) {
-      Assert.assertEquals(containerCpu, containerPlan.getRequiredResource().getCpu(), DELTA);
-      Assert.assertTrue(String.format(// due to round-off when using divide()
-          "expected: %s but was: %s", containerRam, containerPlan.getRequiredResource().getRam()),
-          Math.abs(
-              containerRam.minus(containerPlan.getRequiredResource().getRam()).asBytes()) <= 1);
-      Assert.assertEquals(containerDisk, containerPlan.getRequiredResource().getDisk());
-
+    for (PackingPlan.ContainerPlan containerPlan : packingPlan.getContainers()) {
       // All instances' resource requirement should be equal
       // So the size of set should be 1
       Set<Resource> resources = new HashSet<>();
@@ -251,15 +190,6 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testCompleteRamMapRequestedWithExactlyEnoughResource() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-    Integer totalInstances = spoutParallelism + boltParallelism;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
     // Explicit set resources for container
     // the value should be ignored, since we set the complete component RAM map
     ByteAmount containerRam = ByteAmount.fromGigabytes(8);
@@ -271,15 +201,14 @@ public class RoundRobinPackingTest {
     topologyConfig.setContainerRamRequested(containerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
     topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap =
-        getRoundRobinPackingPlan(topologyExplicitRamMap);
-
-    AssertPacking.assertContainers(packingPlanExplicitRamMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, spoutRam, null);
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
+    doPackingTestWithPartialResource(topology,
+        Optional.of(boltRam), Optional.empty(), boltParallelism,
+        Optional.of(spoutRam), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithRam(containerRam));
   }
 
   /**
@@ -287,14 +216,6 @@ public class RoundRobinPackingTest {
    */
   @Test(expected = PackingException.class)
   public void testCompleteRamMapRequestedWithLessThanEnoughResource() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
     // Explicit set resources for container
     // the value should be ignored, since we set the complete component RAM map
     ByteAmount containerRam = ByteAmount.fromGigabytes(2);
@@ -306,10 +227,14 @@ public class RoundRobinPackingTest {
     topologyConfig.setContainerRamRequested(containerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
     topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    getRoundRobinPackingPlan(topologyExplicitRamMap);
+    doPackingTestWithPartialResource(topology,
+        Optional.of(boltRam), Optional.empty(), boltParallelism,
+        Optional.of(spoutRam), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithRam(containerRam));
   }
 
   /**
@@ -317,15 +242,6 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testCompleteRamMapRequestedWithMoreThanEnoughResource() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-    Integer totalInstances = spoutParallelism + boltParallelism;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
     // Explicit set resources for container
     // the value should be ignored, since we set the complete component RAM map
     ByteAmount containerRam = ByteAmount.fromBytes(Long.MAX_VALUE);
@@ -337,15 +253,14 @@ public class RoundRobinPackingTest {
     topologyConfig.setContainerRamRequested(containerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
     topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap =
-        getRoundRobinPackingPlan(topologyExplicitRamMap);
-
-    AssertPacking.assertContainers(packingPlanExplicitRamMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, spoutRam, containerRam);
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
+    doPackingTestWithPartialResource(topology,
+        Optional.of(boltRam), Optional.empty(), boltParallelism,
+        Optional.of(spoutRam), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithRam(containerRam));
   }
 
   /**
@@ -353,15 +268,6 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testCompleteRamMapRequestedWithoutPaddingResource() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-    Integer totalInstances = spoutParallelism + boltParallelism;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
     // Explicit set resources for container
     // the value should be ignored, since we set the complete component RAM map
     ByteAmount containerRam = ByteAmount.fromGigabytes(6);
@@ -373,15 +279,14 @@ public class RoundRobinPackingTest {
     topologyConfig.setContainerRamRequested(containerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
     topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap =
-        getRoundRobinPackingPlan(topologyExplicitRamMap);
-
-    AssertPacking.assertContainers(packingPlanExplicitRamMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, spoutRam, null);
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
+    doPackingTestWithPartialResource(topology,
+        Optional.of(boltRam), Optional.empty(), boltParallelism,
+        Optional.of(spoutRam), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithRam(containerRam));
   }
 
   /**
@@ -389,15 +294,6 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testCompleteCpuMapRequestedWithExactlyEnoughResource() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-    Integer totalInstances = spoutParallelism + boltParallelism;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
     // Explicit set resources for container
     double containerCpu = 17;
 
@@ -408,15 +304,14 @@ public class RoundRobinPackingTest {
     topologyConfig.setContainerCpuRequested(containerCpu);
     topologyConfig.setComponentCpu(BOLT_NAME, boltCpu);
     topologyConfig.setComponentCpu(SPOUT_NAME, spoutCpu);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitCpuMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitCpuMap =
-        getRoundRobinPackingPlan(topologyExplicitCpuMap);
-
-    AssertPacking.assertContainers(packingPlanExplicitCpuMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltCpu, spoutCpu, null);
-    Assert.assertEquals(totalInstances, packingPlanExplicitCpuMap.getInstanceCount());
+    doPackingTestWithPartialResource(topology,
+        Optional.empty(), Optional.of(boltCpu), boltParallelism,
+        Optional.empty(), Optional.of(spoutCpu), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithCpu(containerCpu));
   }
 
   /**
@@ -424,15 +319,6 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testCompleteCpuMapRequestedWithMoreThanEnoughResource() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-    Integer totalInstances = spoutParallelism + boltParallelism;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
     // Explicit set resources for container
     double containerCpu = 30;
 
@@ -443,15 +329,14 @@ public class RoundRobinPackingTest {
     topologyConfig.setContainerCpuRequested(containerCpu);
     topologyConfig.setComponentCpu(BOLT_NAME, boltCpu);
     topologyConfig.setComponentCpu(SPOUT_NAME, spoutCpu);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitCpuMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitCpuMap =
-        getRoundRobinPackingPlan(topologyExplicitCpuMap);
-
-    AssertPacking.assertContainers(packingPlanExplicitCpuMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltCpu, spoutCpu, null);
-    Assert.assertEquals(totalInstances, packingPlanExplicitCpuMap.getInstanceCount());
+    doPackingTestWithPartialResource(topology,
+        Optional.empty(), Optional.of(boltCpu), boltParallelism,
+        Optional.empty(), Optional.of(spoutCpu), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithCpu(containerCpu));
   }
 
   /**
@@ -459,15 +344,6 @@ public class RoundRobinPackingTest {
    */
   @Test(expected = PackingException.class)
   public void testCompleteCpuMapRequestedWithLessThanEnoughResource() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-    Integer totalInstances = spoutParallelism + boltParallelism;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
     // Explicit set resources for container
     double containerCpu = 10;
 
@@ -478,14 +354,14 @@ public class RoundRobinPackingTest {
     topologyConfig.setContainerCpuRequested(containerCpu);
     topologyConfig.setComponentCpu(BOLT_NAME, boltCpu);
     topologyConfig.setComponentCpu(SPOUT_NAME, spoutCpu);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitCpuMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitCpuMap = getRoundRobinPackingPlan(topologyExplicitCpuMap);
-
-    AssertPacking.assertContainers(packingPlanExplicitCpuMap.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltCpu, spoutCpu, null);
-    Assert.assertEquals(totalInstances, packingPlanExplicitCpuMap.getInstanceCount());
+    doPackingTestWithPartialResource(topology,
+        Optional.empty(), Optional.of(boltCpu), boltParallelism,
+        Optional.empty(), Optional.of(spoutCpu), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithCpu(containerCpu));
   }
 
   /**
@@ -494,14 +370,6 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testCompleteCpuMapRequestedWithoutPaddingResource() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
     // Explicit set resources for container
     double containerCpu = 16;
 
@@ -512,10 +380,14 @@ public class RoundRobinPackingTest {
     topologyConfig.setContainerCpuRequested(containerCpu);
     topologyConfig.setComponentCpu(BOLT_NAME, boltCpu);
     topologyConfig.setComponentCpu(SPOUT_NAME, spoutCpu);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitCpuMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    getRoundRobinPackingPlan(topologyExplicitCpuMap);
+    doPackingTestWithPartialResource(topology,
+        Optional.empty(), Optional.of(boltCpu), boltParallelism,
+        Optional.empty(), Optional.of(spoutCpu), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithCpu(containerCpu));
   }
 
   /**
@@ -523,15 +395,6 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testPartialRamMap() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-    Integer totalInstances = spoutParallelism + boltParallelism;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
     // Explicit set resources for container
     ByteAmount containerRam = ByteAmount.fromGigabytes(10);
 
@@ -540,39 +403,14 @@ public class RoundRobinPackingTest {
 
     topologyConfig.setContainerRamRequested(containerRam);
     topologyConfig.setComponentRam(BOLT_NAME, boltRam);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap =
-        getRoundRobinPackingPlan(topologyExplicitRamMap);
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
-
-    // RAM for bolt should be the value in component RAM map
-    for (PackingPlan.ContainerPlan containerPlan : packingPlanExplicitRamMap.getContainers()) {
-      Assert.assertEquals(containerRam, containerPlan.getRequiredResource().getRam());
-      int boltCount = 0;
-      int instancesCount = containerPlan.getInstances().size();
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-        if (instancePlan.getComponentName().equals(BOLT_NAME)) {
-          Assert.assertEquals(boltRam, instancePlan.getResource().getRam());
-          boltCount++;
-        }
-      }
-
-      // Ram for spout should be:
-      // (containerRam - all RAM for bolt - RAM for padding) / (# of spouts)
-      int spoutCount = instancesCount - boltCount;
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-        if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
-          Assert.assertEquals(
-              containerRam
-                  .minus(boltRam.multiply(boltCount))
-                  .minus(RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER)
-                  .divide(spoutCount),
-              instancePlan.getResource().getRam());
-        }
-      }
-    }
+    doPackingTestWithPartialResource(topology,
+        Optional.of(boltRam), Optional.empty(), boltParallelism,
+        Optional.empty(), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithRam(containerRam));
   }
 
   /**
@@ -580,15 +418,6 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testPartialCpuMap() throws Exception {
-    int numContainers = 2;
-    int spoutParallelism = 4;
-    int boltParallelism = 3;
-    Integer totalInstances = spoutParallelism + boltParallelism;
-
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-
     // Explicit set resources for container
     double containerCpu = 17;
 
@@ -597,39 +426,14 @@ public class RoundRobinPackingTest {
 
     topologyConfig.setContainerCpuRequested(containerCpu);
     topologyConfig.setComponentCpu(BOLT_NAME, boltCpu);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topologyExplicitCpuMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitCpuMap =
-        getRoundRobinPackingPlan(topologyExplicitCpuMap);
-    Assert.assertEquals(totalInstances, packingPlanExplicitCpuMap.getInstanceCount());
-
-    // CPU for bolt should be the value in component CPU map
-    for (PackingPlan.ContainerPlan containerPlan : packingPlanExplicitCpuMap.getContainers()) {
-      Assert.assertEquals(containerCpu, containerPlan.getRequiredResource().getCpu(), DELTA);
-      int boltCount = 0;
-      int instancesCount = containerPlan.getInstances().size();
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-        if (instancePlan.getComponentName().equals(BOLT_NAME)) {
-          Assert.assertEquals(boltCpu, instancePlan.getResource().getCpu(), DELTA);
-          boltCount++;
-        }
-      }
-
-      // CPU for spout should be:
-      // (containerCpu - all CPU for bolt - CPU for padding) / (# of spouts)
-      int spoutCount = instancesCount - boltCount;
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-        if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
-          Assert.assertEquals(
-              (containerCpu
-                  - boltCpu * boltCount
-                  - RoundRobinPacking.DEFAULT_CPU_PADDING_PER_CONTAINER)
-                  / spoutCount,
-              instancePlan.getResource().getCpu(), DELTA);
-        }
-      }
-    }
+    doPackingTestWithPartialResource(topology,
+        Optional.empty(), Optional.of(boltCpu), boltParallelism,
+        Optional.empty(), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithCpu(containerCpu));
   }
 
   /**
@@ -637,30 +441,18 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testEvenPacking() throws Exception {
-    int numContainers = 2;
     int componentParallelism = 4;
+    boltParallelism = componentParallelism;
+    spoutParallelism = componentParallelism;
 
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topology =
-        getTopology(componentParallelism, componentParallelism, topologyConfig);
-
-    int numInstance = TopologyUtils.getTotalInstance(topology);
-    // Two components
-    Assert.assertEquals(2 * componentParallelism, numInstance);
-    PackingPlan output = getRoundRobinPackingPlan(topology);
-    Assert.assertEquals(numContainers, output.getContainers().size());
-    Assert.assertEquals((Integer) numInstance, output.getInstanceCount());
-
-    for (PackingPlan.ContainerPlan container : output.getContainers()) {
-      Assert.assertEquals(numInstance / numContainers, container.getInstances().size());
-
-      // Verify each container got 2 spout and 2 bolt and container 1 got
-      assertComponentCount(container, "spout", 2);
-      assertComponentCount(container, "bolt", 2);
-    }
+    doPackingTestWithPartialResource(topology,
+        Optional.empty(), Optional.empty(), boltParallelism,
+        Optional.empty(), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()));
   }
 
 
@@ -669,42 +461,29 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testRepackingWithSameTotalInstances() throws Exception {
-    int numContainers = 2;
     int componentParallelism = 4;
+    boltParallelism = componentParallelism;
+    spoutParallelism = componentParallelism;
 
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topology =
-        getTopology(componentParallelism, componentParallelism, topologyConfig);
-
-    int numInstance = TopologyUtils.getTotalInstance(topology);
-    // Two components
-    Assert.assertEquals(2 * componentParallelism, numInstance);
+    PackingPlan packingPlan = doPackingTestWithPartialResource(topology,
+        Optional.empty(), Optional.empty(), boltParallelism,
+        Optional.empty(), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()));
 
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, -1);
     componentChanges.put(BOLT_NAME,  +1);
-    PackingPlan output = getRoundRobinRePackingPlan(topology, componentChanges);
-    Assert.assertEquals(numContainers, output.getContainers().size());
-    Assert.assertEquals((Integer) numInstance, output.getInstanceCount());
 
-    int spoutCount = 0;
-    int boltCount = 0;
-    for (PackingPlan.ContainerPlan container : output.getContainers()) {
-      Assert.assertEquals(numInstance / numContainers, container.getInstances().size());
-
-      for (PackingPlan.InstancePlan instancePlan : container.getInstances()) {
-        if (SPOUT_NAME.equals(instancePlan.getComponentName())) {
-          spoutCount++;
-        } else if (BOLT_NAME.equals(instancePlan.getComponentName())) {
-          boltCount++;
-        }
-      }
-    }
-    Assert.assertEquals(componentParallelism - 1, spoutCount);
-    Assert.assertEquals(componentParallelism + 1, boltCount);
+    doScalingTestWithPartialResource(topology, packingPlan, componentChanges,
+        Optional.empty(), Optional.empty(), boltParallelism,
+        Optional.empty(), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()));
   }
 
   /**
@@ -712,43 +491,29 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testRepackingWithMoreTotalInstances() throws Exception {
-    int numContainers = 2;
     int componentParallelism = 4;
+    boltParallelism = componentParallelism;
+    spoutParallelism = componentParallelism;
 
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topology =
-        getTopology(componentParallelism, componentParallelism, topologyConfig);
-
-    int numInstance = TopologyUtils.getTotalInstance(topology);
-    // Two components
-    Assert.assertEquals(2 * componentParallelism, numInstance);
+    PackingPlan packingPlan = doPackingTestWithPartialResource(topology,
+        Optional.empty(), Optional.empty(), boltParallelism,
+        Optional.empty(), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()));
 
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, +1);
     componentChanges.put(BOLT_NAME,  +1);
-    PackingPlan output = getRoundRobinRePackingPlan(topology, componentChanges);
-    Assert.assertEquals(numContainers + 1, output.getContainers().size());
-    Assert.assertEquals((Integer) (numInstance + 2), output.getInstanceCount());
 
-    int spoutCount = 0;
-    int boltCount = 0;
-    for (PackingPlan.ContainerPlan container : output.getContainers()) {
-      Assert.assertTrue((double) container.getInstances().size()
-          <= (double) numInstance / numContainers);
-
-      for (PackingPlan.InstancePlan instancePlan : container.getInstances()) {
-        if (SPOUT_NAME.equals(instancePlan.getComponentName())) {
-          spoutCount++;
-        } else if (BOLT_NAME.equals(instancePlan.getComponentName())) {
-          boltCount++;
-        }
-      }
-    }
-    Assert.assertEquals(componentParallelism + 1, spoutCount);
-    Assert.assertEquals(componentParallelism + 1, boltCount);
+    doScalingTestWithPartialResource(topology, packingPlan, componentChanges,
+        Optional.empty(), Optional.empty(), boltParallelism,
+        Optional.empty(), Optional.empty(), spoutParallelism,
+        numContainers + 1, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()));
   }
 
   /**
@@ -756,54 +521,28 @@ public class RoundRobinPackingTest {
    */
   @Test
   public void testRepackingWithFewerTotalInstances() throws Exception {
-    int numContainers = 2;
     int componentParallelism = 4;
+    boltParallelism = componentParallelism;
+    spoutParallelism = componentParallelism;
 
-    // Set up the topology and its config
-    org.apache.heron.api.Config topologyConfig = new org.apache.heron.api.Config();
-    topologyConfig.put(org.apache.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
-    TopologyAPI.Topology topology =
-        getTopology(componentParallelism, componentParallelism, topologyConfig);
-
-    int numInstance = TopologyUtils.getTotalInstance(topology);
-    // Two components
-    Assert.assertEquals(2 * componentParallelism, numInstance);
+    PackingPlan packingPlan = doPackingTestWithPartialResource(topology,
+        Optional.empty(), Optional.empty(), boltParallelism,
+        Optional.empty(), Optional.empty(), spoutParallelism,
+        numContainers, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()));
 
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(SPOUT_NAME, -2);
     componentChanges.put(BOLT_NAME,  -2);
-    PackingPlan output = getRoundRobinRePackingPlan(topology, componentChanges);
-    Assert.assertEquals(numContainers - 1, output.getContainers().size());
-    Assert.assertEquals((Integer) (numInstance - 4), output.getInstanceCount());
 
-    int spoutCount = 0;
-    int boltCount = 0;
-    for (PackingPlan.ContainerPlan container : output.getContainers()) {
-      Assert.assertTrue((double) container.getInstances().size()
-          <= (double) numInstance / numContainers);
-
-      for (PackingPlan.InstancePlan instancePlan : container.getInstances()) {
-        if (SPOUT_NAME.equals(instancePlan.getComponentName())) {
-          spoutCount++;
-        } else if (BOLT_NAME.equals(instancePlan.getComponentName())) {
-          boltCount++;
-        }
-      }
-    }
-    Assert.assertEquals(componentParallelism - 2, spoutCount);
-    Assert.assertEquals(componentParallelism - 2, boltCount);
+    doScalingTestWithPartialResource(topology, packingPlan, componentChanges,
+        Optional.empty(), Optional.empty(), boltParallelism,
+        Optional.empty(), Optional.empty(), spoutParallelism,
+        numContainers - 1, getDefaultPadding(),
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()));
   }
-
-  private static void assertComponentCount(
-      PackingPlan.ContainerPlan containerPlan, String componentName, int expectedCount) {
-    int count = 0;
-    for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-      if (componentName.equals(instancePlan.getComponentName())) {
-        count++;
-      }
-    }
-    Assert.assertEquals(expectedCount, count);
-  }
-
 }

--- a/heron/spi/src/java/org/apache/heron/spi/packing/Resource.java
+++ b/heron/spi/src/java/org/apache/heron/spi/packing/Resource.java
@@ -63,6 +63,14 @@ public class Resource {
     return new Resource(this.getCpu(), newRam, this.getDisk());
   }
 
+  public Resource cloneWithCpu(double newCpu) {
+    return new Resource(newCpu, this.getRam(), this.getDisk());
+  }
+
+  public Resource cloneWithDisk(ByteAmount newDisk) {
+    return new Resource(this.getCpu(), this.getRam(), newDisk);
+  }
+
   /**
    * Subtracts a given resource from the current resource. The results is never negative.
    */


### PR DESCRIPTION
Breaking down #3184 

This PR mainly revamped RoundRobinPackingTest so that it extends CommonPackingTest and uses assertion helpers just like how other packing tests are doing. 

This PR also re-placed some FFD and RCRR specific tests accordingly