### PR TITLE
Fix build when the source code is not managed by git

### DIFF
--- a/scripts/release/status.sh
+++ b/scripts/release/status.sh
@@ -43,9 +43,10 @@ function disable_e_and_execute {
 }
 
 # get the release tag version or the branch name
-if [ -d .git ];
+if [ -z ${HERON_BUILD_VERSION+x} ];
 then
-  if [ -z ${HERON_BUILD_VERSION+x} ];
+  # variable HERON_BUILD_VERSION is not available, use git branch as build version
+  if [ -d .git ];
   then
     cmd="git rev-parse --abbrev-ref HEAD"
     build_version=$($cmd) || die "Failed to run command to check head: $cmd"
@@ -56,9 +57,12 @@ then
       build_version=$($cmd) || die "Failed to run command to get git release: $cmd"
     fi
   else
-    build_version=${HERON_BUILD_VERSION}
+    # not git managed, use current dir as build version
+    current_dir=$(pwd)
+    build_version=$(basename "$current_dir")
   fi
 else
+  # variable HERON_BUILD_VERSION is available, use it.
   build_version=${HERON_BUILD_VERSION}
 fi
 echo "HERON_BUILD_VERSION ${build_version}"


### PR DESCRIPTION
For this issue: https://github.com/apache/incubator-heron/issues/3243

If someone download source code tar and decompress it. The command below requires a HERON_BUILD_VERSION environment variable to build successfully. The code change adds a fallback to the current directory name when the variable is not set.
