### PR TITLE
Make cppckecker independ of pcre

### DIFF
--- a/third_party/cppcheck/cppcheck.BUILD
+++ b/third_party/cppcheck/cppcheck.BUILD
@@ -4,7 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 install_script = "\n".join([
     "cd external/com_github_danmar_cppcheck",
-    "make SRCDIR=build CFGDIR=cfg HAVE_RULES=yes CXXFLAGS='-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function'",
+    "make SRCDIR=build CFGDIR=cfg CXXFLAGS='-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function'",
     "rm -rf ../../$(@D)/*",
     "cp -R $$(pwd)/* ../../$(@D)/",
 ])


### PR DESCRIPTION
Currently cppchecker relies on pcre which is not installed in some systems. Pcre (rules support) is not really need here so it is disabled here.