### PR TITLE
Improve the error message (with numbers) for the 'More More container…

### DIFF
--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
@@ -365,7 +365,9 @@ public class RoundRobinPacking implements IPacking, IRepacking {
     Map<Integer, List<InstanceId>> allocation = new HashMap<>();
     int totalInstance = TopologyUtils.getTotalInstance(parallelismMap);
     if (numContainer > totalInstance) {
-      throw new RuntimeException("More containers allocated than instance.");
+      throw new RuntimeException(
+          String.format("More containers (%d) allocated than instances (%d).",
+              numContainer, totalInstance));
     }
 
     for (int i = 1; i <= numContainer; ++i) {


### PR DESCRIPTION
…s allocated than instance' exception