### PR TITLE
Add release check scripts

### DIFF
--- a/scripts/release_check/README.md
+++ b/scripts/release_check/README.md
@@ -1,0 +1,34 @@
+# Release Check Scripts
+
+These are the convenience scripts for verifying a release.
+
+Currently the scripts work on MacOS.
+
+Development environment setup is required. Setup instrctuction can be found here: https://apache.github.io/incubator-heron/docs/developers/compiling/mac/.
+
+## Run all release checks
+```
+sh ./scripts/release_check/full_release_check.sh
+```
+
+## Run individual release checks
+
+### To run a license check with Apache Rat. Apache Rat can be downloaded here: http://ftp.wayne.edu/apache//creadur/apache-rat-0.12/apache-rat-0.12-bin.tar.gz
+```
+sh ./scripts/release_check/license_check.sh
+```
+
+### To compile source, into Heron release artifacts (MacOS).
+```
+sh ./scripts/release_check/build.sh
+```
+
+### To run a test topology locally (after build.sh is executed).
+```
+sh ./scripts/release_check/run_test_topology.sh
+```
+
+### To compile source into a Heron docker image (host OS: MacOS, target OS: Debian9).
+```
+sh ./scripts/release_check/build_docker.sh
+```

--- a/scripts/release_check/build.sh
+++ b/scripts/release_check/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -o errexit
+
+bazel build --compilation_mode=dbg --config=darwin heron/... --verbose_failures
+bazel build --compilation_mode=dbg --config=darwin scripts/packages:binpkgs --verbose_failures

--- a/scripts/release_check/build_docker.sh
+++ b/scripts/release_check/build_docker.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -o errexit
+
+BUILD_OS=debian9
+VERSION_TAG=test_build
+TEMP_RELEASE_DIR=artifacts
+
+./docker/scripts/build-artifacts.sh $BUILD_OS $VERSION_TAG $TEMP_RELEASE_DIR
+./docker/scripts/build-docker.sh $BUILD_OS $VERSION_TAG $TEMP_RELEASE_DIR

--- a/scripts/release_check/full_release_check.sh
+++ b/scripts/release_check/full_release_check.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -o errexit
+
+echo "Check licenses..."
+sh ./scripts/release_check/license_check.sh
+
+echo "Build artifacts..."
+sh ./scripts/release_check/build.sh
+
+echo "Run a test topology locally..."
+sh ./scripts/release_check/run_test_topology.sh
+
+echo "Build debian9 docker image..."
+sh ./scripts/release_check/build_docker.sh

--- a/scripts/release_check/license_check.sh
+++ b/scripts/release_check/license_check.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -o errexit
+
+# Assuming Apache Rat is downloaded and extracted to:
+#   ~/Downloads/apache-rat-0.12/apache-rat-0.12.jar.
+# Apache Rat can be downloaded fromm this link:
+#   http://ftp.wayne.edu/apache//creadur/apache-rat-0.12/apache-rat-0.12-bin.tar.gz
+RAT_PATH=~/Downloads/apache-rat-0.12/apache-rat-0.12.jar
+
+echo "Looking for Rat jar"
+ls $RAT_PATH
+java -jar $RAT_PATH . -E .rat-excludes

--- a/scripts/release_check/run_test_topology.sh
+++ b/scripts/release_check/run_test_topology.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -o errexit
+
+echo "Install heron CLI to home directory ..."
+./bazel-bin/scripts/packages/heron-install.sh --user
+
+echo "Start an example topologgy ..."
+~/.heron/bin/heron submit local ~/.heron/examples/heron-api-examples.jar org.apache.heron.examples.api.ExclamationTopology ExclamationTopology
+
+echo "Run for 20s and then kill the example topologgy ..."
+sleep 20
+~/.heron/bin/heron kill local ExclamationTopology


### PR DESCRIPTION
For issue #3246 

4 test scripts are added:
- run license check (rat is required)
- build artifacts
- run a test topology locally
- build a docker image
