### PR TITLE
align protopy to WORKSPACE

### DIFF
--- a/heron/proto/BUILD
+++ b/heron/proto/BUILD
@@ -191,7 +191,7 @@ pex_library(
         ":proto_ckptmgr_py",
     ],
     reqs = [
-        "protobuf==3.4.0",
+        "protobuf==3.4.1",
         "setuptools==18.0.1",
     ],
 )

--- a/heronpy/proto/BUILD
+++ b/heronpy/proto/BUILD
@@ -39,7 +39,7 @@ pex_library(
         ":proto_ckptmgr_py",
     ],
     reqs = [
-        "protobuf==3.4.0",
+        "protobuf==3.4.1",
         "setuptools==18.0.1",
     ],
 )
@@ -62,7 +62,7 @@ pex_binary(
         ":proto_ckptmgr_py",
     ],
     reqs = [
-        "protobuf==3.4.0",
+        "protobuf==3.4.1",
         "setuptools==18.0.1",
     ],
 )


### PR DESCRIPTION
https://github.com/apache/incubator-heron/blob/master/WORKSPACE#L835 shows 3.4.1, but proto py uses 3.4.0. 
update 3.4.0 to 3.4.1