### PR TITLE
init instance state when necessary

### DIFF
--- a/heron/instance/src/java/org/apache/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/org/apache/heron/instance/bolt/BoltInstance.java
@@ -183,8 +183,8 @@ public class BoltInstance implements IInstance {
 
     boltMetrics.registerMetrics(topologyContext);
 
-    // Initialize the instanceState if the bolt is stateful
-    if (bolt instanceof IStatefulComponent) {
+    // Initialize the instanceState if the topology is stateful and bolt is a stateful component
+    if (isTopologyStateful && bolt instanceof IStatefulComponent) {
       this.instanceState = state;
       ((IStatefulComponent<Serializable, Serializable>) bolt).initState(instanceState);
 

--- a/heron/instance/src/java/org/apache/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/org/apache/heron/instance/spout/SpoutInstance.java
@@ -188,8 +188,8 @@ public class SpoutInstance implements IInstance {
 
     spoutMetrics.registerMetrics(topologyContext);
 
-    // Initialize the instanceState if the spout is stateful
-    if (spout instanceof IStatefulComponent) {
+    // Initialize the instanceState if the topology is stateful and spout is a stateful component
+    if (isTopologyStateful && spout instanceof IStatefulComponent) {
       this.instanceState = state;
       ((IStatefulComponent<Serializable, Serializable>) spout).initState(instanceState);
 


### PR DESCRIPTION
init instance state only when the topology is stateful and the component is a stateful component.

If a statefulComponent instance is used in a non-stateful topology currently, the instance's local state map will be updated to `null` without this fix.