### PR TITLE
Update WORKSPACE info for zookeeper http archive.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -865,13 +865,13 @@ new_http_archive(
 new_http_archive(
     name = "org_apache_zookeeper",
     urls = [
-      "http://apache.cs.utah.edu/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz",
-      "http://apache.claz.org/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz",
-      "http://apache.mesi.com.ar/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz",
+      "http://apache.cs.utah.edu/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz",
+      "http://apache.claz.org/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz",
+      "http://apache.mesi.com.ar/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz",
     ],
-    strip_prefix = "zookeeper-3.4.10",
+    strip_prefix = "zookeeper-3.4.13",
     build_file = "third_party/zookeeper/zookeeper.BUILD",
-    sha256 = "7f7f5414e044ac11fee2a1e0bc225469f51fb0cdf821e67df762a43098223f27",
+    sha256 = "7ced798e41d2027784b8fd55c908605ad5bd94a742d5dab2506be8f94770594d",
 )
 
 new_http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -864,14 +864,10 @@ new_http_archive(
 
 new_http_archive(
     name = "org_apache_zookeeper",
-    urls = [
-      "http://apache.cs.utah.edu/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz",
-      "http://apache.claz.org/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz",
-      "http://apache.mesi.com.ar/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz",
-    ],
-    strip_prefix = "zookeeper-3.4.13",
+    urls = ["http://archive.apache.org/dist/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz"],
+    strip_prefix = "zookeeper-3.4.10",
     build_file = "third_party/zookeeper/zookeeper.BUILD",
-    sha256 = "7ced798e41d2027784b8fd55c908605ad5bd94a742d5dab2506be8f94770594d",
+    sha256 = "7f7f5414e044ac11fee2a1e0bc225469f51fb0cdf821e67df762a43098223f27",
 )
 
 new_http_archive(


### PR DESCRIPTION
Updated the new_http_archive entry for org_apache_zookeeper to zookeeper-3.4.13. Attempting to perform a clean installation of Heron failed due to the fact that the previous version (3.4.10) is no longer accessible at the url locations provided.

I updated to the current version and was able to successfully build and run heron.