### PR TITLE
fix print typo

### DIFF
--- a/heron/statemgrs/src/java/org/apache/heron/statemgr/FileSystemStateManager.java
+++ b/heron/statemgrs/src/java/org/apache/heron/statemgr/FileSystemStateManager.java
@@ -295,7 +295,7 @@ public abstract class FileSystemStateManager implements IStateManager {
     if (isTopologyRunning(topologyName).get()) {
       print("==> Topology %s found", topologyName);
       try {
-        print("==> Topology %s:", getTopology(null, topologyName).get());
+        print("==> Topology:\n%s", getTopology(null, topologyName).get());
       } catch (ExecutionException e) {
         print("Topology node not found %s", e.getMessage());
       }


### PR DESCRIPTION
fix a print typo in FileSystemStateManager.java when printing the statemgr details.