### PR TITLE
Heron API/Tracker update for storing Topologies in Array/List instead of Dict object

### DIFF
--- a/heron/tools/tracker/src/python/handlers/stateshandler.py
+++ b/heron/tools/tracker/src/python/handlers/stateshandler.py
@@ -65,7 +65,8 @@ class StatesHandler(BaseHandler):
 
     role = self.get_argument_role()
 
-    ret = {}
+    # ret = {}
+    ret = []
     topologies = self.tracker.topologies
     for topology in topologies:
       cluster = topology.cluster
@@ -85,14 +86,16 @@ class StatesHandler(BaseHandler):
       if environs and environ not in environs:
         continue
 
-      if cluster not in ret:
-        ret[cluster] = {}
-      if environ not in ret[cluster]:
-        ret[cluster][environ] = {}
+      # if cluster not in ret:
+      #   ret[cluster] = {}
+      # if environ not in ret[cluster]:
+      #   ret[cluster][environ] = {}
       try:
         topology_info = self.tracker.getTopologyInfo(topology.name, cluster, role, environ)
         if topology_info and "execution_state" in topology_info:
-          ret[cluster][environ][topology.name] = topology_info["execution_state"]
+
+          ret += [topology_info["execution_state"]]
+          # ret[cluster][environ][topology.name] = topology_info["execution_state"]
       except Exception:
         # Do nothing
         pass

--- a/heron/tools/ui/resources/static/js/alltopologies.js
+++ b/heron/tools/ui/resources/static/js/alltopologies.js
@@ -83,24 +83,20 @@ var TopologyTable = React.createClass({
       data:     { format: 'json' },
       success:  function (result) {
         topologies = [];
-        for (var cluster in result) {
-          for (var env in result[cluster]) {
-            for (var topologyName in result[cluster][env]) {
-              estate = result[cluster][env][topologyName];
-              topologies.push({
-                name: topologyName,
-                cluster: estate.cluster,
-                environ: env,
-                role: estate.role,
-                has_physical_plan: estate.has_physical_plan,
-                has_tmaster_location: estate.has_tmaster_location,
-                release_version: estate.release_version,
-                submission_time: estate.submission_time,
-                submission_user: estate.submission_user,
-                status: estate.status
-              });
-            }
-          }
+        for (var i = 0; i < result.result.length; i++) {
+          var topology = result.result[i];
+          topologies.push({
+            name: topology.jobname,
+            cluster: topology.cluster,
+            environ: topology.environ,
+            role: topology.role,
+            has_physical_plan: topology.has_physical_plan,
+            has_tmaster_location: topology.has_tmaster_location,
+            release_version: topology.release_version,
+            submission_time: topology.submission_time,
+            submission_user: topology.submission_user,
+            status: topology.status
+          });
         }
         this.setState({ topologies: topologies });
       }.bind(this),

--- a/heron/tools/ui/src/python/handlers/api/topology.py
+++ b/heron/tools/ui/src/python/handlers/api/topology.py
@@ -93,25 +93,27 @@ class ListTopologiesJsonHandler(base.BaseHandler):
     # get all the topologies from heron nest
     topologies = yield access.get_topologies_states()
 
-    result = dict()
+    result = []
+    # result = dict()
 
     # now convert some of the fields to be displayable
-    for cluster, cluster_value in topologies.items():
-      result[cluster] = dict()
-      for environ, environ_value in cluster_value.items():
-        result[cluster][environ] = dict()
-        for topology, topology_value in environ_value.items():
-          if "jobname" not in topology_value or topology_value["jobname"] is None:
-            continue
+    for item in topologies:
+      # if item.get('cluster', None) and item['cluster'] not in result:
+      #   result[item['cluster']] = dict()
+      # if item.get('environ', None) and item['environ'] not in result[item['cluster']]:
+      #   result[item['cluster']][item['environ']] = dict()
 
-          if "submission_time" in topology_value:
-            topology_value["submission_time"] = topology_value["submission_time"]
-          else:
-            topology_value["submission_time"] = '-'
+      if not item.get('jobname', None):
+        continue
 
-          result[cluster][environ][topology] = topology_value
+      if not item.get('submission_time', None):
+        item['submission_time'] = '-'
 
-    self.write(result)
+      result += [item]
+      # result[item['cluster']][item['environ']][item['jobname']] = item
+
+    # Tornado doesn't support List object
+    self.write({'result': result})
 
 
 class TopologyLogicalPlanJsonHandler(base.BaseHandler):

--- a/third_party/cppcheck/cppcheck.BUILD
+++ b/third_party/cppcheck/cppcheck.BUILD
@@ -4,7 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 install_script = "\n".join([
     "cd external/com_github_danmar_cppcheck",
-    "make SRCDIR=build CFGDIR=cfg HAVE_RULES=yes CXXFLAGS='-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function'",
+    "make SRCDIR=build CFGDIR=cfg CXXFLAGS='-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function'",
     "rm -rf ../../$(@D)/*",
     "cp -R $$(pwd)/* ../../$(@D)/",
 ])


### PR DESCRIPTION
Old version:
```
{
  (..),
  "result": 
  <cluster>: {
    <environment>: {
      <topology>: {
        (topology_details)
      }
    }
  }
}
```
New version:
```
{
  (..),
  "result": [{
    (topology_details)
  }]
}
```

The cluster, environment, topology variables are actually obtainable from the topology details. This PR is to store these data into array not in dict object so there will be less nested object inside and duplicated cluster/environment/topology can be also displayed on the UI. (Might be useful for multi-cluster with same configurations across all the clusters)

Still need some testing and recommendation. It works perfectly for me, but there are minor 500 errors (unrelated to this change) from the original source code might need to solve as well. 