### PR TITLE
broken zookeeper dependancy fixed

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -865,9 +865,7 @@ new_http_archive(
 new_http_archive(
     name = "org_apache_zookeeper",
     urls = [
-      "http://apache.cs.utah.edu/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz",
-      "http://apache.claz.org/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz",
-      "http://apache.mesi.com.ar/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz",
+      "http://archive.apache.org/dist/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz",
     ],
     strip_prefix = "zookeeper-3.4.10",
     build_file = "third_party/zookeeper/zookeeper.BUILD",


### PR DESCRIPTION
The previous version zookeeper-3.4.10 was removed from all mirrors. 
Now, the only option is to get it from archive.apache.org.