### PR TITLE
Change tmaster/stmgr uptime granularity to be 1 second

### DIFF
--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -129,6 +129,8 @@ class StMgr {
   void FetchMetricsCacheLocation();
   // A wrapper that calls FetchTMasterLocation. Needed for RegisterTimer
   void CheckTMasterLocation(EventLoop::Status);
+
+  void UpdateUptimeMetric();
   void UpdateProcessMetrics(EventLoop::Status);
 
   // Utility function to create checkpoint mgr client

--- a/heron/tmaster/src/cpp/manager/tmaster.h
+++ b/heron/tmaster/src/cpp/manager/tmaster.h
@@ -181,6 +181,8 @@ class TMaster {
   void OnPackingPlanFetch(proto::system::PackingPlan* newPackingPlan,
                           proto::system::StatusCode _status);
 
+  // Metrics updates
+  void UpdateUptimeMetric();
   void UpdateProcessMetrics(EventLoop::Status);
 
   // Update configurations in physical plan.


### PR DESCRIPTION
Currently the uptime metric updates every 1 minute. This is not accurate enough in some case.

uptime metric granularity is changed to 1 second in tmaster and stmgr in this PR