### PR TITLE
Fix version of PyYAML.

### DIFF
--- a/heron/executor/src/python/BUILD
+++ b/heron/executor/src/python/BUILD
@@ -7,7 +7,7 @@ pex_library(
         "//heron/statemgrs/src/python:statemgr-py",
         "//heron/common/src/python:common-py",
     ],
-    reqs = ["PyYAML==3.10"],
+    reqs = ["PyYAML==3.13"],
 )
 
 pex_binary(

--- a/heron/instance/src/python/BUILD
+++ b/heron/instance/src/python/BUILD
@@ -19,6 +19,6 @@ pex_binary(
     deps = [":instance-py"],
     reqs = [
         'colorlog==2.6.1',
-        'PyYAML==3.10'
+        'PyYAML==3.13'
     ]
 )

--- a/heron/statemgrs/src/python/BUILD
+++ b/heron/statemgrs/src/python/BUILD
@@ -7,7 +7,7 @@ pex_library(
     '//heron/proto:proto-py',
   ],
   reqs = [
-    'PyYAML==3.10',
+    'PyYAML==3.13',
     'kazoo==1.3.1',
     'zope.interface==4.0.5'
   ],

--- a/heron/tools/admin/src/python/BUILD
+++ b/heron/tools/admin/src/python/BUILD
@@ -12,7 +12,7 @@ pex_library(
         "//heron/proto:proto-py",
     ],
     reqs = [
-      "PyYAML==3.10",
+      "PyYAML==3.13",
       "enum34==1.1.6",
       "requests==2.12.3",
       "netifaces==0.10.6"

--- a/heron/tools/cli/src/python/BUILD
+++ b/heron/tools/cli/src/python/BUILD
@@ -11,7 +11,7 @@ pex_library(
         "//heron/proto:proto-py",
     ],
     reqs = [
-      "PyYAML==3.10",
+      "PyYAML==3.13",
       "enum34==1.1.6",
       "requests==2.12.3",
       "netifaces==0.10.6"

--- a/heron/tools/common/src/python/BUILD
+++ b/heron/tools/common/src/python/BUILD
@@ -15,5 +15,5 @@ pex_library(
     deps = [
         "//heron/common/src/python:common-py",
     ],
-    reqs = ["PyYAML==3.10"],
+    reqs = ["PyYAML==3.13"],
 )


### PR DESCRIPTION
This error occurred at the time of build.
```
make[1]: Leaving directory `/tmp/gperftools.sOt2Y'
INFO: From Compiling heron/common/src/cpp/basics/processutils.cpp:
heron/common/src/cpp/basics/processutils.cpp: In static member function 'static sp_string ProcessUtils::getCurrentWorkingDirectory()':
heron/common/src/cpp/basics/processutils.cpp:70:29: warning: ignoring return value of 'char* getcwd(char*, size_t)', declared with attribute warn_unused_result [-Wunused-result]
   getcwd(buff, FILENAME_MAX);
                             ^
ERROR: /scratch/heron/tools/admin/src/python/BUILD:22:1: PexPython heron/tools/admin/src/python/heron-admin.pex failed (Exit 1): pex_wrapper.pex failed: error executing command
  (cd /root/.cache/bazel/_bazel_root/c481f31d0aff7f9fd86654fb84c9a629/execroot/org_apache_heron && \
  exec env - \
    PATH=/bin:/usr/bin:/usr/local/bin \
    PEX_ROOT=.pex \
    PEX_VERBOSE=0 \
  bazel-out/host/bin/tools/rules/pex/pex_wrapper.pex --pex-root .pex --entry-point heron.tools.admin.src.python.main --output-file bazel-out/k8-opt/bin/heron/tools/admin/src/python/heron-admin.pex --disable-cache bazel-out/k8-opt/bin/heron/tools/admin/src/python/heron-admin.pex_manifest)
Execution platform: @bazel_tools//platforms:host_platform
Could not satisfy all requirements for PyYAML==3.10:
    PyYAML==3.10, PyYAML==3.13
Target //scripts/packages:tarpkgs failed to build
INFO: Elapsed time: 576.944s, Critical Path: 144.36s
INFO: 481 processes: 476 local, 5 worker.
FAILED: Build did NOT complete successfully
```