### PR TITLE
Fix command line result when --dry-run is enabled

### DIFF
--- a/heron/tools/cli/src/python/result.py
+++ b/heron/tools/cli/src/python/result.py
@@ -186,8 +186,8 @@ def render(results):
 # check if all results are successful
 def is_successful(results):
   if isinstance(results, list):
-    return all([result.status == Status.Ok for result in results])
+    return all([is_successful(result) for result in results])
   elif isinstance(results, Result):
-    return results.status == Status.Ok
+    return results.status == Status.Ok or results.status == Status.DryRun
   else:
     raise RuntimeError("Unknown result instance: %s", str(results.__class__))


### PR DESCRIPTION
Currently "heron submit .... --dry-run" returns 1 when the submission succeeds or fails.

It should return 0 when the submission succeeds.