### PR TITLE
Add metrics for total time spent on user logic

### DIFF
--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/BoltMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/BoltMetrics.java
@@ -48,6 +48,7 @@ public class BoltMetrics implements IBoltMetrics {
   private final CountMetric failCount;
   private final CountMetric executeCount;
   private final ReducedMetric<MeanReducerState, Number, Double> executeLatency;
+  private final CountMetric executeTimeNs;
   private final CountMetric tupleAddedToQueue;
   // Time in nano-seconds spending in execute() at every interval
   private final CountMetric emitCount;
@@ -75,6 +76,7 @@ public class BoltMetrics implements IBoltMetrics {
     failCount = new CountMetric();
     executeCount = new CountMetric();
     executeLatency = new ReducedMetric<>(new MeanReducer());
+    executeTimeNs = new CountMetric();
     emitCount = new CountMetric();
     outQueueFullCount = new CountMetric();
     tupleAddedToQueue = new CountMetric();
@@ -95,6 +97,7 @@ public class BoltMetrics implements IBoltMetrics {
     topologyContext.registerMetric("__fail-count/default", failCount, interval);
     topologyContext.registerMetric("__execute-count/default", executeCount, interval);
     topologyContext.registerMetric("__execute-latency/default", executeLatency, interval);
+    topologyContext.registerMetric("__execute-time-ns/default", executeTimeNs, interval);
     topologyContext.registerMetric("__emit-count/default", emitCount, interval);
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
     topologyContext.registerMetric("__data-tuple-added-to-outgoing-queue/default",
@@ -127,6 +130,7 @@ public class BoltMetrics implements IBoltMetrics {
   public void executeTuple(String streamId, String sourceComponent, long latency) {
     executeCount.incr();
     executeLatency.update(latency);
+    executeTimeNs.incrBy(latency);
   }
 
   public void emittedTuple(String streamId) {

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/FullSpoutMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/FullSpoutMetrics.java
@@ -57,6 +57,7 @@ public class FullSpoutMetrics implements ISpoutMetrics {
   private final MultiCountMetric emitCount;
   private final ReducedMetric<MeanReducerState, Number, Double> nextTupleLatency;
   private final CountMetric nextTupleCount;
+  private final CountMetric nextTupleTimeNs;
   private final MultiCountMetric serializationTimeNs;
   private final CountMetric tupleAddedToQueue;
   // The # of times back-pressure happens on outStreamQueue so instance could not
@@ -87,6 +88,7 @@ public class FullSpoutMetrics implements ISpoutMetrics {
     emitCount = new MultiCountMetric();
     nextTupleLatency = new ReducedMetric<>(new MeanReducer());
     nextTupleCount = new CountMetric();
+    nextTupleTimeNs = new CountMetric();
     outQueueFullCount = new CountMetric();
     pendingTuplesCount = new ReducedMetric<>(new MeanReducer());
     serializationTimeNs = new MultiCountMetric();
@@ -111,6 +113,7 @@ public class FullSpoutMetrics implements ISpoutMetrics {
     topologyContext.registerMetric("__emit-count", emitCount, interval);
     topologyContext.registerMetric("__next-tuple-latency", nextTupleLatency, interval);
     topologyContext.registerMetric("__next-tuple-count", nextTupleCount, interval);
+    topologyContext.registerMetric("__next-tuple-time-ns", nextTupleTimeNs, interval);
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
     topologyContext.registerMetric("__pending-acked-count", pendingTuplesCount, interval);
     topologyContext.registerMetric("__tuple-serialization-time-ns", serializationTimeNs,
@@ -168,6 +171,7 @@ public class FullSpoutMetrics implements ISpoutMetrics {
   public void nextTuple(long latency) {
     nextTupleLatency.update(latency);
     nextTupleCount.incr();
+    nextTupleTimeNs.incrBy(latency);
   }
 
   public void addTupleToQueue(int size) {

--- a/heron/common/src/java/org/apache/heron/common/utils/metrics/SpoutMetrics.java
+++ b/heron/common/src/java/org/apache/heron/common/utils/metrics/SpoutMetrics.java
@@ -51,6 +51,7 @@ public class SpoutMetrics implements ISpoutMetrics {
   private final CountMetric emitCount;
   private final ReducedMetric<MeanReducerState, Number, Double> nextTupleLatency;
   private final CountMetric nextTupleCount;
+  private final CountMetric nextTupleTimeNs;
   private final CountMetric tupleAddedToQueue;
 
   // The # of times back-pressure happens on outStreamQueue so instance could not
@@ -81,6 +82,7 @@ public class SpoutMetrics implements ISpoutMetrics {
     emitCount = new CountMetric();
     nextTupleLatency = new ReducedMetric<>(new MeanReducer());
     nextTupleCount = new CountMetric();
+    nextTupleTimeNs = new CountMetric();
     outQueueFullCount = new CountMetric();
     pendingTuplesCount = new ReducedMetric<>(new MeanReducer());
     tupleAddedToQueue = new CountMetric();
@@ -103,6 +105,7 @@ public class SpoutMetrics implements ISpoutMetrics {
     topologyContext.registerMetric("__emit-count/default", emitCount, interval);
     topologyContext.registerMetric("__next-tuple-latency", nextTupleLatency, interval);
     topologyContext.registerMetric("__next-tuple-count", nextTupleCount, interval);
+    topologyContext.registerMetric("__next-tuple-time-ns", nextTupleTimeNs, interval);
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
     topologyContext.registerMetric("__pending-acked-count", pendingTuplesCount, interval);
     topologyContext.registerMetric("__data-tuple-added-to-outgoing-queue/default",
@@ -147,6 +150,7 @@ public class SpoutMetrics implements ISpoutMetrics {
   public void nextTuple(long latency) {
     nextTupleLatency.update(latency);
     nextTupleCount.incr();
+    nextTupleTimeNs.incrBy(latency);
   }
 
   public void updateOutQueueFullCount() {


### PR DESCRIPTION
executeTimeNs in FullBoltMetrics is quite useful for investigation. However it is not in BoltMetrics. It is added in this PR.

Also, there is no similar metrics in SpoutMetrics and FullSpoutMetrics. A new metric "__next-tuple-time-ns" is added as well.