### PR TITLE
Update to Bazel 0.26.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ addons:
       - libgoogle-perftools-dev
 
 env:
-  - CC=gcc-4.8 CXX=g++-4.8 CPP=cpp-4.8 CXXCPP=cpp-4.8 ENABLE_HEAPCHECK=1
-  - BAZEL_VERSION=0.26.0
+  - BAZEL_VERSION=0.26.0 CC=gcc-4.8 CXX=g++-4.8 CPP=cpp-4.8 CXXCPP=cpp-4.8 ENABLE_HEAPCHECK=1
 
 before_install:
   # download and install bazel

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,13 @@ addons:
 
 env:
   - CC=gcc-4.8 CXX=g++-4.8 CPP=cpp-4.8 CXXCPP=cpp-4.8 ENABLE_HEAPCHECK=1
+  - BAZEL_VERSION=0.25.3
 
 before_install:
   # download and install bazel
-  - wget -q 'https://github.com/bazelbuild/bazel/releases/download/0.23.1/bazel-0.23.1-installer-linux-x86_64.sh'
-  - chmod +x bazel-0.23.1-installer-linux-x86_64.sh
-  - ./bazel-0.23.1-installer-linux-x86_64.sh --user
+  - wget -q "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+  - chmod +x bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
+  - ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --user
 
 before_script:
   # install python module for wheel files

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
 
 env:
   - CC=gcc-4.8 CXX=g++-4.8 CPP=cpp-4.8 CXXCPP=cpp-4.8 ENABLE_HEAPCHECK=1
-  - BAZEL_VERSION=0.25.3
+  - BAZEL_VERSION=0.26.0
 
 before_install:
   # download and install bazel

--- a/docker/compile/Dockerfile.centos7
+++ b/docker/compile/Dockerfile.centos7
@@ -19,7 +19,7 @@ FROM centos:centos7
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM centos
-ENV bazelVersion 0.25.3
+ENV bazelVersion 0.26.0
 
 RUN yum -y upgrade
 RUN yum -y install \

--- a/docker/compile/Dockerfile.centos7
+++ b/docker/compile/Dockerfile.centos7
@@ -19,7 +19,7 @@ FROM centos:centos7
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM centos
-ENV bazelVersion 0.23.2
+ENV bazelVersion 0.25.3
 
 RUN yum -y upgrade
 RUN yum -y install \

--- a/docker/compile/Dockerfile.debian9
+++ b/docker/compile/Dockerfile.debian9
@@ -19,7 +19,7 @@ FROM openjdk:8-jdk-slim
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM debian
-ENV bazelVersion 0.23.2
+ENV bazelVersion 0.25.3
 
 RUN apt-get update && apt-get -y install \
       automake \

--- a/docker/compile/Dockerfile.debian9
+++ b/docker/compile/Dockerfile.debian9
@@ -19,7 +19,7 @@ FROM openjdk:8-jdk-slim
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM debian
-ENV bazelVersion 0.25.3
+ENV bazelVersion 0.26.0
 
 RUN apt-get update && apt-get -y install \
       automake \

--- a/docker/compile/Dockerfile.ubuntu14.04
+++ b/docker/compile/Dockerfile.ubuntu14.04
@@ -19,7 +19,7 @@ FROM ubuntu:14.04
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM ubuntu
-ENV bazelVersion 0.25.3
+ENV bazelVersion 0.26.0
 
 RUN apt-get update && apt-get install -y software-properties-common
 

--- a/docker/compile/Dockerfile.ubuntu14.04
+++ b/docker/compile/Dockerfile.ubuntu14.04
@@ -19,7 +19,7 @@ FROM ubuntu:14.04
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM ubuntu
-ENV bazelVersion 0.23.2
+ENV bazelVersion 0.25.3
 
 RUN apt-get update && apt-get install -y software-properties-common
 

--- a/docker/compile/Dockerfile.ubuntu16.04
+++ b/docker/compile/Dockerfile.ubuntu16.04
@@ -19,7 +19,7 @@ FROM ubuntu:16.04
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM ubuntu
-ENV bazelVersion 0.23.2
+ENV bazelVersion 0.25.3
 
 RUN apt-get update && apt-get -y install \
       automake \

--- a/docker/compile/Dockerfile.ubuntu16.04
+++ b/docker/compile/Dockerfile.ubuntu16.04
@@ -19,7 +19,7 @@ FROM ubuntu:16.04
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM ubuntu
-ENV bazelVersion 0.25.3
+ENV bazelVersion 0.26.0
 
 RUN apt-get update && apt-get -y install \
       automake \

--- a/docker/compile/Dockerfile.ubuntu18.04
+++ b/docker/compile/Dockerfile.ubuntu18.04
@@ -19,7 +19,7 @@ FROM ubuntu:18.04
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM ubuntu
-ENV bazelVersion 0.23.2
+ENV bazelVersion 0.25.3
 
 RUN apt-get update && apt-get -y install \
       g++ \

--- a/docker/compile/Dockerfile.ubuntu18.04
+++ b/docker/compile/Dockerfile.ubuntu18.04
@@ -19,7 +19,7 @@ FROM ubuntu:18.04
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM ubuntu
-ENV bazelVersion 0.25.3
+ENV bazelVersion 0.26.0
 
 RUN apt-get update && apt-get -y install \
       g++ \

