### PR TITLE
Make 0 stat visible in Heron UI

### DIFF
--- a/heron/tools/ui/resources/static/js/stat-trendlines.js
+++ b/heron/tools/ui/resources/static/js/stat-trendlines.js
@@ -133,7 +133,9 @@ function StatTrendlines(baseUrl, cluster, environ, toponame, physicalPlan, logic
           .attr('y2', rowHeight);
       var yScale = d3.scale.linear()
         .domain(extent)
-        .range([rowHeight, 0]);
+        // yScale starts from 1 so that value 0 is visible and users can tell
+        // if metrics are loaded or not
+        .range([rowHeight, 1]);
 
       // request data and render the line chart
       (metric.queryTrendline || makeTrendlineQuery)(metric, name, instance, startTime, endTime, function (data) {

--- a/heron/tools/ui/resources/static/js/stat-trendlines.js
+++ b/heron/tools/ui/resources/static/js/stat-trendlines.js
@@ -135,7 +135,7 @@ function StatTrendlines(baseUrl, cluster, environ, toponame, physicalPlan, logic
         .domain(extent)
         // yScale starts from 1 so that value 0 is visible and users can tell
         // if metrics are loaded or not
-        .range([rowHeight, 1]);
+        .range([rowHeight - 1, 0]);
 
       // request data and render the line chart
       (metric.queryTrendline || makeTrendlineQuery)(metric, name, instance, startTime, endTime, function (data) {


### PR DESCRIPTION
Currently stat 0 looks the same as still loading. The only way to tell is mouse over the data bar. With this PR stat 0 is shown as a 1 pixel high bar so that it is a bit easier for users to tell the difference from UI.