### PR TITLE
Remove 'Kubernetes' in SPI function name

### DIFF
--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesUtils.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesUtils.java
@@ -41,7 +41,7 @@ final class KubernetesUtils {
   }
 
   static String getConfCommand(Config config) {
-    return String.format("%s %s", Context.downloaderConfKubernetes(config), CONTAINER);
+    return String.format("%s %s", Context.downloaderConf(config), CONTAINER);
   }
 
   static String getFetchCommand(Config config, Config runtime) {

--- a/heron/spi/src/java/org/apache/heron/spi/common/Context.java
+++ b/heron/spi/src/java/org/apache/heron/spi/common/Context.java
@@ -346,7 +346,7 @@ public class Context {
     return cfg.getStringValue(Key.DOWNLOADER_BINARY);
   }
 
-  public static String downloaderConfKubernetes(Config cfg) {
+  public static String downloaderConf(Config cfg) {
     return cfg.getStringValue(Key.DOWNLOADER_CONF);
   }
 


### PR DESCRIPTION
'Kubernetes' should be in any SPI function names.

Sorry I didn't catch it in code review.