### PR TITLE
memory leak in tmaster fixed

### DIFF
--- a/heron/tmaster/src/cpp/manager/stats-interface.cpp
+++ b/heron/tmaster/src/cpp/manager/stats-interface.cpp
@@ -160,7 +160,6 @@ void StatsInterface::HandleStmgrsRegistrationSummaryRequest(IncomingHTTPRequest*
   http_response->AddHeader("Content-Length", std::to_string(response_string.size()));
   http_response->AddResponse(response_string);
   http_server_->SendReply(_request, 200, http_response);
-  delete stmgrs_reg_summary_response;
   delete _request;
   LOG(INFO) << "Returned stream managers registration summary response";
 }

--- a/heron/tmaster/src/cpp/manager/tmaster.cpp
+++ b/heron/tmaster/src/cpp/manager/tmaster.cpp
@@ -847,15 +847,19 @@ bool TMaster::DistributePhysicalPlan() {
   return false;
 }
 
-proto::tmaster::StmgrsRegistrationSummaryResponse* TMaster::GetStmgrsRegSummary() {
-  auto response = new proto::tmaster::StmgrsRegistrationSummaryResponse();
+std::unique_ptr<proto::tmaster::StmgrsRegistrationSummaryResponse> TMaster::GetStmgrsRegSummary() {
+  auto response = std::unique_ptr<proto::tmaster::StmgrsRegistrationSummaryResponse>(
+          new proto::tmaster::StmgrsRegistrationSummaryResponse());
+
   for (auto it = stmgrs_.begin(); it != stmgrs_.end(); ++it) {
     response->add_registered_stmgrs(it->first);
   }
+
   for (auto it = absent_stmgrs_.begin(); it != absent_stmgrs_.end(); ++it) {
     response->add_absent_stmgrs(*it);
   }
-  return response;
+
+  return std::move(response);
 }
 
 proto::system::PhysicalPlan* TMaster::MakePhysicalPlan() {

--- a/heron/tmaster/src/cpp/manager/tmaster.h
+++ b/heron/tmaster/src/cpp/manager/tmaster.h
@@ -90,7 +90,7 @@ class TMaster {
   void HandleCleanStatefulCheckpointResponse(proto::system::StatusCode);
 
   // Get stream managers registration summary
-  proto::tmaster::StmgrsRegistrationSummaryResponse* GetStmgrsRegSummary();
+  std::unique_ptr<proto::tmaster::StmgrsRegistrationSummaryResponse> GetStmgrsRegSummary();
 
   // Accessors
   const proto::system::PhysicalPlan* getPhysicalPlan() const { return current_pplan_; }


### PR DESCRIPTION
The memory leak in TMaster was reported by one of the Twitter internal clients.
After running TMaster under Valgrind memory leaks detector, the leak was localized.
This PR aims to fix it. 

`GetStmgrsRegSummary()` now returns a smart pointer (`unique_ptr<>`). So, as soon as a caller no need the returned result anymore the memory is freed automatically.

Tested this PR locally under Valgrind and don't see the leak anymore.