### PR TITLE
Check invalid number of container in round robin packing algorithm

### DIFF
--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
@@ -364,7 +364,9 @@ public class RoundRobinPacking implements IPacking, IRepacking {
       int numContainer, Map<String, Integer> parallelismMap) {
     Map<Integer, List<InstanceId>> allocation = new HashMap<>();
     int totalInstance = TopologyUtils.getTotalInstance(parallelismMap);
-    if (numContainer > totalInstance) {
+    if (numContainer < 1) {
+      throw new RuntimeException(String.format("Invlaid number of container: %d", numContainer));
+    } else if (numContainer > totalInstance) {
       throw new RuntimeException(
           String.format("More containers (%d) allocated than instances (%d).",
               numContainer, totalInstance));

--- a/heron/packing/tests/java/org/apache/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/org/apache/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -545,4 +545,19 @@ public class RoundRobinPackingTest extends CommonPackingTests {
         getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
             numContainers, getDefaultPadding()));
   }
+
+  @Test(expected = RuntimeException.class)
+  public void testZeroContainersFailure() throws Exception {
+    // Explicit set insufficient RAM for container
+    ByteAmount containerRam = ByteAmount.fromGigabytes(10);
+    topologyConfig.setContainerRamRequested(containerRam);
+    topologyConfig.setNumStmgrs(0);
+    topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
+
+    doPackingTest(topology, instanceDefaultResources, boltParallelism,
+        instanceDefaultResources, spoutParallelism,
+        0,  // 0 containers
+        getDefaultUnspecifiedContainerResource(boltParallelism + spoutParallelism,
+            numContainers, getDefaultPadding()).cloneWithRam(containerRam));
+  }
 }


### PR DESCRIPTION
Currently if number of containers is set to an invalid value, we get the following exception which is not ideal.

```

[2019-04-29 15:17:05 -0700] [FINE] org.apache.heron.scheduler.SubmitterMain: Exception when submitting topology 
java.lang.NullPointerException
	at org.apache.heron.packing.roundrobin.RoundRobinPacking.getRoundRobinAllocation(RoundRobinPacking.java:385)
	at org.apache.heron.packing.roundrobin.RoundRobinPacking.packInternal(RoundRobinPacking.java:149)

```

After the change, we would expect "Invlaid number of container: %d" runtime exception.