--- a/scripts/ci/setup_bazel.sh
+++ b/scripts/ci/setup_bazel.sh
@@ -29,7 +29,7 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 BAZEL_OS=$1
-BAZEL_VERSION=0.23.2
+BAZEL_VERSION=0.25.3
 
 # Install Bazel
 BAZEL_INSTALLER=bazel-$BAZEL_VERSION-installer-$BAZEL_OS-x86_64.sh

--- a/scripts/ci/setup_bazel.sh
+++ b/scripts/ci/setup_bazel.sh
@@ -29,7 +29,7 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 BAZEL_OS=$1
-BAZEL_VERSION=0.25.3
+BAZEL_VERSION=0.26.0
 
 # Install Bazel
 BAZEL_INSTALLER=bazel-$BAZEL_VERSION-installer-$BAZEL_OS-x86_64.sh

--- a/vagrant/init.sh
+++ b/vagrant/init.sh
@@ -55,7 +55,7 @@ install_jdk8() {
     apt-get -y install oracle-java8-installer oracle-java8-set-default vim wget screen git    
 }
 
-bazelVersion=0.23.2
+bazelVersion=0.25.3
 bazel_install() {
     install_jdk8
     apt-get install -y g++ automake cmake gcc-4.8 g++-4.8 zlib1g-dev zip pkg-config wget libssl-dev

--- a/vagrant/init.sh
+++ b/vagrant/init.sh
@@ -55,7 +55,7 @@ install_jdk8() {
     apt-get -y install oracle-java8-installer oracle-java8-set-default vim wget screen git    
 }
 
-bazelVersion=0.25.3
+bazelVersion=0.26.0
 bazel_install() {
     install_jdk8
     apt-get install -y g++ automake cmake gcc-4.8 g++-4.8 zlib1g-dev zip pkg-config wget libssl-dev

--- a/website/config.yaml
+++ b/website/config.yaml
@@ -37,7 +37,7 @@ params:
   description: A realtime, distributed, fault-tolerant stream processing engine from Twitter
   versions:
     heron: 0.17.8
-    bazel: 0.23.2
+    bazel: 0.25.3
     heronpy: 0.17.8
   assets:
     favicon:

--- a/website/config.yaml
+++ b/website/config.yaml
@@ -37,7 +37,7 @@ params:
   description: A realtime, distributed, fault-tolerant stream processing engine from Twitter
   versions:
     heron: 0.17.8
-    bazel: 0.25.3
+    bazel: 0.26.0
     heronpy: 0.17.8
   assets:
     favicon:

--- a/website/content/docs/developers/compiling/docker.md
+++ b/website/content/docs/developers/compiling/docker.md
@@ -171,7 +171,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 Here's an example:
 
 ```dockerfile
-RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.23.2/bazel-0.23.2-installer-linux-x86_64.sh \
+RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.25.3/bazel-0.25.3-installer-linux-x86_64.sh \
          && chmod +x /tmp/bazel.sh \
          && /tmp/bazel.sh
 ```

--- a/website/content/docs/developers/compiling/docker.md
+++ b/website/content/docs/developers/compiling/docker.md
@@ -171,7 +171,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 Here's an example:
 
 ```dockerfile
-RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.25.3/bazel-0.25.3-installer-linux-x86_64.sh \
+RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel-0.25.3-installer-linux-x86_64.sh \
          && chmod +x /tmp/bazel.sh \
          && /tmp/bazel.sh
 ```

--- a/website/content/docs/developers/compiling/linux.md
+++ b/website/content/docs/developers/compiling/linux.md
@@ -44,7 +44,7 @@ $ export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
 #### Step 5 - Install Bazel {{% bazelVersion %}}
 
 ```bash
-wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.23.2/bazel-0.23.2-installer-linux-x86_64.sh
+wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.25.3/bazel-0.25.3-installer-linux-x86_64.sh
 chmod +x /tmp/bazel.sh
 /tmp/bazel.sh --user
 ```
@@ -195,7 +195,7 @@ export PATH=$PATH:/opt/jdk1.8.0_91/bin:/opt/jdk1.8.0_91/jre/bin
 #### Step 5 - Install Bazel {{% bazelVersion %}}
 
 ```bash
-wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.23.2/bazel-0.23.2-installer-linux-x86_64.sh
+wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.25.3/bazel-0.25.3-installer-linux-x86_64.sh
 chmod +x /tmp/bazel.sh
 /tmp/bazel.sh --user
 ```

--- a/website/content/docs/developers/compiling/linux.md
+++ b/website/content/docs/developers/compiling/linux.md
@@ -44,7 +44,7 @@ $ export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
 #### Step 5 - Install Bazel {{% bazelVersion %}}
 
 ```bash
-wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.25.3/bazel-0.25.3-installer-linux-x86_64.sh
+wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel-0.25.3-installer-linux-x86_64.sh
 chmod +x /tmp/bazel.sh
 /tmp/bazel.sh --user
 ```
@@ -195,7 +195,7 @@ export PATH=$PATH:/opt/jdk1.8.0_91/bin:/opt/jdk1.8.0_91/jre/bin
 #### Step 5 - Install Bazel {{% bazelVersion %}}
 
 ```bash
-wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.25.3/bazel-0.25.3-installer-linux-x86_64.sh
+wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel-0.25.3-installer-linux-x86_64.sh
 chmod +x /tmp/bazel.sh
 /tmp/bazel.sh --user
 ```


### PR DESCRIPTION
Bazel `0.26.0` was released recently. I think Heron is already compatible after the changes in #3265. If CI passes, can we update to the most recent version `0.26.0`, instead of #3278?