### PR TITLE
STREAMCOMP-2724: Stream Manager migrated to mainly use smart pointers instead of a manual memory management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
       - zlib1g-dev
       - google-perftools
       - libgoogle-perftools-dev
+      - libtool-bin
 
 env:
   - BAZEL_VERSION=0.26.0 CC=gcc-4.8 CXX=g++-4.8 CPP=cpp-4.8 CXXCPP=cpp-4.8 ENABLE_HEAPCHECK=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ group: edge
 
 sudo: required
 
+dist: trusty
+
 language: java
 
 jdk:
@@ -24,7 +26,6 @@ addons:
       - zlib1g-dev
       - google-perftools
       - libgoogle-perftools-dev
-      - libtool-bin
 
 env:
   - BAZEL_VERSION=0.26.0 CC=gcc-4.8 CXX=g++-4.8 CPP=cpp-4.8 CXXCPP=cpp-4.8 ENABLE_HEAPCHECK=1

--- a/heron/common/src/cpp/config/cluster-config-reader.cpp
+++ b/heron/common/src/cpp/config/cluster-config-reader.cpp
@@ -32,8 +32,8 @@
 namespace heron {
 namespace config {
 
-ClusterConfigReader::ClusterConfigReader(EventLoop* eventLoop, const sp_string& _defaults_file)
-    : YamlFileReader(eventLoop, _defaults_file) {
+ClusterConfigReader::ClusterConfigReader(std::shared_ptr<EventLoop> eventLoop,
+        const sp_string& _defaults_file): YamlFileReader(eventLoop, _defaults_file) {
   LoadConfig();
 }
 

--- a/heron/common/src/cpp/config/cluster-config-reader.h
+++ b/heron/common/src/cpp/config/cluster-config-reader.h
@@ -25,7 +25,7 @@ namespace config {
 
 class ClusterConfigReader : public YamlFileReader {
  public:
-  ClusterConfigReader(EventLoop* eventLoop, const sp_string& _defaults_file);
+  ClusterConfigReader(std::shared_ptr<EventLoop> eventLoop, const sp_string& _defaults_file);
   virtual ~ClusterConfigReader();
 
   // Fill topology config with cluster config

--- a/heron/common/src/cpp/config/heron-internals-config-reader.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.cpp
@@ -34,7 +34,7 @@ namespace config {
 // Global initialization to facilitate singleton design pattern
 HeronInternalsConfigReader* HeronInternalsConfigReader::heron_internals_config_reader_ = 0;
 
-HeronInternalsConfigReader::HeronInternalsConfigReader(EventLoop* eventLoop,
+HeronInternalsConfigReader::HeronInternalsConfigReader(std::shared_ptr<EventLoop> eventLoop,
                                                        const sp_string& _defaults_file,
                                                        const sp_string& _override_file)
     : YamlFileReader(eventLoop, _defaults_file) {
@@ -57,7 +57,7 @@ bool HeronInternalsConfigReader::Exists() {
   return (heron_internals_config_reader_ != NULL);  // Return true/false
 }
 
-void HeronInternalsConfigReader::Create(EventLoop* eventLoop,
+void HeronInternalsConfigReader::Create(std::shared_ptr<EventLoop> eventLoop,
                                         const sp_string& _defaults_file,
                                         const sp_string& _override_file) {
   if (heron_internals_config_reader_) {

--- a/heron/common/src/cpp/config/heron-internals-config-reader.h
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.h
@@ -45,7 +45,7 @@ class HeronInternalsConfigReader : public YamlFileReader {
   static bool Exists();
   // Create a singleton reader from a config file,
   // which will check and reload the config change
-  static void Create(EventLoop* eventLoop,
+  static void Create(std::shared_ptr<EventLoop> eventLoop,
                      const sp_string& _defaults_file, const sp_string& _override_file);
   // Create a singleton reader from a config file,
   // which will not check or reload the config change
@@ -235,7 +235,7 @@ class HeronInternalsConfigReader : public YamlFileReader {
   int GetHeronInstanceAcknowledgementNbuckets();
 
  protected:
-  HeronInternalsConfigReader(EventLoop* eventLoop,
+  HeronInternalsConfigReader(std::shared_ptr<EventLoop> eventLoop,
                              const sp_string& _defaults_file,
                              const sp_string& _override_file);
   virtual ~HeronInternalsConfigReader();

--- a/heron/common/src/cpp/config/metrics-sinks-reader.cpp
+++ b/heron/common/src/cpp/config/metrics-sinks-reader.cpp
@@ -35,8 +35,8 @@
 namespace heron {
 namespace config {
 
-MetricsSinksReader::MetricsSinksReader(EventLoop* eventLoop, const sp_string& _defaults_file)
-    : YamlFileReader(eventLoop, _defaults_file) {
+MetricsSinksReader::MetricsSinksReader(std::shared_ptr<EventLoop> eventLoop,
+        const sp_string& _defaults_file): YamlFileReader(eventLoop, _defaults_file) {
   LoadConfig();
 }
 

--- a/heron/common/src/cpp/config/metrics-sinks-reader.h
+++ b/heron/common/src/cpp/config/metrics-sinks-reader.h
@@ -36,7 +36,7 @@ namespace config {
 
 class MetricsSinksReader : public YamlFileReader {
  public:
-  MetricsSinksReader(EventLoop* eventLoop, const sp_string& _defaults_file);
+  MetricsSinksReader(std::shared_ptr<EventLoop> eventLoop, const sp_string& _defaults_file);
   virtual ~MetricsSinksReader();
 
   // Get the list of metrics whitelisted for tmaster along

--- a/heron/common/src/cpp/config/operational-config-reader.cpp
+++ b/heron/common/src/cpp/config/operational-config-reader.cpp
@@ -32,7 +32,7 @@
 namespace heron {
 namespace config {
 
-OperationalConfigReader::OperationalConfigReader(EventLoop* eventLoop,
+OperationalConfigReader::OperationalConfigReader(std::shared_ptr<EventLoop> eventLoop,
                                                  const sp_string& _defaults_file)
     : YamlFileReader(eventLoop, _defaults_file) {
   LoadConfig();

--- a/heron/common/src/cpp/config/operational-config-reader.h
+++ b/heron/common/src/cpp/config/operational-config-reader.h
@@ -32,7 +32,7 @@ namespace config {
 
 class OperationalConfigReader : public YamlFileReader {
  public:
-  OperationalConfigReader(EventLoop* eventLoop, const sp_string& _defaults_file);
+  OperationalConfigReader(std::shared_ptr<EventLoop> eventLoop, const sp_string& _defaults_file);
   virtual ~OperationalConfigReader();
 
   // Gets release override for this topology name

--- a/heron/common/src/cpp/config/yaml-file-reader.cpp
+++ b/heron/common/src/cpp/config/yaml-file-reader.cpp
@@ -29,7 +29,7 @@
 namespace heron {
 namespace config {
 
-YamlFileReader::YamlFileReader(EventLoop* eventLoop, const sp_string& _config_file)
+YamlFileReader::YamlFileReader(std::shared_ptr<EventLoop> eventLoop, const sp_string& _config_file)
     : config_file_(_config_file), last_reload_(-1) {
   if (eventLoop) {
     // If we have specified the EventLoopImpl,

--- a/heron/common/src/cpp/config/yaml-file-reader.h
+++ b/heron/common/src/cpp/config/yaml-file-reader.h
@@ -38,7 +38,7 @@ namespace config {
 
 class YamlFileReader {
  public:
-  YamlFileReader(EventLoop* eventLoop, const sp_string& _config_file);
+  YamlFileReader(std::shared_ptr<EventLoop> eventLoop, const sp_string& _config_file);
   virtual ~YamlFileReader();
 
  protected:

--- a/heron/common/src/cpp/metrics/metrics-mgr-st.cpp
+++ b/heron/common/src/cpp/metrics/metrics-mgr-st.cpp
@@ -38,7 +38,8 @@ namespace common {
 
 using std::shared_ptr;
 
-MetricsMgrSt::MetricsMgrSt(sp_int32 _metricsmgr_port, sp_int32 _interval, EventLoop* eventLoop) {
+MetricsMgrSt::MetricsMgrSt(sp_int32 _metricsmgr_port, sp_int32 _interval,
+        shared_ptr<EventLoop> eventLoop) {
   options_.set_host("127.0.0.1");
   options_.set_port(_metricsmgr_port);
   options_.set_max_packet_size(1024 * 1024);

--- a/heron/common/src/cpp/metrics/metrics-mgr-st.h
+++ b/heron/common/src/cpp/metrics/metrics-mgr-st.h
@@ -51,7 +51,7 @@ class IMetric;
 
 class MetricsMgrSt {
  public:
-  MetricsMgrSt(sp_int32 _metricsmgr_port, sp_int32 _interval, EventLoop* eventLoop);
+  MetricsMgrSt(sp_int32 _metricsmgr_port, sp_int32 _interval, shared_ptr<EventLoop> eventLoop);
   virtual ~MetricsMgrSt();
 
   void register_metric(const sp_string& _metric_name, shared_ptr<IMetric> _metric);
@@ -78,7 +78,7 @@ class MetricsMgrSt {
   MetricsMgrClient* client_;
   NetworkOptions options_;
   sp_int64 timerid_;
-  EventLoop* eventLoop_;
+  shared_ptr<EventLoop> eventLoop_;
 };
 }  // namespace common
 }  // namespace heron

--- a/heron/common/src/cpp/metrics/metricsmgr-client.h
+++ b/heron/common/src/cpp/metrics/metricsmgr-client.h
@@ -41,7 +41,7 @@ class MetricsMgrClient : public Client {
  public:
   MetricsMgrClient(const sp_string& _hostname, sp_int32 _port, const sp_string& _component_name,
                    const sp_string& _instance_id, int instance_index,
-                   EventLoop* eventLoop, const NetworkOptions& options);
+                   std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options);
   ~MetricsMgrClient();
 
   void SendMetrics(proto::system::MetricPublisherPublishMessage* _message);
@@ -57,7 +57,8 @@ class MetricsMgrClient : public Client {
   void InternalSendMetricsCacheLocation();
   void ReConnect();
   void SendRegisterRequest();
-  void HandleRegisterResponse(void* _ctx, proto::system::MetricPublisherRegisterResponse* _respose,
+  void HandleRegisterResponse(void* _ctx,
+                              unique_ptr<proto::system::MetricPublisherRegisterResponse> _respose,
                               NetworkErrorCode _status);
 
   sp_string hostname_;

--- a/heron/common/src/cpp/metrics/tmaster-metrics.cpp
+++ b/heron/common/src/cpp/metrics/tmaster-metrics.cpp
@@ -35,7 +35,9 @@
 namespace heron {
 namespace common {
 
-TMasterMetrics::TMasterMetrics(const sp_string& sinks_filename, EventLoop* eventLoop) {
+using std::shared_ptr;
+
+TMasterMetrics::TMasterMetrics(const sp_string& sinks_filename, shared_ptr<EventLoop> eventLoop) {
   sinks_reader_ = new config::MetricsSinksReader(eventLoop, sinks_filename);
   std::list<std::pair<sp_string, sp_string> > metrics;
   sinks_reader_->GetTMasterMetrics(metrics);

--- a/heron/common/src/cpp/metrics/tmaster-metrics.h
+++ b/heron/common/src/cpp/metrics/tmaster-metrics.h
@@ -49,7 +49,7 @@ class TMasterMetrics {
     AVG,
     LAST  // We only care about the last value
   };
-  TMasterMetrics(const sp_string& metrics_sinks, EventLoop* eventLoop);
+  TMasterMetrics(const sp_string& metrics_sinks, std::shared_ptr<EventLoop> eventLoop);
   ~TMasterMetrics();
 
   bool IsTMasterMetric(const sp_string& _name);

--- a/heron/common/src/cpp/network/asyncdns.cpp
+++ b/heron/common/src/cpp/network/asyncdns.cpp
@@ -28,7 +28,9 @@
 #include "basics/basics.h"
 
 // Constructor. We create a new event_base.
-AsyncDNS::AsyncDNS(EventLoop* eventLoop) { dns_ = evdns_base_new(eventLoop->dispatcher(), 1); }
+AsyncDNS::AsyncDNS(std::shared_ptr<EventLoop> eventLoop) {
+    dns_ = evdns_base_new(eventLoop->dispatcher(), 1);
+}
 
 // Destructor.
 AsyncDNS::~AsyncDNS() { evdns_base_free(dns_, 1); }

--- a/heron/common/src/cpp/network/asyncdns.h
+++ b/heron/common/src/cpp/network/asyncdns.h
@@ -56,7 +56,7 @@ class AsyncDNS {
   };
 
   // Constructor/Destructor
-  explicit AsyncDNS(EventLoop* eventLoop);
+  explicit AsyncDNS(std::shared_ptr<EventLoop> eventLoop);
   ~AsyncDNS();
 
   // The main interface function.

--- a/heron/common/src/cpp/network/baseclient.cpp
+++ b/heron/common/src/cpp/network/baseclient.cpp
@@ -26,11 +26,11 @@
 #include "glog/logging.h"
 #include "basics/basics.h"
 
-BaseClient::BaseClient(EventLoop* eventLoop, const NetworkOptions& _options) {
+BaseClient::BaseClient(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options) {
   Init(eventLoop, _options);
 }
 
-void BaseClient::Init(EventLoop* eventLoop, const NetworkOptions& _options) {
+void BaseClient::Init(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options) {
   eventLoop_ = eventLoop;
   options_ = _options;
   conn_ = NULL;

--- a/heron/common/src/cpp/network/baseclient.h
+++ b/heron/common/src/cpp/network/baseclient.h
@@ -54,7 +54,7 @@ class BaseClient {
   // Note that constructor doesn't do much beyond initializing some members.
   // Users must explicitly invoke the Start method to be able to send requests
   // and receive responses.
-  BaseClient(EventLoop* eventLoop, const NetworkOptions& options);
+  BaseClient(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options);
   virtual ~BaseClient();
 
   // This starts the connect opereation.
@@ -84,7 +84,7 @@ class BaseClient {
  protected:
   // Instantiate a new connection
   virtual BaseConnection* CreateConnection(ConnectionEndPoint* endpoint, ConnectionOptions* options,
-                                           EventLoop* eventLoop) = 0;
+                                           std::shared_ptr<EventLoop> eventLoop) = 0;
 
   // Derived class should implement this method to handle Connection
   // establishment. a status of OK implies that the Client was
@@ -112,11 +112,11 @@ class BaseClient {
   State state_;
 
   // The underlying EventLoop
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
 
  private:
   // Helper function that inits various objects
-  void Init(EventLoop* eventLoop, const NetworkOptions& _options);
+  void Init(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options);
 
   // Internal method to be called by the Connection class when a
   // connect happens.

--- a/heron/common/src/cpp/network/baseconnection.cpp
+++ b/heron/common/src/cpp/network/baseconnection.cpp
@@ -48,7 +48,7 @@ void eventcb(struct bufferevent *bev, sp_int16 events, void *ctx) {
 }
 
 BaseConnection::BaseConnection(ConnectionEndPoint* endpoint, ConnectionOptions* options,
-                               EventLoop* eventLoop)
+                               std::shared_ptr<EventLoop> eventLoop)
     : mOptions(options), mEndpoint(endpoint), mEventLoop(eventLoop) {
   mState = INIT;
   mOnClose = NULL;

--- a/heron/common/src/cpp/network/baseconnection.h
+++ b/heron/common/src/cpp/network/baseconnection.h
@@ -97,7 +97,8 @@ class BaseConnection {
     TO_BE_DISCONNECTED,
   };
 
-  BaseConnection(ConnectionEndPoint* _endpoint, ConnectionOptions* _options, EventLoop* eventLoop);
+  BaseConnection(ConnectionEndPoint* _endpoint, ConnectionOptions* _options,
+          std::shared_ptr<EventLoop> eventLoop);
   virtual ~BaseConnection();
 
   /**
@@ -212,7 +213,7 @@ class BaseConnection {
   ConnectionEndPoint* mEndpoint;
 
   // The underlying event loop
-  EventLoop* mEventLoop;
+  std::shared_ptr<EventLoop> mEventLoop;
   // The underlying bufferevent
   struct bufferevent* buffer_;
 

--- a/heron/common/src/cpp/network/baseserver.cpp
+++ b/heron/common/src/cpp/network/baseserver.cpp
@@ -31,11 +31,11 @@ void CallHandleConnectionCloseAndDelete(BaseServer* _server, BaseConnection* _co
   delete _connection;
 }
 
-BaseServer::BaseServer(EventLoop* eventLoop, const NetworkOptions& _options) {
+BaseServer::BaseServer(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options) {
   Init(eventLoop, _options);
 }
 
-void BaseServer::Init(EventLoop* eventLoop, const NetworkOptions& _options) {
+void BaseServer::Init(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options) {
   eventLoop_ = eventLoop;
   options_ = _options;
   listen_fd_ = -1;

--- a/heron/common/src/cpp/network/baseserver.h
+++ b/heron/common/src/cpp/network/baseserver.h
@@ -62,7 +62,7 @@ class BaseServer {
   // Constructor
   // The Constructor simply inits the member variable.
   // Users must call Start method to start sending/receiving packets.
-  BaseServer(EventLoop* eventLoop, const NetworkOptions& options);
+  BaseServer(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options);
 
   // Destructor.
   virtual ~BaseServer();
@@ -101,7 +101,7 @@ class BaseServer {
  protected:
   // Instantiate a new Connection
   virtual BaseConnection* CreateConnection(ConnectionEndPoint* endpoint, ConnectionOptions* options,
-                                           EventLoop* eventLoop) = 0;
+                                           std::shared_ptr<EventLoop> eventLoop) = 0;
 
   // Called when a new connection is accepted.
   virtual void HandleNewConnection_Base(BaseConnection* newConnection) = 0;
@@ -111,14 +111,14 @@ class BaseServer {
   virtual void HandleConnectionClose_Base(BaseConnection* connection, NetworkErrorCode _status) = 0;
 
   // The underlying EventLoop
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
 
   // The set of active connections
   std::unordered_set<BaseConnection*> active_connections_;
 
  private:
   // Internal helper function to initialize things
-  void Init(EventLoop* eventLoop, const NetworkOptions& options);
+  void Init(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options);
 
   // Internal method to be called when a write event happens on listen_fd_
   void OnNewConnection(EventLoop::Status status);

--- a/heron/common/src/cpp/network/client.cpp
+++ b/heron/common/src/cpp/network/client.cpp
@@ -24,7 +24,7 @@
 #include <string>
 #include "basics/basics.h"
 
-Client::Client(EventLoop* eventLoop, const NetworkOptions& _options)
+Client::Client(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options)
     : BaseClient(eventLoop, _options) {
   Init();
 }
@@ -69,7 +69,7 @@ sp_int64 Client::AddTimer(VCallback<> cb, sp_int64 _msecs) {
 sp_int32 Client::RemoveTimer(sp_int64 timer_id) { return RemoveTimer_Base(timer_id); }
 
 BaseConnection* Client::CreateConnection(ConnectionEndPoint* _endpoint, ConnectionOptions* _options,
-                                         EventLoop* eventLoop) {
+                                         std::shared_ptr<EventLoop> eventLoop) {
   auto conn = new Connection(_endpoint, _options, eventLoop);
 
   conn->registerForNewPacket([this](IncomingPacket* pkt) { this->OnNewPacket(pkt); });

--- a/heron/common/src/cpp/network/connection.cpp
+++ b/heron/common/src/cpp/network/connection.cpp
@@ -34,7 +34,7 @@
 const sp_uint8 __SYSTEM_MIN_NUM_ENQUEUES_WITH_BUFFER_FULL__ = 3;
 
 Connection::Connection(ConnectionEndPoint* endpoint, ConnectionOptions* options,
-                       EventLoop* eventLoop)
+                       std::shared_ptr<EventLoop> eventLoop)
     : BaseConnection(endpoint, options, eventLoop) {
   mIncomingPacket = new IncomingPacket(mOptions->max_packet_size_);
   mOnNewPacket = NULL;

--- a/heron/common/src/cpp/network/connection.h
+++ b/heron/common/src/cpp/network/connection.h
@@ -72,7 +72,8 @@ class Connection : public BaseConnection {
    * `options` is also created by the caller and the caller owns it. options
    *  should be active throught the lifetime of the Connection object.
    */
-  Connection(ConnectionEndPoint* endpoint, ConnectionOptions* options, EventLoop* eventLoop);
+  Connection(ConnectionEndPoint* endpoint, ConnectionOptions* options,
+          std::shared_ptr<EventLoop> eventLoop);
   virtual ~Connection();
 
   /**

--- a/heron/common/src/cpp/network/httpclient.cpp
+++ b/heron/common/src/cpp/network/httpclient.cpp
@@ -64,7 +64,8 @@ void httpconnectionclose(struct evhttp_connection* _connection, void* _arg) {
   client->HandleConnectionClose(_connection);
 }
 
-HTTPClient::HTTPClient(EventLoop* eventLoop, AsyncDNS* _dns) : eventLoop_(eventLoop), dns_(_dns) {}
+HTTPClient::HTTPClient(std::shared_ptr<EventLoop> eventLoop,
+        AsyncDNS* _dns) : eventLoop_(eventLoop), dns_(_dns) {}
 
 HTTPClient::~HTTPClient() {
   for (auto iter = connections_.begin(); iter != connections_.end(); ++iter) {

--- a/heron/common/src/cpp/network/httpclient.h
+++ b/heron/common/src/cpp/network/httpclient.h
@@ -65,7 +65,7 @@ class IncomingHTTPResponse;
 class HTTPClient {
  public:
   // Constructor
-  HTTPClient(EventLoop* eventLoop, AsyncDNS* _dns);
+  HTTPClient(std::shared_ptr<EventLoop> eventLoop, AsyncDNS* _dns);
 
   // Destructor.
   virtual ~HTTPClient();
@@ -82,7 +82,7 @@ class HTTPClient {
   sp_int32 SendRequest(OutgoingHTTPRequest* _request, VCallback<IncomingHTTPResponse*> _cb);
 
   // get the underlying select server
-  EventLoop* getEventLoop() { return eventLoop_; }
+  std::shared_ptr<EventLoop> getEventLoop() { return eventLoop_; }
 
  private:
   //! A structure used for internal purposes
@@ -117,7 +117,7 @@ class HTTPClient {
   std::unordered_map<void*, VCallback<IncomingHTTPResponse*>> inflight_urls_;
 
   //! the EventLoop and the aysnc dns pointers
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
   AsyncDNS* dns_;
 
   //! friend functions

--- a/heron/common/src/cpp/network/httpserver.cpp
+++ b/heron/common/src/cpp/network/httpserver.cpp
@@ -32,7 +32,7 @@ void HTTPServerRequestCallback(struct evhttp_request* _request, void* _arg) {
   server->HandleHTTPRequest(_request);
 }
 
-HTTPServer::HTTPServer(EventLoop* eventLoop, const NetworkOptions& _options) {
+HTTPServer::HTTPServer(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options) {
   eventLoop_ = eventLoop;
   options_ = _options;
   http_ = evhttp_new(eventLoop->dispatcher());

--- a/heron/common/src/cpp/network/httpserver.h
+++ b/heron/common/src/cpp/network/httpserver.h
@@ -44,7 +44,7 @@ class HTTPServer {
   // Constructor
   // The Constructor simply inits the member variable.
   // Users must call Start method to start sending/receiving packets.
-  HTTPServer(EventLoop* eventLoop, const NetworkOptions& options);
+  HTTPServer(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options);
 
   // Destructor.
   virtual ~HTTPServer();
@@ -64,7 +64,7 @@ class HTTPServer {
                       const sp_string& _reason);
 
   // Accessors
-  EventLoop* getEventLoop() { return eventLoop_; }
+  std::shared_ptr<EventLoop> getEventLoop() { return eventLoop_; }
 
  private:
   void HandleHTTPRequest(struct evhttp_request* _request);
@@ -76,7 +76,7 @@ class HTTPServer {
   std::unordered_map<sp_string, VCallback<IncomingHTTPRequest*>> cbs_;
   VCallback<IncomingHTTPRequest*> generic_cb_;
   NetworkOptions options_;
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
 
   // friend declarations
   friend void HTTPServerRequestCallback(struct evhttp_request*, void*);

--- a/heron/common/src/cpp/network/misc/echoclient.cpp
+++ b/heron/common/src/cpp/network/misc/echoclient.cpp
@@ -81,7 +81,7 @@ void EchoClient::HandleClose(NetworkErrorCode)
   getEventLoop()->loopExit();
 }
 
-void EchoClient::HandleEchoResponse(void*, EchoServerResponse* _response,
+void EchoClient::HandleEchoResponse(void*, std::unique_ptr<EchoServerResponse> _response,
                                     NetworkErrorCode _status)
 {
   if (_status != OK) {
@@ -95,6 +95,6 @@ void EchoClient::HandleEchoResponse(void*, EchoServerResponse* _response,
       }
     }
   }
-  delete _response;
+
   CreateAndSendRequest();
 }

--- a/heron/common/src/cpp/network/misc/echoclient.h
+++ b/heron/common/src/cpp/network/misc/echoclient.h
@@ -38,7 +38,7 @@ class EchoClient : public Client
   virtual void HandleClose(NetworkErrorCode status);
 
  private:
-  void HandleEchoResponse(void*, EchoServerResponse* response,
+  void HandleEchoResponse(void*, std::unique_ptr<EchoServerResponse> response,
                           NetworkErrorCode status);
   void CreateAndSendRequest();
   sp_int32 nrequests_;

--- a/heron/common/src/cpp/network/piper.cpp
+++ b/heron/common/src/cpp/network/piper.cpp
@@ -28,7 +28,7 @@
 void RunUserCb(VCallback<> cb) { cb(); }
 
 // Constructor. We create a new event_base
-Piper::Piper(EventLoop* eventLoop)
+Piper::Piper(std::shared_ptr<EventLoop> eventLoop)
     : eventLoop_(eventLoop) {
   cbs_ = new PCQueue<CallBack*>();
   auto wakeup_cb = [this](EventLoop::Status status) {

--- a/heron/common/src/cpp/network/piper.h
+++ b/heron/common/src/cpp/network/piper.h
@@ -39,7 +39,7 @@
 class Piper {
  public:
   // Constructor/Destructor
-  explicit Piper(EventLoop* eventLoop);
+  explicit Piper(std::shared_ptr<EventLoop> eventLoop);
 
   virtual ~Piper();
 
@@ -55,7 +55,7 @@ class Piper {
   // to be called when awoken
   void OnWakeUp(EventLoop::Status status);
 
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
 
   // These pipers are how they communicate it across to our thread
   sp_int32 pipers_[2];

--- a/heron/common/src/cpp/network/server.cpp
+++ b/heron/common/src/cpp/network/server.cpp
@@ -26,7 +26,7 @@
 #include <utility>
 #include "basics/basics.h"
 
-Server::Server(EventLoop* eventLoop, const NetworkOptions& _options)
+Server::Server(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options)
     : BaseServer(eventLoop, _options) {
   request_rid_gen_ = new REQID_Generator();
 }
@@ -94,7 +94,7 @@ void Server::SendRequest(Connection* _conn, google::protobuf::Message* _request,
 
 // The interfaces of BaseServer being implemented
 BaseConnection* Server::CreateConnection(ConnectionEndPoint* _endpoint, ConnectionOptions* _options,
-                                         EventLoop* eventLoop) {
+                                         std::shared_ptr<EventLoop> eventLoop) {
   // Create the connection object and register our callbacks on various events.
   auto conn = new Connection(_endpoint, _options, eventLoop);
   auto npcb = [conn, this](IncomingPacket* packet) { this->OnNewPacket(conn, packet); };

--- a/heron/common/src/cpp/setup/zk-setup.cpp
+++ b/heron/common/src/cpp/setup/zk-setup.cpp
@@ -111,10 +111,10 @@ int main(int argc, char* argv[]) {
     zkroot = std::string(zkroot, 0, zkroot.size() - 1);
   }
 
-  EventLoopImpl ss;
-  zkclient = new ZKClient(zkhostport, &ss);
+  auto ss = std::make_shared<EventLoopImpl>();
+  zkclient = new ZKClient(zkhostport, ss);
 
   zkclient->CreateNode(zkroot, "Heron Cluster " + clustername, false,
                        [](sp_int32 status) { ZkRootDone(status); });
-  ss.loop();
+  ss->loop();
 }

--- a/heron/common/src/cpp/zookeeper/zkclient.cpp
+++ b/heron/common/src/cpp/zookeeper/zkclient.cpp
@@ -124,12 +124,12 @@ void ExistsCompletionHandler(sp_int32 _rc, const struct Stat*, const void* _data
 }
 
 // Constructor. We create a new event_base.
-ZKClient::ZKClient(const std::string& hostportlist, EventLoop* eventLoop)
+ZKClient::ZKClient(const std::string& hostportlist, std::shared_ptr<EventLoop> eventLoop)
     : eventLoop_(eventLoop), hostportlist_(hostportlist) {
   Init();
 }
 
-ZKClient::ZKClient(const std::string& hostportlist, EventLoop* eventLoop,
+ZKClient::ZKClient(const std::string& hostportlist, std::shared_ptr<EventLoop> eventLoop,
                    VCallback<ZkWatchEvent> global_watcher_cb)
     : eventLoop_(eventLoop),
       hostportlist_(hostportlist),

--- a/heron/common/src/cpp/zookeeper/zkclient.h
+++ b/heron/common/src/cpp/zookeeper/zkclient.h
@@ -49,12 +49,12 @@ class ZKClient {
   };
 
   // Constructor/Destructor
-  ZKClient(const std::string& hostportlist, EventLoop* eventLoop);
+  ZKClient(const std::string& hostportlist, std::shared_ptr<EventLoop> eventLoop);
 
   // If a global_watcher is provided, the clients can watch on session events.
   // Right now only SessionExpired event is notified, but could have others
   // in the future. global_watcher_cb should be a PermanentCallback.
-  ZKClient(const std::string& hostportlist, EventLoop* eventLoop,
+  ZKClient(const std::string& hostportlist, std::shared_ptr<EventLoop> eventLoop,
            VCallback<ZkWatchEvent> global_watcher_cb);
 
   virtual ~ZKClient();
@@ -147,7 +147,7 @@ class ZKClient {
 
   clientid_t zk_clientid_;
   zhandle_t* zk_handle_;
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
   std::string hostportlist_;
 
   // We use libzookeeper_mt as our zk library. This means that

--- a/heron/common/src/cpp/zookeeper/zkclient_factory.h
+++ b/heron/common/src/cpp/zookeeper/zkclient_factory.h
@@ -27,7 +27,7 @@
 
 class ZKClientFactory {
  public:
-  virtual ZKClient* create(const std::string& hostportlist, EventLoop* eventLoop,
+  virtual ZKClient* create(const std::string& hostportlist, std::shared_ptr<EventLoop> eventLoop,
                            VCallback<ZKClient::ZkWatchEvent> global_watcher_cb) = 0;
 
   virtual ~ZKClientFactory() {}
@@ -35,7 +35,7 @@ class ZKClientFactory {
 
 class DefaultZKClientFactory : public ZKClientFactory {
  public:
-  virtual ZKClient* create(const std::string& hostportlist, EventLoop* eventLoop,
+  virtual ZKClient* create(const std::string& hostportlist, std::shared_ptr<EventLoop> eventLoop,
                            VCallback<ZKClient::ZkWatchEvent> global_watcher_cb) {
     if (global_watcher_cb == NULL) {
       return new ZKClient(hostportlist, eventLoop);

--- a/heron/common/tests/cpp/network/client_unittest.cpp
+++ b/heron/common/tests/cpp/network/client_unittest.cpp
@@ -28,8 +28,8 @@
 #include "errors/errors.h"
 #include "threads/threads.h"
 
-TestClient::TestClient(EventLoopImpl* eventLoop, const NetworkOptions& _options, sp_uint64 _ntotal)
-    : Client(eventLoop, _options), ntotal_(_ntotal) {
+TestClient::TestClient(std::shared_ptr<EventLoopImpl> eventLoop, const NetworkOptions& _options,
+        sp_uint64 _ntotal): Client(eventLoop, _options), ntotal_(_ntotal) {
   InstallMessageHandler(&TestClient::HandleTestMessage);
   start_time_ = time(NULL);
   nsent_ = nrecv_ = 0;
@@ -62,9 +62,8 @@ void TestClient::HandleConnect(NetworkErrorCode _status) {
 
 void TestClient::HandleClose(NetworkErrorCode) {}
 
-void TestClient::HandleTestMessage(TestMessage* _message) {
+void TestClient::HandleTestMessage(unique_ptr<TestMessage> _message) {
   ++nrecv_;
-  delete _message;
 
   if (nrecv_ >= ntotal_) {
     Stop();

--- a/heron/common/tests/cpp/network/client_unittest.h
+++ b/heron/common/tests/cpp/network/client_unittest.h
@@ -28,7 +28,8 @@
 
 class TestClient : public Client {
  public:
-  TestClient(EventLoopImpl* eventLoop, const NetworkOptions& _options, sp_uint64 _ntotal);
+  TestClient(std::shared_ptr<EventLoopImpl> eventLoop, const NetworkOptions& _options,
+          sp_uint64 _ntotal);
 
   ~TestClient();
 
@@ -43,7 +44,7 @@ class TestClient : public Client {
 
  private:
   // Handle incoming message
-  void HandleTestMessage(TestMessage* _message);
+  void HandleTestMessage(unique_ptr<TestMessage> _message);
 
   void SendMessages();
   void CreateAndSendMessage();

--- a/heron/common/tests/cpp/network/http_client_unittest.cpp
+++ b/heron/common/tests/cpp/network/http_client_unittest.cpp
@@ -73,9 +73,9 @@ void start_http_client(sp_uint32 _port, sp_uint64 _requests, sp_uint32 _nkeys) {
   ntotal = _requests;
   nkeys = _nkeys;
 
-  EventLoopImpl ss;
-  AsyncDNS dns(&ss);
-  HTTPClient client(&ss, &dns);
+  auto ss = std::make_shared<EventLoopImpl>();
+  AsyncDNS dns(ss);
+  HTTPClient client(ss, &dns);
   SendRequest(&client);
-  ss.loop();
+  ss->loop();
 }

--- a/heron/common/tests/cpp/network/http_server_unittest.cpp
+++ b/heron/common/tests/cpp/network/http_server_unittest.cpp
@@ -27,7 +27,7 @@
 
 static sp_uint32 nkeys = 0;
 
-TestHttpServer::TestHttpServer(EventLoopImpl* eventLoop, NetworkOptions& _options) {
+TestHttpServer::TestHttpServer(std::shared_ptr<EventLoopImpl> eventLoop, NetworkOptions& _options) {
   server_ = new HTTPServer(eventLoop, _options);
   server_->InstallCallBack(
       "/meta", [this](IncomingHTTPRequest* request) { this->HandleMetaRequest(request); });
@@ -88,7 +88,7 @@ void TestHttpServer::HandleTerminateRequest(IncomingHTTPRequest* _request) {
 void start_http_server(sp_uint32 _port, sp_uint32 _nkeys, int fd) {
   nkeys = _nkeys;
 
-  EventLoopImpl ss;
+  auto ss = std::make_shared<EventLoopImpl>();
 
   // set host, port and packet size
   NetworkOptions options;
@@ -97,11 +97,11 @@ void start_http_server(sp_uint32 _port, sp_uint32 _nkeys, int fd) {
   options.set_max_packet_size(BUFSIZ << 4);
 
   // start the server
-  TestHttpServer http_server(&ss, options);
+  TestHttpServer http_server(ss, options);
 
   // use pipe to block clients before server enters event loop
   int sent;
   write(fd, &sent, sizeof(int));
 
-  ss.loop();
+  ss->loop();
 }

--- a/heron/common/tests/cpp/network/http_server_unittest.h
+++ b/heron/common/tests/cpp/network/http_server_unittest.h
@@ -27,7 +27,7 @@
 class TestHttpServer {
  public:
   // Constructor
-  TestHttpServer(EventLoopImpl* ss, NetworkOptions& options);
+  TestHttpServer(std::shared_ptr<EventLoopImpl> ss, NetworkOptions& options);
 
   // Destructor
   ~TestHttpServer();

--- a/heron/common/tests/cpp/network/http_unittest.cpp
+++ b/heron/common/tests/cpp/network/http_unittest.cpp
@@ -47,9 +47,9 @@ void TerminateRequestDone(HTTPClient* client, IncomingHTTPResponse* response) {
 }
 
 void TerminateServer(sp_uint32 port) {
-  EventLoopImpl ss;
-  AsyncDNS dns(&ss);
-  HTTPClient client(&ss, &dns);
+  auto ss = std::make_shared<EventLoopImpl>();
+  AsyncDNS dns(ss);
+  HTTPClient client(ss, &dns);
 
   HTTPKeyValuePairs kvs;
 
@@ -63,7 +63,7 @@ void TerminateServer(sp_uint32 port) {
     GTEST_FAIL();
   }
 
-  ss.loop();
+  ss->loop();
 }
 
 void StartTest(sp_uint32 nclients, sp_uint64 requests, sp_uint32 nkeys) {

--- a/heron/common/tests/cpp/network/oclient_unittest.cpp
+++ b/heron/common/tests/cpp/network/oclient_unittest.cpp
@@ -29,7 +29,7 @@
 #include "threads/threads.h"
 #include "network/network.h"
 
-OrderClient::OrderClient(EventLoopImpl* eventLoop, const NetworkOptions& _options,
+OrderClient::OrderClient(std::shared_ptr<EventLoopImpl> eventLoop, const NetworkOptions& _options,
                          sp_uint64 _ntotal)
     : Client(eventLoop, _options), ntotal_(_ntotal) {
   InstallMessageHandler(&OrderClient::HandleOrderMessage);
@@ -60,12 +60,10 @@ void OrderClient::HandleConnect(NetworkErrorCode _status) {
 
 void OrderClient::HandleClose(NetworkErrorCode) {}
 
-void OrderClient::HandleOrderMessage(OrderMessage* _message) {
+void OrderClient::HandleOrderMessage(unique_ptr<OrderMessage> _message) {
   ++nrecv_;
 
   EXPECT_EQ(msgidr_++, _message->id());
-
-  delete _message;
 
   if (nrecv_ >= ntotal_) {
     Stop();

--- a/heron/common/tests/cpp/network/oclient_unittest.h
+++ b/heron/common/tests/cpp/network/oclient_unittest.h
@@ -27,7 +27,8 @@
 
 class OrderClient : public Client {
  public:
-  OrderClient(EventLoopImpl* eventLoop, const NetworkOptions& _options, sp_uint64 _ntotal);
+  OrderClient(std::shared_ptr<EventLoopImpl> eventLoop, const NetworkOptions& _options,
+          sp_uint64 _ntotal);
 
   ~OrderClient() {}
 
@@ -42,7 +43,7 @@ class OrderClient : public Client {
 
  private:
   // Handle incoming message
-  void HandleOrderMessage(OrderMessage* _message);
+  void HandleOrderMessage(unique_ptr<OrderMessage> _message);
 
   void SendMessages();
   void CreateAndSendMessage();

--- a/heron/common/tests/cpp/network/oserver_unittest.cpp
+++ b/heron/common/tests/cpp/network/oserver_unittest.cpp
@@ -28,7 +28,7 @@
 #include "threads/threads.h"
 #include "network/network.h"
 
-OrderServer::OrderServer(EventLoopImpl* eventLoop, const NetworkOptions& _options)
+OrderServer::OrderServer(std::shared_ptr<EventLoopImpl> eventLoop, const NetworkOptions& _options)
     : Server(eventLoop, _options) {
   InstallMessageHandler(&OrderServer::HandleOrderMessage);
   InstallMessageHandler(&OrderServer::HandleTerminateMessage);
@@ -56,7 +56,7 @@ void OrderServer::HandleConnectionClose(Connection* _conn,
   delete ids;
 }
 
-void OrderServer::HandleOrderMessage(Connection* _conn, OrderMessage* _message) {
+void OrderServer::HandleOrderMessage(Connection* _conn, unique_ptr<OrderMessage> _message) {
   if (clients_.find(_conn) == clients_.end()) return;
 
   nrecv_++;
@@ -77,6 +77,6 @@ void OrderServer::Terminate() {
 }
 
 void OrderServer::HandleTerminateMessage(Connection* _connection __attribute__((unused)),
-                                         TerminateMessage* _message __attribute__((unused))) {
+                                   unique_ptr<TerminateMessage> _message __attribute__((unused))) {
   AddTimer([this]() { std::cout << "OrderServer:Terminate"; this->Terminate(); }, 1);
 }

--- a/heron/common/tests/cpp/network/oserver_unittest.h
+++ b/heron/common/tests/cpp/network/oserver_unittest.h
@@ -28,7 +28,7 @@
 
 class OrderServer : public Server {
  public:
-  OrderServer(EventLoopImpl* ss, const NetworkOptions& options);
+  OrderServer(std::shared_ptr<EventLoopImpl> ss, const NetworkOptions& options);
 
   ~OrderServer();
 
@@ -46,10 +46,10 @@ class OrderServer : public Server {
   virtual void HandleConnectionClose(Connection* connection, NetworkErrorCode status);
 
   // handle the test message
-  virtual void HandleOrderMessage(Connection* connection, OrderMessage* message);
+  virtual void HandleOrderMessage(Connection* connection, unique_ptr<OrderMessage> message);
 
   // handle the terminate message
-  virtual void HandleTerminateMessage(Connection* connection, TerminateMessage* message);
+  virtual void HandleTerminateMessage(Connection* connection, unique_ptr<TerminateMessage> message);
 
  private:
   void Terminate();

--- a/heron/common/tests/cpp/network/piper_unittest.cpp
+++ b/heron/common/tests/cpp/network/piper_unittest.cpp
@@ -32,13 +32,13 @@ struct Resource {
   sp_int32 count;
 };
 
-void RunningEventLoop(EventLoopImpl* ss) {
+void RunningEventLoop(std::shared_ptr<EventLoopImpl> ss) {
   ss->registerTimer([](EventLoop::Status status) { /* do nothing */ }, true, 1 * 1000 * 1000);
   ss->loop();
 }
 
 TEST(PiperTest, test_piper) {
-  EventLoopImpl* eventLoop = new EventLoopImpl();
+  auto eventLoop = std::make_shared<EventLoopImpl>();
   std::thread* thread = new std::thread(RunningEventLoop, eventLoop);
 
   Piper* piper = new Piper(eventLoop);
@@ -62,7 +62,6 @@ TEST(PiperTest, test_piper) {
 
   delete piper;
   delete resource;
-  delete eventLoop;
   delete thread;
 }
 

--- a/heron/common/tests/cpp/network/server_unittest.cpp
+++ b/heron/common/tests/cpp/network/server_unittest.cpp
@@ -27,7 +27,7 @@
 #include "threads/threads.h"
 #include "network/network.h"
 
-TestServer::TestServer(EventLoopImpl* eventLoop, const NetworkOptions& _options)
+TestServer::TestServer(std::shared_ptr<EventLoopImpl> eventLoop, const NetworkOptions& _options)
     : Server(eventLoop, _options) {
   InstallMessageHandler(&TestServer::HandleTestMessage);
   InstallMessageHandler(&TestServer::HandleTerminateMessage);
@@ -55,7 +55,7 @@ void TestServer::HandleConnectionClose(Connection* _conn,
 }
 
 void TestServer::HandleTestMessage(Connection* _connection __attribute__((unused)),
-                                   TestMessage* _message) {
+                                   unique_ptr<TestMessage> _message) {
   nrecv_++;
 
   // find a random client to send the message to
@@ -73,6 +73,6 @@ void TestServer::Terminate() {
 }
 
 void TestServer::HandleTerminateMessage(Connection* _connection __attribute__((unused)),
-                                        TerminateMessage* _message __attribute__((unused))) {
+                                    unique_ptr<TerminateMessage> _message __attribute__((unused))) {
   AddTimer([this]() { this->Terminate(); }, 1);
 }

--- a/heron/common/tests/cpp/network/server_unittest.h
+++ b/heron/common/tests/cpp/network/server_unittest.h
@@ -29,7 +29,7 @@
 
 class TestServer : public Server {
  public:
-  TestServer(EventLoopImpl* ss, const NetworkOptions& options);
+  TestServer(std::shared_ptr<EventLoopImpl> ss, const NetworkOptions& options);
 
   ~TestServer();
 
@@ -47,10 +47,10 @@ class TestServer : public Server {
   virtual void HandleConnectionClose(Connection* connection, NetworkErrorCode status);
 
   // handle the test message
-  virtual void HandleTestMessage(Connection* connection, TestMessage* message);
+  virtual void HandleTestMessage(Connection* connection, unique_ptr<TestMessage> message);
 
   // handle the terminate message
-  virtual void HandleTerminateMessage(Connection* connection, TerminateMessage* message);
+  virtual void HandleTerminateMessage(Connection* connection, unique_ptr<TerminateMessage> message);
 
  private:
   void Terminate();

--- a/heron/common/tests/cpp/network/switch_unittest.cpp
+++ b/heron/common/tests/cpp/network/switch_unittest.cpp
@@ -38,7 +38,7 @@
 
 class Terminate : public Client {
  public:
-  Terminate(EventLoopImpl* eventLoop, const NetworkOptions& _options)
+  Terminate(std::shared_ptr<EventLoopImpl> eventLoop, const NetworkOptions& _options)
       : Client(eventLoop, _options) {
     // Setup the call back function to be invoked when retrying
     retry_cb_ = [this]() { this->Retry(); };
@@ -77,13 +77,13 @@ void start_server(sp_uint32* port, CountDownLatch* latch) {
   options.set_max_packet_size(1024 * 1024);
   options.set_socket_family(PF_INET);
 
-  EventLoopImpl ss;
-  server_ = new TestServer(&ss, options);
+  auto ss = std::make_shared<EventLoopImpl>();
+  server_ = new TestServer(ss, options);
   EXPECT_EQ(0, server_->get_serveroptions().get_port());
   if (server_->Start() != 0) GTEST_FAIL();
   *port = server_->get_serveroptions().get_port();
   latch->countDown();
-  ss.loop();
+  ss->loop();
 }
 
 void start_client(sp_uint32 port, sp_uint64 requests) {
@@ -93,10 +93,10 @@ void start_client(sp_uint32 port, sp_uint64 requests) {
   options.set_max_packet_size(1024 * 1024);
   options.set_socket_family(PF_INET);
 
-  EventLoopImpl ss;
-  TestClient client(&ss, options, requests);
+  auto ss = std::make_shared<EventLoopImpl>();
+  TestClient client(ss, options, requests);
   client.Start();
-  ss.loop();
+  ss->loop();
 }
 
 void terminate_server(sp_uint32 port) {
@@ -106,10 +106,10 @@ void terminate_server(sp_uint32 port) {
   options.set_max_packet_size(1024 * 1024);
   options.set_socket_family(PF_INET);
 
-  EventLoopImpl ss;
-  Terminate ts(&ss, options);
+  auto ss = std::make_shared<EventLoopImpl>();
+  Terminate ts(ss, options);
   ts.Start();
-  ss.loop();
+  ss->loop();
 }
 
 void start_test(sp_int32 nclients, sp_uint64 requests) {

--- a/heron/common/tests/cpp/zookeeper/simpletest.cpp
+++ b/heron/common/tests/cpp/zookeeper/simpletest.cpp
@@ -28,7 +28,7 @@ std::string topdir = "/";
 std::string testtopdir = "/";
 sp_uint32 nchildren = 10;
 sp_uint32 children_notifications = 0;
-EventLoopImpl* ss;
+std::shared_ptr<EventLoopImpl> ss;
 ZKClient* zk_client = NULL;
 
 void DeleteDone(sp_int32 _rc) {
@@ -187,13 +187,12 @@ int main(int argc, char* argv[]) {
   }
   testtopdir = topdir + "/simplezktest";
 
-  ss = new EventLoopImpl();
+  ss = std::make_shared<EventLoopImpl>();
   zk_client = new ZKClient(argv[1], ss);
   zk_client->CreateNode(testtopdir, "Created as part of the unittests", false,
                         [](sp_uint32 rc) { TopDirCreateDone(rc); });
   ss->loop();
   delete zk_client;
-  delete ss;
 
   /*************** Test Session expiry with NO client global watch. *********/
   // ss = new EventLoopImpl();

--- a/heron/instance/src/cpp/boltimpl/bolt-instance.h
+++ b/heron/instance/src/cpp/boltimpl/bolt-instance.h
@@ -40,8 +40,8 @@ namespace instance {
 
 class BoltInstance : public InstanceBase {
  public:
-  BoltInstance(EventLoop* eventLoop, std::shared_ptr<TaskContextImpl> taskContext,
-               NotifyingCommunicator<google::protobuf::Message*>* dataToSlave,
+  BoltInstance(std::shared_ptr<EventLoop> eventLoop, std::shared_ptr<TaskContextImpl> taskContext,
+               NotifyingCommunicator<unique_ptr<google::protobuf::Message>>* dataToSlave,
                NotifyingCommunicator<google::protobuf::Message*>* dataFromSlave,
                void* dllHandle);
   virtual ~BoltInstance();
@@ -52,7 +52,7 @@ class BoltInstance : public InstanceBase {
   virtual void Deactivate();
   virtual bool IsRunning() { return active_; }
   virtual void DoWork();
-  virtual void HandleGatewayTuples(proto::system::HeronTupleSet2* tupleSet);
+  virtual void HandleGatewayTuples(unique_ptr<proto::system::HeronTupleSet2> tupleSet);
 
  private:
   void executeTuple(const proto::api::StreamId& stream,
@@ -62,9 +62,9 @@ class BoltInstance : public InstanceBase {
                     const proto::system::HeronDataTuple& tup);
 
   std::shared_ptr<TaskContextImpl> taskContext_;
-  NotifyingCommunicator<google::protobuf::Message*>* dataToSlave_;
+  NotifyingCommunicator<unique_ptr<google::protobuf::Message>>* dataToSlave_;
   NotifyingCommunicator<google::protobuf::Message*>* dataFromSlave_;
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
   api::bolt::IBolt* bolt_;
   std::shared_ptr<api::serializer::IPluggableSerializer> serializer_;
   std::shared_ptr<BoltOutputCollectorImpl> collector_;

--- a/heron/instance/src/cpp/gateway/gateway-metrics.cpp
+++ b/heron/instance/src/cpp/gateway/gateway-metrics.cpp
@@ -31,7 +31,7 @@ namespace heron {
 namespace instance {
 
 GatewayMetrics::GatewayMetrics(std::shared_ptr<common::MetricsMgrClient> metricsMgrClient,
-                               EventLoop* eventLoop)
+                               std::shared_ptr<EventLoop> eventLoop)
   : metricsMgrClient_(metricsMgrClient) {
   receivedPacketsCount_.reset(new api::metric::CountMetric());
   receivedPacketsSize_.reset(new api::metric::CountMetric());

--- a/heron/instance/src/cpp/gateway/gateway-metrics.h
+++ b/heron/instance/src/cpp/gateway/gateway-metrics.h
@@ -36,7 +36,7 @@ namespace instance {
 class GatewayMetrics {
  public:
   GatewayMetrics(std::shared_ptr<common::MetricsMgrClient> metricsMgrClient,
-                 EventLoop* eventLoop);
+                 std::shared_ptr<EventLoop> eventLoop);
   virtual ~GatewayMetrics();
 
   void updateReceivedPacketsCount(int64_t count) {

--- a/heron/instance/src/cpp/gateway/gateway.cpp
+++ b/heron/instance/src/cpp/gateway/gateway.cpp
@@ -37,7 +37,7 @@ Gateway::Gateway(const std::string& topologyName,
                  const std::string& topologyId, const std::string& instanceId,
                  const std::string& componentName, int taskId, int componentIndex,
                  const std::string& stmgrId, int stmgrPort, int metricsMgrPort,
-                 EventLoop* eventLoop)
+                 std::shared_ptr<EventLoop> eventLoop)
   : topologyName_(topologyName), topologyId_(topologyId), stmgrPort_(stmgrPort),
     metricsMgrPort_(metricsMgrPort), dataToSlave_(NULL), dataFromSlave_(NULL),
     metricsFromSlave_(NULL), eventLoop_(eventLoop),
@@ -91,7 +91,7 @@ void Gateway::Start() {
   eventLoop_->loop();
 }
 
-void Gateway::HandleNewPhysicalPlan(proto::system::PhysicalPlan* pplan) {
+void Gateway::HandleNewPhysicalPlan(unique_ptr<proto::system::PhysicalPlan> pplan) {
   LOG(INFO) << "Received a new physical plan from Stmgr";
   if (config::TopologyConfigHelper::IsComponentSpout(pplan->topology(),
                                                      instanceProto_.info().component_name())) {
@@ -105,11 +105,12 @@ void Gateway::HandleNewPhysicalPlan(proto::system::PhysicalPlan* pplan) {
     maxWriteBufferSize_ = config::HeronInternalsConfigReader::Instance()
                                 ->GetHeronInstanceInternalBoltWriteQueueCapacity();
   }
-  dataToSlave_->enqueue(pplan);
+
+  dataToSlave_->enqueue(std::move(pplan));
 }
 
-void Gateway::HandleStMgrTuples(proto::system::HeronTupleSet2* msg) {
-  dataToSlave_->enqueue(msg);
+void Gateway::HandleStMgrTuples(unique_ptr<proto::system::HeronTupleSet2> msg) {
+  dataToSlave_->enqueue(std::move(msg));
   if (dataToSlave_->size() > maxReadBufferSize_) {
     stmgrClient_->putBackPressure();
   }

--- a/heron/instance/src/cpp/gateway/gateway.h
+++ b/heron/instance/src/cpp/gateway/gateway.h
@@ -40,7 +40,7 @@ class Gateway {
         const std::string& topologyId, const std::string& instanceId,
         const std::string& componentName, int taskId, int componentIndex,
         const std::string& stmgrId, int stmgrPort, int metricsMgrPort,
-        EventLoop* eventLoop);
+        std::shared_ptr<EventLoop> eventLoop);
   virtual ~Gateway();
 
   // All kinds of initialization like starting clients
@@ -55,8 +55,8 @@ class Gateway {
   // Called when we need to consume metrics from slave
   void HandleSlaveMetrics(google::protobuf::Message* msg);
 
-  EventLoop* eventLoop() { return eventLoop_; }
-  void setCommunicators(NotifyingCommunicator<google::protobuf::Message*>* dataToSlave,
+  std::shared_ptr<EventLoop> eventLoop() { return eventLoop_; }
+  void setCommunicators(NotifyingCommunicator<unique_ptr<google::protobuf::Message>>* dataToSlave,
                         NotifyingCommunicator<google::protobuf::Message*>* dataFromSlave,
                         NotifyingCommunicator<google::protobuf::Message*>* metricsFromSlave) {
     dataToSlave_ = dataToSlave;
@@ -65,8 +65,8 @@ class Gateway {
   }
 
  private:
-  void HandleNewPhysicalPlan(proto::system::PhysicalPlan* pplan);
-  void HandleStMgrTuples(proto::system::HeronTupleSet2* tuples);
+  void HandleNewPhysicalPlan(unique_ptr<proto::system::PhysicalPlan> pplan);
+  void HandleStMgrTuples(unique_ptr<proto::system::HeronTupleSet2> tuples);
   void ResumeConsumingFromSlaveTimer();
   std::string topologyName_;
   std::string topologyId_;
@@ -76,10 +76,10 @@ class Gateway {
   std::shared_ptr<StMgrClient> stmgrClient_;
   std::shared_ptr<common::MetricsMgrClient> metricsMgrClient_;
   std::shared_ptr<GatewayMetrics> gatewayMetrics_;
-  NotifyingCommunicator<google::protobuf::Message*>* dataToSlave_;
+  NotifyingCommunicator<unique_ptr<google::protobuf::Message>>* dataToSlave_;
   NotifyingCommunicator<google::protobuf::Message*>* dataFromSlave_;
   NotifyingCommunicator<google::protobuf::Message*>* metricsFromSlave_;
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
   // This is the max number of outstanding packets that are yet to be
   // consumed by the Slave
   int maxReadBufferSize_;

--- a/heron/instance/src/cpp/gateway/stmgr-client.cpp
+++ b/heron/instance/src/cpp/gateway/stmgr-client.cpp
@@ -32,12 +32,13 @@
 namespace heron {
 namespace instance {
 
-StMgrClient::StMgrClient(EventLoop* eventLoop, const NetworkOptions& options,
-                         const std::string& topologyName, const std::string& topologyId,
-                         const proto::system::Instance& instanceProto,
-                         std::shared_ptr<GatewayMetrics> gatewayMetrics,
-                         std::function<void(proto::system::PhysicalPlan*)> pplanWatcher,
-                         std::function<void(proto::system::HeronTupleSet2*)> tupleWatcher)
+StMgrClient::StMgrClient(
+                   std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options,
+                   const std::string& topologyName, const std::string& topologyId,
+                   const proto::system::Instance& instanceProto,
+                   std::shared_ptr<GatewayMetrics> gatewayMetrics,
+                   std::function<void(std::unique_ptr<proto::system::PhysicalPlan>)> pplanWatcher,
+                   std::function<void(std::unique_ptr<proto::system::HeronTupleSet2>)> tupleWatcher)
     : Client(eventLoop, options),
       topologyName_(topologyName),
       topologyId_(topologyId),
@@ -97,32 +98,35 @@ void StMgrClient::HandleClose(NetworkErrorCode code) {
   AddTimer([this]() { this->OnReconnectTimer(); }, reconnect_interval_ * 1000 * 1000);
 }
 
-void StMgrClient::HandleRegisterResponse(void*, proto::stmgr::RegisterInstanceResponse* response,
-                                         NetworkErrorCode status) {
+void StMgrClient::HandleRegisterResponse(
+    void*,
+    unique_ptr<proto::stmgr::RegisterInstanceResponse> response,
+    NetworkErrorCode status) {
   if (status != OK) {
     LOG(ERROR) << "NonOK network code " << status << " for register response from stmgr "
                << instanceProto_.stmgr_id() << " running at " << get_clientoptions().get_host()
                << ":" << get_clientoptions().get_port();
-    delete response;
     Stop();
     return;
   }
+
   proto::system::StatusCode stat = response->status().status();
+
   if (stat != proto::system::OK) {
     LOG(ERROR) << "NonOK register response " << stat << " from stmgr "
                << instanceProto_.stmgr_id() << " running at "
                << get_clientoptions().get_host() << ":" << get_clientoptions().get_port();
-    delete response;
     Stop();
     return;
   }
+
   LOG(INFO) << "Registered with our stmgr " << instanceProto_.stmgr_id() << " running at "
               << get_clientoptions().get_host() << ":" << get_clientoptions().get_port();
+
   if (response->has_pplan()) {
     LOG(INFO) << "Registration response had a pplan";
-    pplanWatcher_(response->release_pplan());
+    pplanWatcher_(std::move(unique_ptr<proto::system::PhysicalPlan>(response->release_pplan())));
   }
-  delete response;
 }
 
 void StMgrClient::OnReconnectTimer() { Start(); }
@@ -132,21 +136,20 @@ void StMgrClient::SendRegisterRequest() {
   request->set_topology_name(topologyName_);
   request->set_topology_id(topologyId_);
   request->mutable_instance()->CopyFrom(instanceProto_);
-  SendRequest(std::move(request), NULL);
+  SendRequest(std::move(request), nullptr);
   return;
 }
 
-void StMgrClient::HandlePhysicalPlan(proto::stmgr::NewInstanceAssignmentMessage* msg) {
+void StMgrClient::HandlePhysicalPlan(unique_ptr<proto::stmgr::NewInstanceAssignmentMessage> msg) {
   LOG(INFO) << "Got a Physical Plan from our stmgr " << instanceProto_.stmgr_id() << " running at "
-              << get_clientoptions().get_host() << ":" << get_clientoptions().get_port();
-  pplanWatcher_(msg->release_pplan());
-  delete msg;
+            << get_clientoptions().get_host() << ":" << get_clientoptions().get_port();
+  pplanWatcher_(std::move(unique_ptr<proto::system::PhysicalPlan>(msg->release_pplan())));
 }
 
-void StMgrClient::HandleTupleMessage(proto::system::HeronTupleSet2* msg) {
+void StMgrClient::HandleTupleMessage(unique_ptr<proto::system::HeronTupleSet2> msg) {
   gatewayMetrics_->updateReceivedPacketsCount(1);
   gatewayMetrics_->updateReceivedPacketsSize(msg->ByteSize());
-  tupleWatcher_(msg);
+  tupleWatcher_(std::move(msg));
 }
 
 void StMgrClient::SendTupleMessage(const proto::system::HeronTupleSet& msg) {

--- a/heron/instance/src/cpp/gateway/stmgr-client.h
+++ b/heron/instance/src/cpp/gateway/stmgr-client.h
@@ -34,11 +34,12 @@ namespace instance {
 
 class StMgrClient : public Client {
  public:
-  StMgrClient(EventLoop* eventLoop, const NetworkOptions& options, const std::string& topologyName,
+  StMgrClient(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options,
+              const std::string& topologyName,
               const std::string& topologyId, const proto::system::Instance& instance,
               std::shared_ptr<GatewayMetrics> gatewayMetrics,
-              std::function<void(proto::system::PhysicalPlan*)> pplan_watcher,
-              std::function<void(proto::system::HeronTupleSet2*)> tuple_watcher);
+              std::function<void(std::unique_ptr<proto::system::PhysicalPlan>)> pplan_watcher,
+              std::function<void(std::unique_ptr<proto::system::HeronTupleSet2>)> tuple_watcher);
   virtual ~StMgrClient();
 
   void SendTupleMessage(const proto::system::HeronTupleSet& msg);
@@ -50,10 +51,10 @@ class StMgrClient : public Client {
   virtual void HandleClose(NetworkErrorCode status);
 
  private:
-  void HandleRegisterResponse(void*, proto::stmgr::RegisterInstanceResponse* response,
+  void HandleRegisterResponse(void*, unique_ptr<proto::stmgr::RegisterInstanceResponse> response,
                               NetworkErrorCode status);
-  void HandlePhysicalPlan(proto::stmgr::NewInstanceAssignmentMessage* msg);
-  void HandleTupleMessage(proto::system::HeronTupleSet2* tupleMessage);
+  void HandlePhysicalPlan(unique_ptr<proto::stmgr::NewInstanceAssignmentMessage> msg);
+  void HandleTupleMessage(unique_ptr<proto::system::HeronTupleSet2> tupleMessage);
 
   void OnReconnectTimer();
   void SendRegisterRequest();
@@ -62,8 +63,8 @@ class StMgrClient : public Client {
   std::string topologyId_;
   const proto::system::Instance& instanceProto_;
   std::shared_ptr<GatewayMetrics> gatewayMetrics_;
-  std::function<void(proto::system::PhysicalPlan*)> pplanWatcher_;
-  std::function<void(proto::system::HeronTupleSet2*)> tupleWatcher_;
+  std::function<void(std::unique_ptr<proto::system::PhysicalPlan>)> pplanWatcher_;
+  std::function<void(std::unique_ptr<proto::system::HeronTupleSet2>)> tupleWatcher_;
   int64_t ndropped_messages_;
   int reconnect_interval_;
   int max_reconnect_times_;

--- a/heron/instance/src/cpp/instance-main.cpp
+++ b/heron/instance/src/cpp/instance-main.cpp
@@ -52,18 +52,19 @@ int main(int argc, char* argv[]) {
 
   // Read heron internals config from local file
   // Create the heron-internals-config-reader to read the heron internals config
-  EventLoopImpl eventLoop;
-  heron::config::HeronInternalsConfigReader::Create(&eventLoop, FLAGS_config_file,
+  auto eventLoop = std::make_shared<EventLoopImpl>();
+  heron::config::HeronInternalsConfigReader::Create(eventLoop, FLAGS_config_file,
                                                     FLAGS_override_config_file);
 
   auto gateway = new heron::instance::Gateway(FLAGS_topology_name, FLAGS_topology_id,
                                               FLAGS_instance_id, FLAGS_component_name,
                                               FLAGS_task_id, FLAGS_component_index,
                                               FLAGS_stmgr_id, FLAGS_stmgr_port,
-                                              FLAGS_metricsmgr_port, &eventLoop);
+                                              FLAGS_metricsmgr_port, eventLoop);
   auto slave = new heron::instance::Slave(FLAGS_task_id, FLAGS_topology_binary);
 
-  auto dataToSlave = new heron::instance::NotifyingCommunicator<google::protobuf::Message*>(
+  auto dataToSlave =
+          new heron::instance::NotifyingCommunicator<unique_ptr<google::protobuf::Message>>(
                                slave->eventLoop(),
                                std::bind(&heron::instance::Slave::HandleGatewayData,
                                          slave, std::placeholders::_1),

--- a/heron/instance/src/cpp/slave/imetrics-registrar-impl.cpp
+++ b/heron/instance/src/cpp/slave/imetrics-registrar-impl.cpp
@@ -29,7 +29,7 @@
 namespace heron {
 namespace instance {
 
-IMetricsRegistrarImpl::IMetricsRegistrarImpl(EventLoop* eventLoop,
+IMetricsRegistrarImpl::IMetricsRegistrarImpl(std::shared_ptr<EventLoop> eventLoop,
            NotifyingCommunicator<google::protobuf::Message*>* metricsFromSlave)
   : eventLoop_(eventLoop), metricsFromSlave_(metricsFromSlave) {
 }

--- a/heron/instance/src/cpp/slave/imetrics-registrar-impl.h
+++ b/heron/instance/src/cpp/slave/imetrics-registrar-impl.h
@@ -42,7 +42,7 @@ namespace instance {
  */
 class IMetricsRegistrarImpl : public api::metric::IMetricsRegistrar {
  public:
-  explicit IMetricsRegistrarImpl(EventLoop* eventLoop,
+  explicit IMetricsRegistrarImpl(std::shared_ptr<EventLoop> eventLoop,
            NotifyingCommunicator<google::protobuf::Message*>* metricsFromSlave);
   virtual ~IMetricsRegistrarImpl();
   virtual void registerMetric(const std::string& metricName,
@@ -57,7 +57,7 @@ class IMetricsRegistrarImpl : public api::metric::IMetricsRegistrar {
   std::map<std::string, std::shared_ptr<api::metric::IMetric>> metrics_;
   std::map<std::string, std::shared_ptr<api::metric::IMultiMetric>> multiMetrics_;
   std::map<int, std::list<std::string>> timeBuckets_;
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
   NotifyingCommunicator<google::protobuf::Message*>* metricsFromSlave_;
 };
 

--- a/heron/instance/src/cpp/slave/instance-base.h
+++ b/heron/instance/src/cpp/slave/instance-base.h
@@ -36,7 +36,7 @@ class InstanceBase {
   virtual void Deactivate() = 0;
   virtual bool IsRunning() = 0;
   virtual void DoWork() = 0;
-  virtual void HandleGatewayTuples(proto::system::HeronTupleSet2* tupleSet) = 0;
+  virtual void HandleGatewayTuples(unique_ptr<proto::system::HeronTupleSet2> tupleSet) = 0;
 };
 
 }  // namespace instance

--- a/heron/instance/src/cpp/slave/slave.cpp
+++ b/heron/instance/src/cpp/slave/slave.cpp
@@ -40,7 +40,7 @@ namespace instance {
 Slave::Slave(int myTaskId, const std::string& topologySo)
   : myTaskId_(myTaskId), taskContext_(new TaskContextImpl(myTaskId_)),
     dataToSlave_(NULL), dataFromSlave_(NULL), metricsFromSlave_(NULL),
-    instance_(NULL), eventLoop_(new EventLoopImpl()) {
+    instance_(NULL), eventLoop_(std::make_shared<EventLoopImpl>()) {
   auto pplan = new proto::system::PhysicalPlan();
   pplan_typename_ = pplan->GetTypeName();
   delete pplan;
@@ -57,9 +57,10 @@ Slave::~Slave() {
   }
 }
 
-void Slave::setCommunicators(NotifyingCommunicator<google::protobuf::Message*>* dataToSlave,
-                             NotifyingCommunicator<google::protobuf::Message*>* dataFromSlave,
-                             NotifyingCommunicator<google::protobuf::Message*>* metricsFromSlave) {
+void Slave::setCommunicators(
+                        NotifyingCommunicator<unique_ptr<google::protobuf::Message>>* dataToSlave,
+                        NotifyingCommunicator<google::protobuf::Message*>* dataFromSlave,
+                        NotifyingCommunicator<google::protobuf::Message*>* metricsFromSlave) {
   dataToSlave_ = dataToSlave;
   dataFromSlave_ = dataFromSlave;
   metricsFromSlave_ = metricsFromSlave;
@@ -79,19 +80,22 @@ void Slave::InternalStart() {
   eventLoop_->loop();
 }
 
-void Slave::HandleGatewayData(google::protobuf::Message* msg) {
+void Slave::HandleGatewayData(unique_ptr<google::protobuf::Message> msg) {
   if (msg->GetTypeName() == pplan_typename_) {
     LOG(INFO) << "Slave Received a new pplan message from Gateway";
-    auto pplan = static_cast<proto::system::PhysicalPlan*>(msg);
-    HandleNewPhysicalPlan(pplan);
+    auto pplan = unique_ptr<proto::system::PhysicalPlan>(
+            static_cast<proto::system::PhysicalPlan*>(msg.release()));
+    HandleNewPhysicalPlan(std::move(pplan));
   } else {
-    auto tupleSet = static_cast<proto::system::HeronTupleSet2*>(msg);
-    HandleStMgrTuples(tupleSet);
+    auto tupleSet = unique_ptr<proto::system::HeronTupleSet2>(
+            static_cast<proto::system::HeronTupleSet2*>(msg.release()));
+    HandleStMgrTuples(std::move(tupleSet));
   }
 }
 
-void Slave::HandleNewPhysicalPlan(proto::system::PhysicalPlan* pplan) {
-  taskContext_->newPhysicalPlan(pplan);
+void Slave::HandleNewPhysicalPlan(unique_ptr<proto::system::PhysicalPlan> pplan) {
+  std::shared_ptr<proto::system::PhysicalPlan> newPplan = std::move(pplan);
+  taskContext_->newPhysicalPlan(newPplan);
   if (!instance_) {
     LOG(INFO) << "Creating the instance for the first time";
     if (taskContext_->isSpout()) {
@@ -103,7 +107,7 @@ void Slave::HandleNewPhysicalPlan(proto::system::PhysicalPlan* pplan) {
       instance_ = new BoltInstance(eventLoop_, taskContext_,
                                    dataToSlave_, dataFromSlave_, dllHandle_);
     }
-    if (pplan->topology().state() == proto::api::TopologyState::RUNNING) {
+    if (newPplan->topology().state() == proto::api::TopologyState::RUNNING) {
       LOG(INFO) << "Starting the instance";
       instance_->Start();
       instance_->DoWork();
@@ -111,19 +115,19 @@ void Slave::HandleNewPhysicalPlan(proto::system::PhysicalPlan* pplan) {
       LOG(INFO) << "Not starting the instance";
     }
   } else {
-    if (pplan->topology().state() == proto::api::TopologyState::RUNNING &&
+    if (newPplan->topology().state() == proto::api::TopologyState::RUNNING &&
         !instance_->IsRunning()) {
       instance_->Activate();
-    } else if (pplan->topology().state() == proto::api::TopologyState::PAUSED &&
+    } else if (newPplan->topology().state() == proto::api::TopologyState::PAUSED &&
         instance_->IsRunning()) {
       instance_->Deactivate();
     }
   }
 }
 
-void Slave::HandleStMgrTuples(proto::system::HeronTupleSet2* tupleSet) {
+void Slave::HandleStMgrTuples(unique_ptr<proto::system::HeronTupleSet2> tupleSet) {
   if (instance_) {
-    instance_->HandleGatewayTuples(tupleSet);
+    instance_->HandleGatewayTuples(std::move(tupleSet));
   } else {
     LOG(FATAL) << "Received StMgr tuples before instance was instantiated";
   }

--- a/heron/instance/src/cpp/slave/slave.h
+++ b/heron/instance/src/cpp/slave/slave.h
@@ -41,13 +41,13 @@ class Slave {
   // This essentially fires a thread with internalStart
   void Start();
 
-  EventLoop* eventLoop() { return eventLoop_; }
-  void setCommunicators(NotifyingCommunicator<google::protobuf::Message*>* dataToSlave,
+  std::shared_ptr<EventLoop> eventLoop() { return eventLoop_; }
+  void setCommunicators(NotifyingCommunicator<unique_ptr<google::protobuf::Message>>* dataToSlave,
                         NotifyingCommunicator<google::protobuf::Message*>* dataFromSlave,
                         NotifyingCommunicator<google::protobuf::Message*>* metricsFromSlave);
 
   // Handles data from gateway thread
-  void HandleGatewayData(google::protobuf::Message* msg);
+  void HandleGatewayData(unique_ptr<google::protobuf::Message> msg);
 
   // This is the notification that gateway thread consumed something that we wrote
   void HandleGatewayDataConsumed();
@@ -59,17 +59,17 @@ class Slave {
   // This is the one thats running in the slave thread
   void InternalStart();
   // Called when a new phyiscal plan is received
-  void HandleNewPhysicalPlan(proto::system::PhysicalPlan* pplan);
+  void HandleNewPhysicalPlan(unique_ptr<proto::system::PhysicalPlan> pplan);
   // Called when we receive new tuple messages from gateway
-  void HandleStMgrTuples(proto::system::HeronTupleSet2* msg);
+  void HandleStMgrTuples(unique_ptr<proto::system::HeronTupleSet2> msg);
 
   int myTaskId_;
   std::shared_ptr<TaskContextImpl> taskContext_;
-  NotifyingCommunicator<google::protobuf::Message*>* dataToSlave_;
+  NotifyingCommunicator<unique_ptr<google::protobuf::Message>>* dataToSlave_;
   NotifyingCommunicator<google::protobuf::Message*>* dataFromSlave_;
   NotifyingCommunicator<google::protobuf::Message*>* metricsFromSlave_;
   InstanceBase* instance_;
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
   void* dllHandle_;
   std::string pplan_typename_;
   std::unique_ptr<std::thread> slaveThread_;

--- a/heron/instance/src/cpp/slave/task-context-impl.cpp
+++ b/heron/instance/src/cpp/slave/task-context-impl.cpp
@@ -32,16 +32,14 @@ namespace heron {
 namespace instance {
 
 TaskContextImpl::TaskContextImpl(int myTaskId)
-  : myTaskId_(myTaskId), pplan_(NULL), myComponent_(NULL),
+  : myTaskId_(myTaskId), pplan_(nullptr), myComponent_(NULL),
     mySpout_(NULL), myBolt_(NULL), myInstance_(NULL),
     myMergedConfig_(new api::config::Config()) {
 }
 
-TaskContextImpl::~TaskContextImpl() {
-  delete pplan_;
-}
+TaskContextImpl::~TaskContextImpl() {}
 
-void TaskContextImpl::newPhysicalPlan(proto::system::PhysicalPlan* pplan) {
+void TaskContextImpl::newPhysicalPlan(std::shared_ptr<proto::system::PhysicalPlan> pplan) {
   cleanUp();
   pplan_ = pplan;
   for (int i = 0; i < pplan_->instances_size(); ++i) {
@@ -90,8 +88,7 @@ void TaskContextImpl::newPhysicalPlan(proto::system::PhysicalPlan* pplan) {
 
 void TaskContextImpl::cleanUp() {
   if (pplan_) {
-    delete pplan_;
-    pplan_ = NULL;
+    pplan_ = nullptr;
   }
   myOutputSchema_.clear();
   taskToComponentName_.clear();

--- a/heron/instance/src/cpp/slave/task-context-impl.h
+++ b/heron/instance/src/cpp/slave/task-context-impl.h
@@ -45,7 +45,7 @@ class TaskContextImpl : public api::topology::TaskContext {
  public:
   explicit TaskContextImpl(int myTaskId);
   ~TaskContextImpl();
-  void newPhysicalPlan(proto::system::PhysicalPlan* pplan);
+  void newPhysicalPlan(std::shared_ptr<proto::system::PhysicalPlan> pplan);
 
   // TopologyContext related implementations
   virtual const std::string& getTopologyId();
@@ -103,7 +103,7 @@ class TaskContextImpl : public api::topology::TaskContext {
   void cleanUp();
 
   int myTaskId_;
-  proto::system::PhysicalPlan* pplan_;
+  std::shared_ptr<proto::system::PhysicalPlan> pplan_;
   std::string myComponentName_;
   std::string myInstanceId_;
   std::map<std::string, int> myOutputSchema_;

--- a/heron/instance/src/cpp/spoutimpl/spout-instance.h
+++ b/heron/instance/src/cpp/spoutimpl/spout-instance.h
@@ -40,7 +40,7 @@ namespace instance {
 
 class SpoutInstance : public InstanceBase {
  public:
-  SpoutInstance(EventLoop* eventLoop, std::shared_ptr<TaskContextImpl> taskContext,
+  SpoutInstance(std::shared_ptr<EventLoop> eventLoop, std::shared_ptr<TaskContextImpl> taskContext,
                 NotifyingCommunicator<google::protobuf::Message*>* dataFromSlave,
                 void* dllHandle);
   virtual ~SpoutInstance();
@@ -51,7 +51,7 @@ class SpoutInstance : public InstanceBase {
   virtual void Deactivate();
   virtual bool IsRunning() { return active_; }
   virtual void DoWork();
-  virtual void HandleGatewayTuples(proto::system::HeronTupleSet2* tupleSet);
+  virtual void HandleGatewayTuples(unique_ptr<proto::system::HeronTupleSet2> tupleSet);
 
  private:
   void lookForTimeouts();
@@ -63,7 +63,7 @@ class SpoutInstance : public InstanceBase {
 
   std::shared_ptr<TaskContextImpl> taskContext_;
   NotifyingCommunicator<google::protobuf::Message*>* dataFromSlave_;
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
   api::spout::ISpout* spout_;
   std::shared_ptr<api::serializer::IPluggableSerializer> serializer_;
   std::shared_ptr<SpoutOutputCollectorImpl> collector_;

--- a/heron/instance/src/cpp/utils/notifying-communicator.h
+++ b/heron/instance/src/cpp/utils/notifying-communicator.h
@@ -49,9 +49,9 @@ template<typename T>
 class NotifyingCommunicator {
  public:
   // Constructor/Destructor
-  NotifyingCommunicator(EventLoop* consumer_loop,
+  NotifyingCommunicator(std::shared_ptr<EventLoop> consumer_loop,
                         std::function<void(T)> consumer_function,
-                        EventLoop* notification_loop,
+                        std::shared_ptr<EventLoop> notification_loop,
                         std::function<void()> notification_function) {
     consumption_function_ = std::move(consumer_function);
     notification_function_ = std::move(notification_function);
@@ -69,7 +69,7 @@ class NotifyingCommunicator {
   }
 
   void enqueue(T t) {
-    forward_channel_->enqueue(t);
+    forward_channel_->enqueue(std::move(t));
   }
 
   int size() {
@@ -88,7 +88,7 @@ class NotifyingCommunicator {
     notification_function_();
   }
   void consumption_function(T t) {
-    consumption_function_(t);
+    consumption_function_(std::move(t));
     notification_channel_->enqueue(&unused_);
   }
 

--- a/heron/statemgrs/src/cpp/statemgr/heron-localfilestatemgr.cpp
+++ b/heron/statemgrs/src/cpp/statemgr/heron-localfilestatemgr.cpp
@@ -35,7 +35,7 @@ namespace heron {
 namespace common {
 
 HeronLocalFileStateMgr::HeronLocalFileStateMgr(const std::string& _topleveldir,
-                                               EventLoop* eventLoop)
+                                               shared_ptr<EventLoop> eventLoop)
     : HeronStateMgr(_topleveldir), eventLoop_(eventLoop) {
   InitTree();
 }
@@ -107,7 +107,7 @@ void HeronLocalFileStateMgr::SetPackingPlanWatch(const std::string& topology_nam
 }
 
 void HeronLocalFileStateMgr::GetTMasterLocation(const std::string& _topology_name,
-                                                proto::tmaster::TMasterLocation* _return,
+                                                shared_ptr<proto::tmaster::TMasterLocation> _return,
                                                 VCallback<proto::system::StatusCode> cb) {
   std::string contents;
   proto::system::StatusCode status =
@@ -123,8 +123,8 @@ void HeronLocalFileStateMgr::GetTMasterLocation(const std::string& _topology_nam
 }
 
 void HeronLocalFileStateMgr::GetMetricsCacheLocation(const std::string& _topology_name,
-                                                proto::tmaster::MetricsCacheLocation* _return,
-                                                VCallback<proto::system::StatusCode> cb) {
+                                          shared_ptr<proto::tmaster::MetricsCacheLocation> _return,
+                                          VCallback<proto::system::StatusCode> cb) {
   std::string contents;
   proto::system::StatusCode status =
       ReadAllFileContents(GetMetricsCacheLocationPath(_topology_name), contents);

--- a/heron/statemgrs/src/cpp/statemgr/heron-localfilestatemgr.h
+++ b/heron/statemgrs/src/cpp/statemgr/heron-localfilestatemgr.h
@@ -42,7 +42,7 @@ namespace common {
 
 class HeronLocalFileStateMgr : public HeronStateMgr {
  public:
-  HeronLocalFileStateMgr(const std::string& _topleveldir, EventLoop* eventLoop);
+  HeronLocalFileStateMgr(const std::string& _topleveldir, shared_ptr<EventLoop> eventLoop);
   virtual ~HeronLocalFileStateMgr();
 
   // Sets up the basic filesystem tree at the given location
@@ -54,12 +54,12 @@ class HeronLocalFileStateMgr : public HeronStateMgr {
 
   // implement the functions
   void GetTMasterLocation(const std::string& _topology_name,
-                          proto::tmaster::TMasterLocation* _return,
+                          shared_ptr<proto::tmaster::TMasterLocation> _return,
                           VCallback<proto::system::StatusCode> _cb);
   void SetTMasterLocation(const proto::tmaster::TMasterLocation& _location,
                           VCallback<proto::system::StatusCode> _cb);
   void GetMetricsCacheLocation(const std::string& _topology_name,
-                          proto::tmaster::MetricsCacheLocation* _return,
+                          shared_ptr<proto::tmaster::MetricsCacheLocation> _return,
                           VCallback<proto::system::StatusCode> _cb);
   void SetMetricsCacheLocation(const proto::tmaster::MetricsCacheLocation& _location,
                           VCallback<proto::system::StatusCode> _cb);
@@ -137,7 +137,7 @@ class HeronLocalFileStateMgr : public HeronStateMgr {
                         VCallback<> _watcher, EventLoop::Status);
 
   // Hold the EventLoop for scheduling callbacks
-  EventLoop* eventLoop_;
+  shared_ptr<EventLoop> eventLoop_;
 };
 }  // namespace common
 }  // namespace heron

--- a/heron/statemgrs/src/cpp/statemgr/heron-statemgr.cpp
+++ b/heron/statemgrs/src/cpp/statemgr/heron-statemgr.cpp
@@ -32,9 +32,12 @@
 namespace heron {
 namespace common {
 
-shared_ptr<HeronStateMgr> HeronStateMgr::MakeStateMgr(const std::string& _zk_hostport,
-                                           const std::string& _topleveldir, EventLoop* eventLoop,
-                                           bool exitOnSessionExpiry) {
+shared_ptr<HeronStateMgr> HeronStateMgr::MakeStateMgr(
+    const std::string& _zk_hostport,
+    const std::string& _topleveldir,
+    shared_ptr<EventLoop> eventLoop,
+    bool exitOnSessionExpiry) {
+
   if (_zk_hostport.empty()) {
     return std::make_shared<HeronLocalFileStateMgr>(_topleveldir, eventLoop);
   } else {

--- a/heron/statemgrs/src/cpp/statemgr/heron-statemgr.h
+++ b/heron/statemgrs/src/cpp/statemgr/heron-statemgr.h
@@ -63,9 +63,11 @@ class HeronStateMgr {
   virtual ~HeronStateMgr();
 
   // Factory method to create
-  static shared_ptr<HeronStateMgr> MakeStateMgr(const std::string& _zk_hostport,
-                                             const std::string& _topleveldir, EventLoop* eventLoop,
-                                             bool exitOnSessionExpiry = true);
+  static shared_ptr<HeronStateMgr> MakeStateMgr(
+    const std::string& _zk_hostport,
+    const std::string& _topleveldir,
+    shared_ptr<EventLoop> eventLoop,
+    bool exitOnSessionExpiry = true);
 
   //
   // Interface methods
@@ -85,12 +87,12 @@ class HeronStateMgr {
 
   // Sets/Gets the Tmaster
   virtual void GetTMasterLocation(const std::string& _topology_name,
-                                  proto::tmaster::TMasterLocation* _return,
+                                  shared_ptr<proto::tmaster::TMasterLocation> _return,
                                   VCallback<proto::system::StatusCode> _cb) = 0;
   virtual void SetTMasterLocation(const proto::tmaster::TMasterLocation& _location,
                                   VCallback<proto::system::StatusCode> _cb) = 0;
   virtual void GetMetricsCacheLocation(const std::string& _topology_name,
-                                  proto::tmaster::MetricsCacheLocation* _return,
+                                  shared_ptr<proto::tmaster::MetricsCacheLocation> _return,
                                   VCallback<proto::system::StatusCode> _cb) = 0;
   virtual void SetMetricsCacheLocation(const proto::tmaster::MetricsCacheLocation& _location,
                                   VCallback<proto::system::StatusCode> _cb) = 0;

--- a/heron/statemgrs/src/cpp/statemgr/heron-zkstatemgr.cpp
+++ b/heron/statemgrs/src/cpp/statemgr/heron-zkstatemgr.cpp
@@ -32,7 +32,7 @@ namespace heron {
 namespace common {
 
 HeronZKStateMgr::HeronZKStateMgr(const std::string& zkhostport, const std::string& topleveldir,
-                                 EventLoop* eventLoop, bool exitOnSessionExpiry)
+                                 std::shared_ptr<EventLoop> eventLoop, bool exitOnSessionExpiry)
     : HeronStateMgr(topleveldir),
       zkhostport_(zkhostport),
       zkclient_(NULL),
@@ -44,7 +44,8 @@ HeronZKStateMgr::HeronZKStateMgr(const std::string& zkhostport, const std::strin
 }
 
 HeronZKStateMgr::HeronZKStateMgr(const std::string& zkhostport, const std::string& topleveldir,
-                                 EventLoop* eventLoop, ZKClientFactory* zkclient_factory,
+                                 std::shared_ptr<EventLoop> eventLoop,
+                                 ZKClientFactory* zkclient_factory,
                                  bool exitOnSessionExpiry)
     : HeronStateMgr(topleveldir),
       zkhostport_(zkhostport),
@@ -130,7 +131,7 @@ void HeronZKStateMgr::SetMetricsCacheLocation(const proto::tmaster::MetricsCache
 }
 
 void HeronZKStateMgr::GetTMasterLocation(const std::string& _topology_name,
-                                         proto::tmaster::TMasterLocation* _return,
+                                         shared_ptr<proto::tmaster::TMasterLocation> _return,
                                          VCallback<proto::system::StatusCode> cb) {
   std::string path = GetTMasterLocationPath(_topology_name);
   std::string* contents = new std::string();
@@ -143,7 +144,7 @@ void HeronZKStateMgr::GetTMasterLocation(const std::string& _topology_name,
 }
 
 void HeronZKStateMgr::GetMetricsCacheLocation(const std::string& _topology_name,
-                                         proto::tmaster::MetricsCacheLocation* _return,
+                                         shared_ptr<proto::tmaster::MetricsCacheLocation> _return,
                                          VCallback<proto::system::StatusCode> cb) {
   std::string path = GetMetricsCacheLocationPath(_topology_name);
   std::string* contents = new std::string();
@@ -405,7 +406,7 @@ void HeronZKStateMgr::SetMetricsCacheLocationDone(VCallback<proto::system::Statu
 }
 
 void HeronZKStateMgr::GetTMasterLocationDone(std::string* _contents,
-                                             proto::tmaster::TMasterLocation* _return,
+                                             shared_ptr<proto::tmaster::TMasterLocation> _return,
                                              VCallback<proto::system::StatusCode> cb,
                                              sp_int32 _rc) {
   proto::system::StatusCode code = proto::system::OK;
@@ -426,9 +427,9 @@ void HeronZKStateMgr::GetTMasterLocationDone(std::string* _contents,
 }
 
 void HeronZKStateMgr::GetMetricsCacheLocationDone(std::string* _contents,
-                                             proto::tmaster::MetricsCacheLocation* _return,
-                                             VCallback<proto::system::StatusCode> cb,
-                                             sp_int32 _rc) {
+                                         shared_ptr<proto::tmaster::MetricsCacheLocation> _return,
+                                         VCallback<proto::system::StatusCode> cb,
+                                         sp_int32 _rc) {
   proto::system::StatusCode code = proto::system::OK;
   if (_rc == ZOK) {
     if (!_return->ParseFromString(*_contents)) {

--- a/heron/statemgrs/src/cpp/statemgr/heron-zkstatemgr.h
+++ b/heron/statemgrs/src/cpp/statemgr/heron-zkstatemgr.h
@@ -57,7 +57,7 @@ namespace common {
 class HeronZKStateMgr : public HeronStateMgr {
  public:
   HeronZKStateMgr(const std::string& zkhostport, const std::string& topleveldir,
-                  EventLoop* eventLoop, bool exitOnSessionExpiry);
+                  std::shared_ptr<EventLoop> eventLoop, bool exitOnSessionExpiry);
   virtual ~HeronZKStateMgr();
 
   //
@@ -75,12 +75,12 @@ class HeronZKStateMgr : public HeronStateMgr {
   void SetTMasterLocation(const proto::tmaster::TMasterLocation& _location,
                           VCallback<proto::system::StatusCode> _cb);
   void GetTMasterLocation(const std::string& _topology_name,
-                          proto::tmaster::TMasterLocation* _return,
+                          shared_ptr<proto::tmaster::TMasterLocation> _return,
                           VCallback<proto::system::StatusCode> _cb);
   void SetMetricsCacheLocation(const proto::tmaster::MetricsCacheLocation& _location,
                           VCallback<proto::system::StatusCode> _cb);
   void GetMetricsCacheLocation(const std::string& _topology_name,
-                          proto::tmaster::MetricsCacheLocation* _return,
+                          shared_ptr<proto::tmaster::MetricsCacheLocation> _return,
                           VCallback<proto::system::StatusCode> _cb);
 
   // Gets/Sets the Topology
@@ -138,17 +138,18 @@ class HeronZKStateMgr : public HeronStateMgr {
   // A test ONLY constructor used to pass a ZKClientFactory which could
   // return a MockZKClient
   HeronZKStateMgr(const std::string& zkhostport, const std::string& topleveldir,
-                  EventLoop* eventLoop, ZKClientFactory* zkclient_factory,
+                  std::shared_ptr<EventLoop> eventLoop, ZKClientFactory* zkclient_factory,
                   bool exitOnSessionExpiry = false);
 
  private:
   // Done methods
   void SetTMasterLocationDone(VCallback<proto::system::StatusCode> _cb, sp_int32 _rc);
   void SetMetricsCacheLocationDone(VCallback<proto::system::StatusCode> _cb, sp_int32 _rc);
-  void GetTMasterLocationDone(std::string* _contents, proto::tmaster::TMasterLocation* _return,
+  void GetTMasterLocationDone(std::string* _contents,
+                              shared_ptr<proto::tmaster::TMasterLocation> _return,
                               VCallback<proto::system::StatusCode> _cb, sp_int32 _rc);
   void GetMetricsCacheLocationDone(std::string* _contents,
-                                   proto::tmaster::MetricsCacheLocation* _return,
+                                   shared_ptr<proto::tmaster::MetricsCacheLocation> _return,
                                    VCallback<proto::system::StatusCode> _cb,
                                    sp_int32 _rc);
 
@@ -227,7 +228,7 @@ class HeronZKStateMgr : public HeronStateMgr {
   // For tests it could be overriden to a factor that returns a MockZkClient
   // This class owns the factory, and is responsible for deleting it.
   ZKClientFactory* const zkclient_factory_;
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
   // A permanent callback initialized to wrap the WatchEventHandler
   VCallback<ZKClient::ZkWatchEvent> watch_event_cb_;
 

--- a/heron/stmgr/src/cpp/grouping/grouping.cpp
+++ b/heron/stmgr/src/cpp/grouping/grouping.cpp
@@ -45,43 +45,44 @@ Grouping::Grouping(const std::vector<sp_int32>& _task_ids)
 
 Grouping::~Grouping() {}
 
-Grouping* Grouping::Create(proto::api::Grouping grouping_, const proto::api::InputStream& _is,
+unique_ptr<Grouping> Grouping::Create(proto::api::Grouping grouping_,
+                           const proto::api::InputStream& _is,
                            const proto::api::StreamSchema& _schema,
                            const std::vector<sp_int32>& _task_ids) {
   switch (grouping_) {
     case proto::api::SHUFFLE: {
-      return new ShuffleGrouping(_task_ids);
+      return make_unique<ShuffleGrouping>(_task_ids);
       break;
     }
 
     case proto::api::FIELDS: {
-      return new FieldsGrouping(_is, _schema, _task_ids);
+      return make_unique<FieldsGrouping>(_is, _schema, _task_ids);
       break;
     }
 
     case proto::api::ALL: {
-      return new AllGrouping(_task_ids);
+      return make_unique<AllGrouping>(_task_ids);
       break;
     }
 
     case proto::api::LOWEST: {
-      return new LowestGrouping(_task_ids);
+      return make_unique<LowestGrouping>(_task_ids);
       break;
     }
 
     case proto::api::NONE: {
       // This is what storm does right now
-      return new ShuffleGrouping(_task_ids);
+      return make_unique<ShuffleGrouping>(_task_ids);
       break;
     }
 
     case proto::api::DIRECT: {
-      return new DirectGrouping(_task_ids);
+      return make_unique<DirectGrouping>(_task_ids);
       break;
     }
 
     case proto::api::CUSTOM: {
-      return new CustomGrouping(_task_ids);
+      return make_unique<CustomGrouping>(_task_ids);
       break;
     }
 

--- a/heron/stmgr/src/cpp/grouping/grouping.h
+++ b/heron/stmgr/src/cpp/grouping/grouping.h
@@ -32,7 +32,8 @@ class Grouping {
   explicit Grouping(const std::vector<sp_int32>& _task_ids);
   virtual ~Grouping();
 
-  static Grouping* Create(proto::api::Grouping grouping_, const proto::api::InputStream& _is,
+  static std::unique_ptr<Grouping> Create(proto::api::Grouping grouping_,
+                          const proto::api::InputStream& _is,
                           const proto::api::StreamSchema& _schema,
                           const std::vector<sp_int32>& _task_ids);
 

--- a/heron/stmgr/src/cpp/manager/checkpoint-gateway.cpp
+++ b/heron/stmgr/src/cpp/manager/checkpoint-gateway.cpp
@@ -35,12 +35,14 @@
 namespace heron {
 namespace stmgr {
 
+using proto::ckptmgr::InitiateStatefulCheckpoint;
+
 CheckpointGateway::CheckpointGateway(sp_uint64 _drain_threshold,
-         NeighbourCalculator* _neighbour_calculator,
-         common::MetricsMgrSt* _metrics_manager_client,
+         shared_ptr<NeighbourCalculator> _neighbour_calculator,
+         shared_ptr<common::MetricsMgrSt> const& _metrics_manager_client,
          std::function<void(sp_int32, proto::system::HeronTupleSet2*)> _tupleset_drainer,
          std::function<void(proto::stmgr::TupleStreamMessage*)> _tuplestream_drainer,
-         std::function<void(sp_int32, proto::ckptmgr::InitiateStatefulCheckpoint*)> _ckpt_drainer)
+         std::function<void(sp_int32, std::unique_ptr<InitiateStatefulCheckpoint>)> _ckpt_drainer)
   : drain_threshold_(_drain_threshold), current_size_(0),
     neighbour_calculator_(_neighbour_calculator),
     metrics_manager_client_(_metrics_manager_client), tupleset_drainer_(_tupleset_drainer),
@@ -50,10 +52,7 @@ CheckpointGateway::CheckpointGateway(sp_uint64 _drain_threshold,
 }
 
 CheckpointGateway::~CheckpointGateway() {
-  for (auto kv : pending_tuples_) {
-    delete kv.second;
-  }
-
+  pending_tuples_.erase(pending_tuples_.begin(), pending_tuples_.end());
   metrics_manager_client_->unregister_metric("__stateful_gateway_size");
 }
 
@@ -62,9 +61,9 @@ void CheckpointGateway::SendToInstance(sp_int32 _task_id,
   if (current_size_ > drain_threshold_) {
     ForceDrain();
   }
-  CheckpointInfo* info = get_info(_task_id);
+  CheckpointInfo& info = get_info(_task_id);
   sp_uint64 size = _message->GetCachedSize();
-  _message = info->SendToInstance(_message, size);
+  _message = info.SendToInstance(_message, size);
   if (!_message) {
     current_size_ += size;
   } else {
@@ -73,19 +72,23 @@ void CheckpointGateway::SendToInstance(sp_int32 _task_id,
   size_metric_->SetValue(current_size_);
 }
 
-void CheckpointGateway::SendToInstance(proto::stmgr::TupleStreamMessage* _message) {
+void CheckpointGateway::SendToInstance(unique_ptr<proto::stmgr::TupleStreamMessage> _message) {
   if (current_size_ > drain_threshold_) {
     ForceDrain();
   }
+
   sp_int32 task_id = _message->task_id();
   sp_uint64 size = _message->set().size();
-  CheckpointInfo* info = get_info(task_id);
-  _message = info->SendToInstance(_message, size);
-  if (!_message) {
+  CheckpointInfo& info = get_info(task_id);
+
+  proto::stmgr::TupleStreamMessage *raw_message = info.SendToInstance(_message.release(), size);
+
+  if (!raw_message) {
     current_size_ += size;
   } else {
-    tuplestream_drainer_(_message);
+    tuplestream_drainer_(raw_message);
   }
+
   size_metric_->SetValue(current_size_);
 }
 
@@ -93,10 +96,10 @@ void CheckpointGateway::HandleUpstreamMarker(sp_int32 _src_task_id, sp_int32 _de
                                              const sp_string& _checkpoint_id) {
   LOG(INFO) << "Got checkpoint marker for triplet "
             << _checkpoint_id << " " << _src_task_id << " " << _destination_task_id;
-  CheckpointInfo* info = get_info(_destination_task_id);
+  CheckpointInfo& info = get_info(_destination_task_id);
   sp_uint64 size = 0;
-  std::deque<Tuple> tuples = info->HandleUpstreamMarker(_src_task_id, _checkpoint_id, &size);
-  for (auto tupl : tuples) {
+  std::deque<Tuple> tuples = info.HandleUpstreamMarker(_src_task_id, _checkpoint_id, &size);
+  for (auto &tupl : tuples) {
     DrainTuple(_destination_task_id, tupl);
   }
   current_size_ -= size;
@@ -109,14 +112,14 @@ void CheckpointGateway::DrainTuple(sp_int32 _dest, Tuple& _tuple) {
   } else if (std::get<1>(_tuple)) {
     tuplestream_drainer_(std::get<1>(_tuple));
   } else {
-    ckpt_drainer_(_dest, std::get<2>(_tuple));
+    ckpt_drainer_(_dest, std::move(std::get<2>(_tuple)));
   }
 }
 
 void CheckpointGateway::ForceDrain() {
-  for (auto kv : pending_tuples_) {
+  for (auto &kv : pending_tuples_) {
     std::deque<Tuple> tuples = kv.second->ForceDrain();
-    for (auto tupl : tuples) {
+    for (auto &tupl : tuples) {
       DrainTuple(kv.first, tupl);
     }
   }
@@ -124,24 +127,24 @@ void CheckpointGateway::ForceDrain() {
   size_metric_->SetValue(current_size_);
 }
 
-CheckpointGateway::CheckpointInfo*
-CheckpointGateway::get_info(sp_int32 _task_id) {
+CheckpointGateway::CheckpointInfo& CheckpointGateway::get_info(sp_int32 _task_id) {
   auto iter = pending_tuples_.find(_task_id);
   if (iter == pending_tuples_.end()) {
-    CheckpointInfo* info =
-         new CheckpointInfo(_task_id, neighbour_calculator_->get_upstreamers(_task_id));
-    pending_tuples_[_task_id] = info;
-    return info;
+    auto info =
+        make_unique<CheckpointInfo>(_task_id, neighbour_calculator_->get_upstreamers(_task_id));
+    pending_tuples_[_task_id] = std::move(info);
+    return *pending_tuples_[_task_id];
   } else {
-    return iter->second;
+    return *(iter->second);
   }
 }
 
 void CheckpointGateway::Clear() {
-  for (auto kv : pending_tuples_) {
+  for (auto &kv : pending_tuples_) {
     kv.second->Clear();
-    delete kv.second;
+    pending_tuples_.erase(kv.first);
   }
+
   pending_tuples_.clear();
   current_size_ = 0;
   size_metric_->SetValue(current_size_);
@@ -172,8 +175,10 @@ CheckpointGateway::CheckpointInfo::SendToInstance(proto::system::HeronTupleSet2*
       // This means that we still are expecting a checkpoint marker from this src task id
       return _tuple;
     } else {
-      add(std::make_tuple(_tuple, (proto::stmgr::TupleStreamMessage*)nullptr,
-                         (proto::ckptmgr::InitiateStatefulCheckpoint*)nullptr), _size);
+      auto tp = std::make_tuple(_tuple,
+                                (proto::stmgr::TupleStreamMessage*)nullptr,
+                                (unique_ptr<proto::ckptmgr::InitiateStatefulCheckpoint>)nullptr);
+      add(tp, _size);
       return nullptr;
     }
   }
@@ -190,8 +195,10 @@ CheckpointGateway::CheckpointInfo::SendToInstance(proto::stmgr::TupleStreamMessa
       // This means that we still are expecting a checkpoint marker from this src task id
       return _tuple;
     } else {
-      add(std::make_tuple((proto::system::HeronTupleSet2*)nullptr, _tuple,
-                         (proto::ckptmgr::InitiateStatefulCheckpoint*)nullptr), _size);
+      auto tp = std::make_tuple((proto::system::HeronTupleSet2*)nullptr,
+                                _tuple,
+                                (unique_ptr<proto::ckptmgr::InitiateStatefulCheckpoint>)nullptr);
+      add(tp, _size);
       return nullptr;
     }
   }
@@ -228,11 +235,13 @@ CheckpointGateway::CheckpointInfo::HandleUpstreamMarker(sp_int32 _src_task_id,
               << " All checkpoint markers received for checkpoint "
                  << _checkpoint_id;
     // We need to add Initiate Checkpoint message before the current set
-    auto message = new proto::ckptmgr::InitiateStatefulCheckpoint();
+    auto message = make_unique<proto::ckptmgr::InitiateStatefulCheckpoint>();
     message->set_checkpoint_id(_checkpoint_id);
-    add_front(std::make_tuple((proto::system::HeronTupleSet2*)nullptr,
-                              (proto::stmgr::TupleStreamMessage*)nullptr, message),
-                              message->GetCachedSize());
+    int cache_size = message->GetCachedSize();
+    auto new_tuple = std::make_tuple(
+            (proto::system::HeronTupleSet2*)nullptr,
+            (proto::stmgr::TupleStreamMessage*)nullptr, std::move(message));
+    add_front(new_tuple, cache_size);
     return ForceDrain();
   } else {
     std::deque<Tuple> dummy;
@@ -244,32 +253,49 @@ std::deque<CheckpointGateway::Tuple>
 CheckpointGateway::CheckpointInfo::ForceDrain() {
   checkpoint_id_ = "";
   current_size_ = 0;
-  std::deque<Tuple> tmp = pending_tuples_;
+  std::deque<Tuple> tmp;
+
+  for (auto it = pending_tuples_.begin(); it != pending_tuples_.end(); ++it) {
+    auto m1 = std::get<0>(*it);
+    auto m2 = std::get<1>(*it);
+    auto m3 = std::move(std::get<2>(*it));
+    tmp.push_back(std::make_tuple(m1, m2, std::move(m3)));
+  }
+
   pending_tuples_.clear();
+
   pending_upstream_dependencies_ = all_upstream_dependencies_;
+
   return tmp;
 }
 
-void CheckpointGateway::CheckpointInfo::add(Tuple _tuple, sp_uint64 _size) {
-  pending_tuples_.push_back(_tuple);
+void CheckpointGateway::CheckpointInfo::add(Tuple& _tuple, sp_uint64 _size) {
+  auto m1 = std::get<0>(_tuple);
+  auto m2 = std::get<1>(_tuple);
+  auto m3 = std::move(std::get<2>(_tuple));
+  pending_tuples_.push_back(std::make_tuple(m1, m2, std::move(m3)));
   current_size_ += _size;
 }
 
-void CheckpointGateway::CheckpointInfo::add_front(Tuple _tuple, sp_uint64 _size) {
-  pending_tuples_.push_front(_tuple);
+void CheckpointGateway::CheckpointInfo::add_front(Tuple& _tuple, sp_uint64 _size) {
+  auto m1 = std::get<0>(_tuple);
+  auto m2 = std::get<1>(_tuple);
+  auto m3 = std::move(std::get<2>(_tuple));
+  pending_tuples_.push_front(std::make_tuple(m1, m2, std::move(m3)));
   current_size_ += _size;
 }
 
 void CheckpointGateway::CheckpointInfo::Clear() {
-  for (auto tupl : pending_tuples_) {
+  for (auto &tupl : pending_tuples_) {
     if (std::get<0>(tupl)) {
       __global_protobuf_pool_release__(std::get<0>(tupl));
     } else if (std::get<1>(tupl)) {
       __global_protobuf_pool_release__(std::get<1>(tupl));
     } else {
-      __global_protobuf_pool_release__(std::get<2>(tupl));
+      auto message = std::move(std::get<2>(tupl));
     }
   }
+
   pending_tuples_.clear();
   current_size_ = 0;
   checkpoint_id_ = "";

--- a/heron/stmgr/src/cpp/manager/checkpoint-gateway.h
+++ b/heron/stmgr/src/cpp/manager/checkpoint-gateway.h
@@ -41,6 +41,10 @@ namespace stmgr {
 
 class NeighbourCalculator;
 
+using std::unique_ptr;
+using std::shared_ptr;
+using proto::ckptmgr::InitiateStatefulCheckpoint;
+
 // The CheckpointGateway class defines the buffer inside the stmgr
 // that exists to buffer tuples to all the local instances until
 // all upstream checkpoint markers are received. The gateway
@@ -49,14 +53,14 @@ class NeighbourCalculator;
 class CheckpointGateway {
  public:
   explicit CheckpointGateway(sp_uint64 _drain_threshold,
-        NeighbourCalculator* _neighbour_calculator,
-        common::MetricsMgrSt* _metrics_manager_client,
+        shared_ptr<NeighbourCalculator> _neighbour_calculator,
+        shared_ptr<common::MetricsMgrSt> const& _metrics_manager_client,
         std::function<void(sp_int32, proto::system::HeronTupleSet2*)> tupleset_drainer,
         std::function<void(proto::stmgr::TupleStreamMessage*)> tuplestream_drainer,
-        std::function<void(sp_int32, proto::ckptmgr::InitiateStatefulCheckpoint*)> ckpt_drainer);
+        std::function<void(sp_int32, unique_ptr<InitiateStatefulCheckpoint>)> ckpt_drainer);
   virtual ~CheckpointGateway();
   void SendToInstance(sp_int32 _task_id, proto::system::HeronTupleSet2* _message);
-  void SendToInstance(proto::stmgr::TupleStreamMessage* _message);
+  void SendToInstance(unique_ptr<proto::stmgr::TupleStreamMessage> _message);
   void HandleUpstreamMarker(sp_int32 _src_task_id, sp_int32 _destination_task_id,
                             const sp_string& _checkpoint_id);
 
@@ -66,7 +70,7 @@ class CheckpointGateway {
  private:
   typedef std::tuple<proto::system::HeronTupleSet2*,
                      proto::stmgr::TupleStreamMessage*,
-                     proto::ckptmgr::InitiateStatefulCheckpoint*>
+                     unique_ptr<proto::ckptmgr::InitiateStatefulCheckpoint>>
           Tuple;
 
   // This helper class defines the current state of affairs
@@ -85,8 +89,8 @@ class CheckpointGateway {
     std::deque<Tuple> ForceDrain();
     void Clear();
    private:
-    void add(Tuple _tuple, sp_uint64 _size);
-    void add_front(Tuple _tuple, sp_uint64 _size);
+    void add(Tuple& _tuple, sp_uint64 _size);
+    void add_front(Tuple& _tuple, sp_uint64 _size);
     sp_string checkpoint_id_;
     std::unordered_set<sp_int32> all_upstream_dependencies_;
     std::unordered_set<sp_int32> pending_upstream_dependencies_;
@@ -96,17 +100,18 @@ class CheckpointGateway {
   };
   void ForceDrain();
   void DrainTuple(sp_int32 _dest, Tuple& _tuple);
-  CheckpointInfo* get_info(sp_int32 _task_id);
+  CheckpointGateway::CheckpointInfo& get_info(sp_int32 _task_id);
+
   // The maximum buffering that we can do before we discard the marker
   sp_uint64 drain_threshold_;
   sp_uint64 current_size_;
-  NeighbourCalculator* neighbour_calculator_;
-  common::MetricsMgrSt* metrics_manager_client_;
+  shared_ptr<NeighbourCalculator> neighbour_calculator_;
+  shared_ptr<common::MetricsMgrSt> metrics_manager_client_;
   std::shared_ptr<common::AssignableMetric> size_metric_;
-  std::unordered_map<sp_int32, CheckpointInfo*> pending_tuples_;
+  std::unordered_map<sp_int32, unique_ptr<CheckpointInfo>> pending_tuples_;
   std::function<void(sp_int32, proto::system::HeronTupleSet2*)> tupleset_drainer_;
   std::function<void(proto::stmgr::TupleStreamMessage*)> tuplestream_drainer_;
-  std::function<void(sp_int32, proto::ckptmgr::InitiateStatefulCheckpoint*)> ckpt_drainer_;
+  std::function<void(sp_int32, unique_ptr<InitiateStatefulCheckpoint>)> ckpt_drainer_;
 };
 
 }  // namespace stmgr

--- a/heron/stmgr/src/cpp/manager/ckptmgr-client.h
+++ b/heron/stmgr/src/cpp/manager/ckptmgr-client.h
@@ -33,7 +33,7 @@ using std::unique_ptr;
 
 class CkptMgrClient : public Client {
  public:
-  CkptMgrClient(EventLoop* eventLoop, const NetworkOptions& _options,
+  CkptMgrClient(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options,
                 const sp_string& _topology_name, const sp_string& _topology_id,
                 const sp_string& _our_ckptmgr_id, const sp_string& _our_stmgr_id,
                 std::function<void(const proto::system::Instance&,
@@ -55,16 +55,18 @@ class CkptMgrClient : public Client {
   void GetInstanceState(const proto::system::Instance& _instance,
                         const std::string& _checkpoint_id, int32_t* _nattempts);
   virtual void HandleSaveInstanceStateResponse(void*,
-                             proto::ckptmgr::SaveInstanceStateResponse* _response,
+                             unique_ptr<proto::ckptmgr::SaveInstanceStateResponse> _response,
                              NetworkErrorCode status);
   virtual void HandleGetInstanceStateResponse(void*,
-                             proto::ckptmgr::GetInstanceStateResponse* _response,
+                             unique_ptr<proto::ckptmgr::GetInstanceStateResponse> _response,
                              NetworkErrorCode status);
   virtual void HandleConnect(NetworkErrorCode status);
   virtual void HandleClose(NetworkErrorCode status);
 
  private:
-  void HandleRegisterStMgrResponse(void *, proto::ckptmgr::RegisterStMgrResponse *_response,
+  void HandleRegisterStMgrResponse(
+                                   void *,
+                                   unique_ptr<proto::ckptmgr::RegisterStMgrResponse >_response,
                                    NetworkErrorCode);
   void SendRegisterRequest();
 

--- a/heron/stmgr/src/cpp/manager/instance-server.cpp
+++ b/heron/stmgr/src/cpp/manager/instance-server.cpp
@@ -87,13 +87,16 @@ const sp_string CONNECTION_BUFFER_LENGTH_BY_INSTANCEID =
 const sp_int64 SYSTEM_METRICS_SAMPLE_INTERVAL_MICROSECOND = 10_s;
 
 
-InstanceServer::InstanceServer(EventLoop* eventLoop, const NetworkOptions& _options,
-                               const sp_string& _topology_name, const sp_string& _topology_id,
-                               const sp_string& _stmgr_id,
-                               const std::vector<sp_string>& _expected_instances, StMgr* _stmgr,
-                               heron::common::MetricsMgrSt* _metrics_manager_client,
-                               NeighbourCalculator* _neighbour_calculator,
-                               bool _droptuples_upon_backpressure)
+InstanceServer::InstanceServer(
+    shared_ptr<EventLoop> eventLoop,
+    const NetworkOptions& _options,
+    const sp_string& _topology_name, const sp_string& _topology_id,
+    const sp_string& _stmgr_id,
+    const std::vector<sp_string>& _expected_instances,
+    StMgr* _stmgr,
+    shared_ptr<heron::common::MetricsMgrSt> const& _metrics_manager_client,
+    shared_ptr<NeighbourCalculator> _neighbour_calculator,
+    bool _droptuples_upon_backpressure)
     : Server(eventLoop, _options),
       topology_name_(_topology_name),
       topology_id_(_topology_id),
@@ -123,7 +126,7 @@ InstanceServer::InstanceServer(EventLoop* eventLoop, const NetworkOptions& _opti
 
   sp_uint64 drain_threshold_bytes =
     config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrStatefulBufferSizeMb() * 1_MB;
-  stateful_gateway_ = new CheckpointGateway(drain_threshold_bytes, neighbour_calculator_,
+  stateful_gateway_ = make_shared<CheckpointGateway>(drain_threshold_bytes, neighbour_calculator_,
                                             metrics_manager_client_,
     std::bind(&InstanceServer::DrainTupleSet, this, std::placeholders::_1, std::placeholders::_2),
     std::bind(&InstanceServer::DrainTupleStream, this, std::placeholders::_1),
@@ -182,8 +185,6 @@ InstanceServer::~InstanceServer() {
   for (auto iter = instance_info_.begin(); iter != instance_info_.end(); ++iter) {
     delete iter->second;
   }
-
-  delete stateful_gateway_;
 }
 
 void InstanceServer::GetInstanceInfo(std::vector<proto::system::Instance*>& _return) {
@@ -286,7 +287,7 @@ void InstanceServer::HandleConnectionClose(Connection* _conn, NetworkErrorCode) 
 }
 
 void InstanceServer::HandleRegisterInstanceRequest(REQID _reqid, Connection* _conn,
-    proto::stmgr::RegisterInstanceRequest* _request) {
+                                       unique_ptr<proto::stmgr::RegisterInstanceRequest> _request) {
   LOG(INFO) << "Got HandleRegisterInstanceRequest from connection " << _conn << " and instance "
             << _request->instance().instance_id();
   // Do some basic checks
@@ -356,7 +357,7 @@ void InstanceServer::HandleRegisterInstanceRequest(REQID _reqid, Connection* _co
 
     proto::stmgr::RegisterInstanceResponse response;
     response.mutable_status()->set_status(proto::system::OK);
-    const proto::system::PhysicalPlan* pplan = stmgr_->GetPhysicalPlan();
+    const shared_ptr<proto::system::PhysicalPlan> pplan = stmgr_->GetPhysicalPlan();
     if (pplan) {
       response.mutable_pplan()->CopyFrom(*pplan);
     }
@@ -373,17 +374,16 @@ void InstanceServer::HandleRegisterInstanceRequest(REQID _reqid, Connection* _co
       stmgr_->HandleAllInstancesConnected();
     }
   }
-  delete _request;
 }
 
 void InstanceServer::HandleTupleSetMessage(Connection* _conn,
-                                        proto::system::HeronTupleSet* _message) {
+                                           unique_ptr<proto::system::HeronTupleSet> _message) {
   auto iter = active_instances_.find(_conn);
   if (iter == active_instances_.end()) {
     LOG(ERROR) << "Received TupleSet from unknown instance connection. Dropping..";
-    __global_protobuf_pool_release__(_message);
     return;
   }
+
   if (_message->has_data()) {
     instance_server_metrics_->scope(METRIC_DATA_TUPLES_FROM_INSTANCES)
         ->incr_by(_message->data().tuples_size());
@@ -393,11 +393,12 @@ void InstanceServer::HandleTupleSetMessage(Connection* _conn,
     instance_server_metrics_->scope(METRIC_FAIL_TUPLES_FROM_INSTANCES)
         ->incr_by(_message->control().fails_size());
   }
-  stmgr_->HandleInstanceData(iter->second, instance_info_[iter->second]->local_spout_, _message);
-  __global_protobuf_pool_release__(_message);
+
+  stmgr_->HandleInstanceData(iter->second, instance_info_[iter->second]->local_spout_,
+                             std::move(_message));
 }
 
-void InstanceServer::SendToInstance2(proto::stmgr::TupleStreamMessage* _message) {
+void InstanceServer::SendToInstance2(unique_ptr<proto::stmgr::TupleStreamMessage> _message) {
   sp_string instance_id = task_id_to_name[_message->task_id()];
   ConnectionBufferLengthMetricMap::const_iterator it =
     connection_buffer_length_metric_map_.find(instance_id);
@@ -405,7 +406,7 @@ void InstanceServer::SendToInstance2(proto::stmgr::TupleStreamMessage* _message)
     connection_buffer_length_metric_map_
       [instance_id]->scope("packets")->incr_by(_message->num_tuples());
 
-  stateful_gateway_->SendToInstance(_message);
+  stateful_gateway_->SendToInstance(std::move(_message));
 }
 
 void InstanceServer::DrainTupleStream(proto::stmgr::TupleStreamMessage* _message) {
@@ -468,7 +469,7 @@ void InstanceServer::DrainTupleSet(sp_int32 _task_id,
 }
 
 void InstanceServer::DrainCheckpoint(sp_int32 _task_id,
-                                  proto::ckptmgr::InitiateStatefulCheckpoint* _message) {
+                                  unique_ptr<proto::ckptmgr::InitiateStatefulCheckpoint> _message) {
   TaskIdInstanceDataMap::iterator iter = instance_info_.find(_task_id);
   if (iter == instance_info_.end() || iter->second->conn_ == NULL) {
     LOG(ERROR) << "task_id " << _task_id << " has not yet connected to us. Dropping...";
@@ -476,7 +477,6 @@ void InstanceServer::DrainCheckpoint(sp_int32 _task_id,
     LOG(INFO) << "Sending Initiate Checkpoint Message to local task " << _task_id;
     SendMessage(iter->second->conn_, *_message);
   }
-  __global_protobuf_pool_release__(_message);
 }
 
 void InstanceServer::BroadcastNewPhysicalPlan(const proto::system::PhysicalPlan& _pplan) {
@@ -639,58 +639,52 @@ void InstanceServer::InitiateStatefulCheckpoint(const sp_string& _checkpoint_tag
                 << _checkpoint_tag << " to local spout "
                 << iter->second->instance_->info().component_name()
                 << " with task_id " << iter->second->instance_->info().task_id();
-      proto::ckptmgr::InitiateStatefulCheckpoint* message = nullptr;
-      message = __global_protobuf_pool_acquire__(message);
+      auto message = make_unique<proto::ckptmgr::InitiateStatefulCheckpoint>();
       message->set_checkpoint_id(_checkpoint_tag);
       SendMessage(iter->second->conn_, *message);
-      __global_protobuf_pool_release__(message);
     }
   }
 }
 
 void InstanceServer::HandleStoreInstanceStateCheckpointMessage(Connection* _conn,
-                               proto::ckptmgr::StoreInstanceStateCheckpoint* _message) {
+                               unique_ptr<proto::ckptmgr::StoreInstanceStateCheckpoint> _message) {
   ConnectionTaskIdMap::iterator iter = active_instances_.find(_conn);
   if (iter == active_instances_.end()) {
     LOG(ERROR) << "Hmm.. Got InstaceStateCheckpoint Message from an unknown connection";
-    __global_protobuf_pool_release__(_message);
     return;
   }
+
   sp_int32 task_id = iter->second;
   TaskIdInstanceDataMap::iterator it = instance_info_.find(task_id);
   if (it == instance_info_.end()) {
     LOG(ERROR) << "Hmm.. Got InstaceStateCheckpoint Message from unknown task_id "
                << task_id;
-    __global_protobuf_pool_release__(_message);
     return;
   }
 
   // send the checkpoint message to all downstream task ids
   stmgr_->HandleStoreInstanceStateCheckpoint(_message->state(), *(it->second->instance_));
-  __global_protobuf_pool_release__(_message);
 }
 
 void InstanceServer::HandleRestoreInstanceStateResponse(Connection* _conn,
-                               proto::ckptmgr::RestoreInstanceStateResponse* _message) {
+                               unique_ptr<proto::ckptmgr::RestoreInstanceStateResponse> _message) {
   ConnectionTaskIdMap::iterator iter = active_instances_.find(_conn);
   if (iter == active_instances_.end()) {
     LOG(ERROR) << "Hmm.. Got RestoreInstanceStateResponse Message from an unknown connection";
-    __global_protobuf_pool_release__(_message);
     return;
   }
+
   sp_int32 task_id = iter->second;
   TaskIdInstanceDataMap::iterator it = instance_info_.find(task_id);
   if (it == instance_info_.end()) {
     LOG(ERROR) << "Hmm.. Got RestoreInstanceStateResponse Message from unknown task_id "
                << task_id;
-    __global_protobuf_pool_release__(_message);
     return;
   }
 
   // send the checkpoint message to all downstream task ids
   stmgr_->HandleRestoreInstanceStateResponse(task_id, _message->status(),
                                              _message->checkpoint_id());
-  __global_protobuf_pool_release__(_message);
 }
 
 void InstanceServer::HandleCheckpointMarker(sp_int32 _src_task_id, sp_int32 _destination_task_id,
@@ -709,11 +703,9 @@ bool InstanceServer::SendRestoreInstanceStateRequest(sp_int32 _task_id,
   }
   Connection* conn = instance_info_[_task_id]->conn_;
   if (conn) {
-    proto::ckptmgr::RestoreInstanceStateRequest* message = nullptr;
-    message = __global_protobuf_pool_acquire__(message);
+    auto message = make_unique<proto::ckptmgr::RestoreInstanceStateRequest>();
     message->mutable_state()->CopyFrom(_state);
     SendMessage(conn, *message);
-    __global_protobuf_pool_release__(message);
     return true;
   } else {
     LOG(WARNING) << "Cannot send RestoreInstanceState Request to task "
@@ -726,11 +718,9 @@ void InstanceServer::SendStartInstanceStatefulProcessing(const std::string& _ckp
   for (auto kv : instance_info_) {
     Connection* conn = kv.second->conn_;
     if (conn) {
-      proto::ckptmgr::StartInstanceStatefulProcessing* message = nullptr;
-      message = __global_protobuf_pool_acquire__(message);
+      auto message = make_unique<proto::ckptmgr::StartInstanceStatefulProcessing>();
       message->set_checkpoint_id(_ckpt_id);
       SendMessage(conn, *message);
-      __global_protobuf_pool_release__(message);
     } else {
       LOG(WARNING) << "Cannot send StartInstanceStatefulProcessing to task "
                    << kv.first << " because it is not connected to us";

--- a/heron/stmgr/src/cpp/manager/stateful-restorer.cpp
+++ b/heron/stmgr/src/cpp/manager/stateful-restorer.cpp
@@ -53,10 +53,11 @@ const sp_string METRIC_INSTANCE_RESTORE_REQUESTS = "__instance_restore_requests"
 const sp_string METRIC_INSTANCE_RESTORE_RESPONSES = "__instance_restore_responses";
 const sp_string METRIC_INSTANCE_RESTORE_RESPONSES_IGNORED = "__instance_restore_response_ignored";
 
-StatefulRestorer::StatefulRestorer(CkptMgrClient* _ckptmgr,
-                             StMgrClientMgr* _clientmgr, TupleCache* _tuple_cache,
-                             InstanceServer* _server,
-                             common::MetricsMgrSt* _metrics_manager_client,
+StatefulRestorer::StatefulRestorer(shared_ptr<CkptMgrClient> _ckptmgr,
+                             shared_ptr<StMgrClientMgr> _clientmgr,
+                             shared_ptr<TupleCache> _tuple_cache,
+                             shared_ptr<InstanceServer> _server,
+                             shared_ptr<common::MetricsMgrSt> const& _metrics_manager_client,
                              std::function<void(proto::system::StatusCode,
                                                 std::string, sp_int64)> _restore_done_watcher) {
   ckptmgr_ = _ckptmgr;
@@ -80,7 +81,7 @@ StatefulRestorer::~StatefulRestorer() {
 
 void StatefulRestorer::StartRestore(const std::string& _checkpoint_id, sp_int64 _restore_txid,
                                     const std::unordered_set<sp_int32>& _local_taskids,
-                                    proto::system::PhysicalPlan* _pplan) {
+                                    proto::system::PhysicalPlan const& _pplan) {
   multi_count_metric_->scope(METRIC_START_RESTORE)->incr();
   if (in_progress_) {
     multi_count_metric_->scope(METRIC_START_RESTORE_IN_PROGRESS)->incr();

--- a/heron/stmgr/src/cpp/manager/stateful-restorer.h
+++ b/heron/stmgr/src/cpp/manager/stateful-restorer.h
@@ -77,10 +77,11 @@ class CkptMgrClient;
 // and in particular the recovery section.
 class StatefulRestorer {
  public:
-  explicit StatefulRestorer(CkptMgrClient* _ckptmgr,
-                            StMgrClientMgr* _clientmgr, TupleCache* _tuple_cache,
-                            InstanceServer* _server,
-                            common::MetricsMgrSt* _metrics_manager_client,
+  explicit StatefulRestorer(shared_ptr<CkptMgrClient> _ckptmgr,
+                            shared_ptr<StMgrClientMgr> _clientmgr,
+                            shared_ptr<TupleCache> _tuple_cache,
+                            shared_ptr<InstanceServer> _server,
+                            shared_ptr<common::MetricsMgrSt> const& _metrics_manager_client,
                             std::function<void(proto::system::StatusCode,
                                                std::string, sp_int64)> _restore_done_watcher);
   virtual ~StatefulRestorer();
@@ -94,7 +95,7 @@ class StatefulRestorer {
   // and the _restore_txid
   void StartRestore(const std::string& _checkpoint_id, sp_int64 _restore_txid,
                     const std::unordered_set<sp_int32>& _local_taskids,
-                    proto::system::PhysicalPlan* _pplan);
+                    proto::system::PhysicalPlan const& _pplan);
   // Called when ckptmgr client restarts
   void HandleCkptMgrRestart();
   // Called when local instance _task_id is done restoring its state at
@@ -144,11 +145,11 @@ class StatefulRestorer {
   // What are all our local taskids that we need to restore
   std::unordered_set<sp_int32> local_taskids_;
 
-  CkptMgrClient* ckptmgr_;
-  StMgrClientMgr* clientmgr_;
-  TupleCache* tuple_cache_;
-  InstanceServer* server_;
-  common::MetricsMgrSt* metrics_manager_client_;
+  shared_ptr<CkptMgrClient> ckptmgr_;
+  shared_ptr<StMgrClientMgr> clientmgr_;
+  shared_ptr<TupleCache> tuple_cache_;
+  shared_ptr<InstanceServer> server_;
+  shared_ptr<common::MetricsMgrSt> metrics_manager_client_;
 
   // Are we in the middle of a restore
   bool in_progress_;

--- a/heron/stmgr/src/cpp/manager/stmgr-client.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-client.h
@@ -41,10 +41,11 @@ class StMgrClientMgr;
 
 class StMgrClient : public Client {
  public:
-  StMgrClient(EventLoop* eventLoop, const NetworkOptions& _options, const sp_string& _topology_name,
+  StMgrClient(shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options,
+              const sp_string& _topology_name,
               const sp_string& _topology_id, const sp_string& _our_id, const sp_string& _other_id,
               StMgrClientMgr* _client_manager,
-              heron::common::MetricsMgrSt* _metrics_manager_client,
+              shared_ptr<heron::common::MetricsMgrSt> const& _metrics_manager_client,
               bool _droptuples_upon_backpressure);
   virtual ~StMgrClient();
 
@@ -62,8 +63,11 @@ class StMgrClient : public Client {
   virtual void HandleClose(NetworkErrorCode status);
 
  private:
-  void HandleHelloResponse(void*, proto::stmgr::StrMgrHelloResponse* _response, NetworkErrorCode);
-  void HandleTupleStreamMessage(proto::stmgr::TupleStreamMessage* _message);
+  void HandleHelloResponse(
+          void*,
+          unique_ptr<proto::stmgr::StrMgrHelloResponse> _response,
+          NetworkErrorCode);
+  void HandleTupleStreamMessage(unique_ptr<proto::stmgr::TupleStreamMessage> _message);
 
   void OnReConnectTimer();
   void SendHelloRequest();
@@ -80,7 +84,7 @@ class StMgrClient : public Client {
 
   StMgrClientMgr* client_manager_;
   // Metrics
-  heron::common::MetricsMgrSt* metrics_manager_client_;
+  shared_ptr<heron::common::MetricsMgrSt> metrics_manager_client_;
   shared_ptr<heron::common::MultiCountMetric> stmgr_client_metrics_;
 
   // Configs to be read

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
@@ -39,12 +39,12 @@ using std::make_shared;
 // New connections made with other stream managers.
 const sp_string METRIC_STMGR_NEW_CONNECTIONS = "__stmgr_new_connections";
 
-StMgrClientMgr::StMgrClientMgr(EventLoop* eventLoop, const sp_string& _topology_name,
-                               const sp_string& _topology_id, const sp_string& _stmgr_id,
-                               StMgr* _stream_manager,
-                               heron::common::MetricsMgrSt* _metrics_manager_client,
-                               sp_int64 _high_watermark, sp_int64 _low_watermark,
-                               bool _droptuples_upon_backpressure)
+StMgrClientMgr::StMgrClientMgr(shared_ptr<EventLoop> eventLoop, const sp_string& _topology_name,
+                             const sp_string& _topology_id, const sp_string& _stmgr_id,
+                             StMgr* _stream_manager,
+                             shared_ptr<heron::common::MetricsMgrSt> const& _metrics_manager_client,
+                             sp_int64 _high_watermark, sp_int64 _low_watermark,
+                             bool _droptuples_upon_backpressure)
     : topology_name_(_topology_name),
       topology_id_(_topology_id),
       stmgr_id_(_stmgr_id),
@@ -61,14 +61,15 @@ StMgrClientMgr::StMgrClientMgr(EventLoop* eventLoop, const sp_string& _topology_
 StMgrClientMgr::~StMgrClientMgr() {
   // This should not be called
   metrics_manager_client_->unregister_metric("__clientmgr");
+  clients_.clear();
 }
 
-void StMgrClientMgr::StartConnections(const proto::system::PhysicalPlan* _pplan) {
+void StMgrClientMgr::StartConnections(proto::system::PhysicalPlan const& _pplan) {
   // TODO(vikasr) : Currently we establish connections with all streammanagers
   // In the next iteration we might want to make it better
   std::unordered_set<sp_string> all_stmgrs;
-  for (sp_int32 i = 0; i < _pplan->stmgrs_size(); ++i) {
-    const proto::system::StMgr& s = _pplan->stmgrs(i);
+  for (sp_int32 i = 0; i < _pplan.stmgrs_size(); ++i) {
+    const proto::system::StMgr& s = _pplan.stmgrs(i);
     if (s.id() == stmgr_id_) {
       continue;  // dont want to connect to ourselves
     }
@@ -114,7 +115,7 @@ bool StMgrClientMgr::DidAnnounceBackPressure() {
   return stream_manager_->DidAnnounceBackPressure();
 }
 
-StMgrClient* StMgrClientMgr::CreateClient(const sp_string& _other_stmgr_id,
+shared_ptr<StMgrClient> StMgrClientMgr::CreateClient(const sp_string& _other_stmgr_id,
                                           const sp_string& _hostname, sp_int32 _port) {
   stmgr_clientmgr_metrics_->scope(METRIC_STMGR_NEW_CONNECTIONS)->incr();
   NetworkOptions options;
@@ -125,7 +126,7 @@ StMgrClient* StMgrClientMgr::CreateClient(const sp_string& _other_stmgr_id,
   options.set_high_watermark(high_watermark_);
   options.set_low_watermark(low_watermark_);
   options.set_socket_family(PF_INET);
-  StMgrClient* client = new StMgrClient(eventLoop_, options, topology_name_, topology_id_,
+  auto client = make_shared<StMgrClient>(eventLoop_, options, topology_name_, topology_id_,
                                         stmgr_id_, _other_stmgr_id, this, metrics_manager_client_,
                                         droptuples_upon_backpressure_);
   client->Start();

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.h
@@ -42,14 +42,15 @@ class StMgrClient;
 
 class StMgrClientMgr {
  public:
-  StMgrClientMgr(EventLoop* eventLoop, const sp_string& _topology_name,
+  StMgrClientMgr(shared_ptr<EventLoop> eventLoop, const sp_string& _topology_name,
                  const sp_string& _topology_id, const sp_string& _stmgr_id, StMgr* _stream_manager,
-                 heron::common::MetricsMgrSt* _metrics_manager_client, sp_int64 _high_watermark,
-                 sp_int64 _low_watermark, bool _droptuples_upon_backpressure);
+                 shared_ptr<heron::common::MetricsMgrSt> const& _metrics_manager_client,
+                 sp_int64 _high_watermark, sp_int64 _low_watermark,
+                 bool _droptuples_upon_backpressure);
   virtual ~StMgrClientMgr();
 
   // Start the appropriate clients based on a new physical plan
-  virtual void StartConnections(const proto::system::PhysicalPlan* _pplan);
+  virtual void StartConnections(proto::system::PhysicalPlan const& _pplan);
   // return true if we are successful in sending the message. false otherwise
   bool SendTupleStreamMessage(sp_int32 _task_id,
                               const sp_string& _stmgr_id,
@@ -78,20 +79,20 @@ class StMgrClientMgr {
   virtual bool AllStMgrClientsRegistered();
 
  private:
-  StMgrClient* CreateClient(const sp_string& _other_stmgr_id, const sp_string& _host_name,
-                            sp_int32 _port);
+  shared_ptr<StMgrClient> CreateClient(const sp_string& _other_stmgr_id,
+                            const sp_string& _host_name, sp_int32 _port);
 
   // map of stmgrid to its client
-  std::unordered_map<sp_string, StMgrClient*> clients_;
+  std::unordered_map<sp_string, shared_ptr<StMgrClient>> clients_;
 
   sp_string topology_name_;
   sp_string topology_id_;
   sp_string stmgr_id_;
-  EventLoop* eventLoop_;
+  shared_ptr<EventLoop> eventLoop_;
 
   StMgr* stream_manager_;
   // Metrics
-  heron::common::MetricsMgrSt* metrics_manager_client_;
+  shared_ptr<heron::common::MetricsMgrSt> metrics_manager_client_;
   shared_ptr<heron::common::MultiCountMetric> stmgr_clientmgr_metrics_;
 
   sp_int64 high_watermark_;

--- a/heron/stmgr/src/cpp/manager/stmgr-server.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.h
@@ -45,9 +45,10 @@ class StMgr;
 
 class StMgrServer : public Server {
  public:
-  StMgrServer(EventLoop* eventLoop, const NetworkOptions& options, const sp_string& _topology_name,
+  StMgrServer(shared_ptr<EventLoop> eventLoop, const NetworkOptions& options,
+              const sp_string& _topology_name,
               const sp_string& _topology_id, const sp_string& _stmgr_id, StMgr* _stmgr,
-              heron::common::MetricsMgrSt* _metrics_manager_client);
+              shared_ptr<heron::common::MetricsMgrSt> const& _metrics_manager_client);
   virtual ~StMgrServer();
 
   // Do back pressure
@@ -69,18 +70,19 @@ class StMgrServer : public Server {
 
   // First from other stream managers
   void HandleStMgrHelloRequest(REQID _id, Connection* _conn,
-                               proto::stmgr::StrMgrHelloRequest* _request);
-  void HandleTupleStreamMessage(Connection* _conn, proto::stmgr::TupleStreamMessage* _message);
+                               unique_ptr<proto::stmgr::StrMgrHelloRequest> _request);
+  void HandleTupleStreamMessage(Connection* _conn,
+          unique_ptr<proto::stmgr::TupleStreamMessage> _message);
 
   // Handler for DownstreamStatefulCheckpoint from a peer stmgr
   void HandleDownstreamStatefulCheckpointMessage(Connection* _conn,
-                                        proto::ckptmgr::DownstreamStatefulCheckpoint* _message);
+                                unique_ptr<proto::ckptmgr::DownstreamStatefulCheckpoint> _message);
 
   // Backpressure message from and to other stream managers
   void HandleStartBackPressureMessage(Connection* _conn,
-                                      proto::stmgr::StartBackPressureMessage* _message);
+                                      unique_ptr<proto::stmgr::StartBackPressureMessage> _message);
   void HandleStopBackPressureMessage(Connection* _conn,
-                                     proto::stmgr::StopBackPressureMessage* _message);
+                                     unique_ptr<proto::stmgr::StopBackPressureMessage> _message);
 
   // map from stmgr_id to their connection
   typedef std::unordered_map<sp_string, Connection*> StreamManagerConnectionMap;
@@ -100,7 +102,7 @@ class StMgrServer : public Server {
   StMgr* stmgr_;
 
   // Metrics
-  heron::common::MetricsMgrSt* metrics_manager_client_;
+  shared_ptr<heron::common::MetricsMgrSt> metrics_manager_client_;
   shared_ptr<heron::common::CountMetric> tuples_from_stmgrs_metrics_;
   shared_ptr<heron::common::CountMetric> ack_tuples_from_stmgrs_metrics_;
   shared_ptr<heron::common::CountMetric> fail_tuples_from_stmgrs_metrics_;

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -73,31 +73,24 @@ const sp_int64 PROCESS_METRICS_FREQUENCY = 10_s;
 const sp_int64 UPTIME_METRIC_FREQUENCY = 1_s;
 const sp_int64 TMASTER_RETRY_FREQUENCY = 10_s;
 
-StMgr::StMgr(EventLoop* eventLoop, const sp_string& _myhost, sp_int32 _data_port,
+StMgr::StMgr(shared_ptr<EventLoop> eventLoop, const sp_string& _myhost, sp_int32 _data_port,
              sp_int32 _local_data_port,
              const sp_string& _topology_name, const sp_string& _topology_id,
-             proto::api::Topology* _hydrated_topology, const sp_string& _stmgr_id,
+             shared_ptr<proto::api::Topology> _hydrated_topology, const sp_string& _stmgr_id,
              const std::vector<sp_string>& _instances, const sp_string& _zkhostport,
              const sp_string& _zkroot, sp_int32 _metricsmgr_port, sp_int32 _shell_port,
              sp_int32 _ckptmgr_port, const sp_string& _ckptmgr_id,
              sp_int64 _high_watermark, sp_int64 _low_watermark,
              const sp_string& _metricscachemgr_mode)
 
-    : pplan_(NULL),
-      topology_name_(_topology_name),
+    : topology_name_(_topology_name),
       topology_id_(_topology_id),
       stmgr_id_(_stmgr_id),
       stmgr_host_(_myhost),
       data_port_(_data_port),
       local_data_port_(_local_data_port),
       instances_(_instances),
-      stmgr_server_(NULL),
-      instance_server_(NULL),
-      clientmgr_(NULL),
-      tmaster_client_(NULL),
       eventLoop_(eventLoop),
-      xor_mgrs_(NULL),
-      tuple_cache_(NULL),
       hydrated_topology_(_hydrated_topology),
       start_time_(std::chrono::high_resolution_clock::now()),
       zkhostport_(_zkhostport),
@@ -118,7 +111,7 @@ void StMgr::Init() {
     heron::config::HeronInternalsConfigReader::Instance()
       ->GetHeronStreammgrMempoolMaxMessageNumber());
   state_mgr_ = heron::common::HeronStateMgr::MakeStateMgr(zkhostport_, zkroot_, eventLoop_, false);
-  metrics_manager_client_ = new heron::common::MetricsMgrSt(
+  metrics_manager_client_ = make_shared<heron::common::MetricsMgrSt>(
       metricsmgr_port_, metrics_export_interval_sec, eventLoop_);
   stmgr_process_metrics_ = make_shared<heron::common::MultiAssignableMetric>();
   metrics_manager_client_->register_metric(METRIC_PROCESS, stmgr_process_metrics_);
@@ -145,8 +138,8 @@ void StMgr::Init() {
   stateful_restorer_ = nullptr;
 
   // Create the client manager
-  clientmgr_ = new StMgrClientMgr(eventLoop_, topology_name_, topology_id_, stmgr_id_, this,
-                   metrics_manager_client_, high_watermark_, low_watermark_,
+  clientmgr_ = make_shared<StMgrClientMgr>(eventLoop_, topology_name_, topology_id_, stmgr_id_,
+                   this, metrics_manager_client_, high_watermark_, low_watermark_,
                    config::TopologyConfigHelper::DropTuplesUponBackpressure(*hydrated_topology_));
 
   // Create and Register Tuple cache
@@ -160,7 +153,7 @@ void StMgr::Init() {
       0);  // fire only once
 
   // Instantiate neighbour calculator. Required by stmgr server
-  neighbour_calculator_ = new NeighbourCalculator();
+  neighbour_calculator_ = make_shared<NeighbourCalculator>();
 
   // Create and start StmgrServer. The actual stmgr server port is assgined.
   StartStmgrServer();
@@ -207,20 +200,8 @@ StMgr::~StMgr() {
   metrics_manager_client_->unregister_metric(METRIC_DROPPED_DURING_RESTORE);
   metrics_manager_client_->unregister_metric(METRIC_INSTANCE_BYTES_RECEIVED);
   metrics_manager_client_->unregister_metric(METRIC_TIME_SPENT_BACK_PRESSURE_INIT);
-  delete tuple_cache_;
-  delete pplan_;
-  delete stmgr_server_;
-  delete instance_server_;
-  delete clientmgr_;
-  delete tmaster_client_;
   CleanupStreamConsumers();
   CleanupXorManagers();
-  delete hydrated_topology_;
-  delete ckptmgr_client_;
-  delete stateful_restorer_;
-  delete metrics_manager_client_;
-
-  delete neighbour_calculator_;
 }
 
 bool StMgr::DidAnnounceBackPressure() {
@@ -267,7 +248,7 @@ void StMgr::UpdateProcessMetrics(EventLoop::Status) {
 
 void StMgr::FetchTMasterLocation() {
   LOG(INFO) << "Fetching TMaster Location";
-  auto tmaster = new proto::tmaster::TMasterLocation();
+  auto tmaster = make_shared<proto::tmaster::TMasterLocation>();
 
   auto cb = [tmaster, this](proto::system::StatusCode status) {
     this->OnTMasterLocationFetch(tmaster, status);
@@ -278,7 +259,7 @@ void StMgr::FetchTMasterLocation() {
 
 void StMgr::FetchMetricsCacheLocation() {
   LOG(INFO) << "Fetching MetricsCache Location";
-  auto metricscache = new proto::tmaster::MetricsCacheLocation();
+  auto metricscache = make_shared<proto::tmaster::MetricsCacheLocation>();
 
   auto cb = [metricscache, this](proto::system::StatusCode status) {
     this->OnMetricsCacheLocationFetch(metricscache, status);
@@ -300,8 +281,8 @@ void StMgr::StartStmgrServer() {
       1_MB);
   sops.set_high_watermark(high_watermark_);
   sops.set_low_watermark(low_watermark_);
-  stmgr_server_ = new StMgrServer(eventLoop_, sops, topology_name_, topology_id_, stmgr_id_, this,
-                                  metrics_manager_client_);
+  stmgr_server_ = make_shared<StMgrServer>(eventLoop_, sops, topology_name_, topology_id_,
+                                           stmgr_id_, this, metrics_manager_client_);
 
   // start the server
   CHECK_EQ(stmgr_server_->Start(), 0);
@@ -321,8 +302,8 @@ void StMgr::StartInstanceServer() {
       1_MB);
   sops.set_high_watermark(high_watermark_);
   sops.set_low_watermark(low_watermark_);
-  instance_server_ = new InstanceServer(eventLoop_, sops, topology_name_, topology_id_, stmgr_id_,
-                     instances_, this, metrics_manager_client_,
+  instance_server_ = make_shared<InstanceServer>(eventLoop_, sops, topology_name_, topology_id_,
+                     stmgr_id_, instances_, this, metrics_manager_client_,
                      neighbour_calculator_,
                      config::TopologyConfigHelper::DropTuplesUponBackpressure(*hydrated_topology_));
 
@@ -347,13 +328,13 @@ void StMgr::CreateCheckpointMgrClient() {
                            std::placeholders::_1, std::placeholders::_2,
                            std::placeholders::_3, std::placeholders::_4);
   auto ckpt_watcher = std::bind(&StMgr::HandleCkptMgrRegistration, this);
-  ckptmgr_client_ = new CkptMgrClient(eventLoop_, client_options,
+  ckptmgr_client_ = make_shared<CkptMgrClient>(eventLoop_, client_options,
                                       topology_name_, topology_id_,
                                       ckptmgr_id_, stmgr_id_,
                                       save_watcher, get_watcher, ckpt_watcher);
 }
 
-void StMgr::CreateTMasterClient(proto::tmaster::TMasterLocation* tmasterLocation) {
+void StMgr::CreateTMasterClient(shared_ptr<proto::tmaster::TMasterLocation> tmasterLocation) {
   CHECK(!tmaster_client_);
   LOG(INFO) << "Creating Tmaster Client at " << tmasterLocation->host() << ":"
             << tmasterLocation->master_port();
@@ -367,21 +348,27 @@ void StMgr::CreateTMasterClient(proto::tmaster::TMasterLocation* tmasterLocation
       1_MB);
   master_options.set_high_watermark(high_watermark_);
   master_options.set_low_watermark(low_watermark_);
-  auto pplan_watch = [this](proto::system::PhysicalPlan* pplan) { this->NewPhysicalPlan(pplan); };
+
+  auto pplan_watch = [this](shared_ptr<proto::system::PhysicalPlan> pplan) {
+    this->NewPhysicalPlan(pplan);
+  };
+
   auto stateful_checkpoint_watch =
        [this](sp_string checkpoint_id) {
     this->InitiateStatefulCheckpoint(checkpoint_id);
   };
+
   auto restore_topology_watch =
        [this](sp_string checkpoint_id, sp_int64 restore_txid) {
     this->RestoreTopologyState(checkpoint_id, restore_txid);
   };
+
   auto start_stateful_watch =
        [this](sp_string checkpoint_id) {
     this->StartStatefulProcessing(checkpoint_id);
   };
 
-  tmaster_client_ = new TMasterClient(eventLoop_, master_options, stmgr_id_, stmgr_host_,
+  tmaster_client_ = make_shared<TMasterClient>(eventLoop_, master_options, stmgr_id_, stmgr_host_,
                                       data_port_, local_data_port_, shell_port_,
                                       std::move(pplan_watch),
                                       std::move(stateful_checkpoint_watch),
@@ -394,13 +381,13 @@ void StMgr::CreateTupleCache() {
   LOG(INFO) << "Creating tuple cache ";
   sp_uint32 drain_threshold_bytes_ =
       config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrCacheDrainSizeMb() * 1_MB;
-  tuple_cache_ = new TupleCache(eventLoop_, drain_threshold_bytes_);
+  tuple_cache_ = make_shared<TupleCache>(eventLoop_, drain_threshold_bytes_);
 
   tuple_cache_->RegisterDrainer(&StMgr::DrainInstanceData, this);
   tuple_cache_->RegisterCheckpointDrainer(&StMgr::DrainDownstreamCheckpoint, this);
 }
 
-void StMgr::HandleNewTmaster(proto::tmaster::TMasterLocation* newTmasterLocation) {
+void StMgr::HandleNewTmaster(shared_ptr<proto::tmaster::TMasterLocation> newTmasterLocation) {
   // Lets delete the existing tmaster if we have one.
   if (tmaster_client_) {
     LOG(INFO) << "Destroying existing tmasterClient";
@@ -419,20 +406,21 @@ void StMgr::HandleNewTmaster(proto::tmaster::TMasterLocation* newTmasterLocation
   }
 }
 
-void StMgr::BroadcastTmasterLocation(proto::tmaster::TMasterLocation* tmasterLocation) {
+void StMgr::BroadcastTmasterLocation(shared_ptr<proto::tmaster::TMasterLocation> tmasterLocation) {
   // Notify metrics manager of the tmaster location changes
   // TODO(vikasr): What if the refresh fails?
   metrics_manager_client_->RefreshTMasterLocation(*tmasterLocation);
 }
 
-void StMgr::BroadcastMetricsCacheLocation(proto::tmaster::MetricsCacheLocation* tmasterLocation) {
+void StMgr::BroadcastMetricsCacheLocation(
+        shared_ptr<proto::tmaster::MetricsCacheLocation> tmasterLocation) {
   // Notify metrics manager of the metricscache location changes
   // TODO(huijun): What if the refresh fails?
   LOG(INFO) << "BroadcastMetricsCacheLocation";
   metrics_manager_client_->RefreshMetricsCacheLocation(*tmasterLocation);
 }
 
-void StMgr::OnTMasterLocationFetch(proto::tmaster::TMasterLocation* newTmasterLocation,
+void StMgr::OnTMasterLocationFetch(shared_ptr<proto::tmaster::TMasterLocation> newTmasterLocation,
                                    proto::system::StatusCode _status) {
   if (_status != proto::system::OK) {
     LOG(INFO) << "TMaster Location Fetch failed with status " << _status;
@@ -481,13 +469,11 @@ void StMgr::OnTMasterLocationFetch(proto::tmaster::TMasterLocation* newTmasterLo
     // to broadcast the location, even though we know its the same tmaster.
     BroadcastTmasterLocation(newTmasterLocation);
   }
-
-  // Delete the tmasterLocation Proto
-  delete newTmasterLocation;
 }
 
-void StMgr::OnMetricsCacheLocationFetch(proto::tmaster::MetricsCacheLocation* newTmasterLocation,
-                                   proto::system::StatusCode _status) {
+void StMgr::OnMetricsCacheLocationFetch(
+                               shared_ptr<proto::tmaster::MetricsCacheLocation> newTmasterLocation,
+                               proto::system::StatusCode _status) {
   if (_status != proto::system::OK) {
     LOG(INFO) << "MetricsCache Location Fetch failed with status " << _status;
     LOG(INFO) << "Retrying after " << TMASTER_RETRY_FREQUENCY << " micro seconds ";
@@ -513,9 +499,6 @@ void StMgr::OnMetricsCacheLocationFetch(proto::tmaster::MetricsCacheLocation* ne
     // to broadcast the location, even though we know its the same metricscache.
     BroadcastMetricsCacheLocation(newTmasterLocation);
   }
-
-  // Delete the tmasterLocation Proto
-  delete newTmasterLocation;
 }
 
 // Start the tmaster client
@@ -536,7 +519,7 @@ void StMgr::StartTMasterClient() {
   }
 }
 
-void StMgr::NewPhysicalPlan(proto::system::PhysicalPlan* _pplan) {
+void StMgr::NewPhysicalPlan(shared_ptr<proto::system::PhysicalPlan> _pplan) {
   LOG(INFO) << "Received a new physical plan from tmaster";
   heron::config::TopologyConfigHelper::LogTopology(_pplan->topology());
   // first make sure that we are part of the plan ;)
@@ -563,7 +546,7 @@ void StMgr::NewPhysicalPlan(proto::system::PhysicalPlan* _pplan) {
               << _pplan->topology().state();
   }
 
-  PatchPhysicalPlanWithHydratedTopology(_pplan, hydrated_topology_);
+  PatchPhysicalPlanWithHydratedTopology(_pplan, *hydrated_topology_);
   LOG(INFO) << "Patched with hydrated topology";
   heron::config::TopologyConfigHelper::LogTopology(_pplan->topology());
 
@@ -587,14 +570,13 @@ void StMgr::NewPhysicalPlan(proto::system::PhysicalPlan* _pplan) {
                         component_to_task_ids);
   }
 
-  delete pplan_;
   pplan_ = _pplan;
   neighbour_calculator_->Reconstruct(*pplan_);
   // For effectively once topologies, we only start connecting after we have recovered
   // from a globally consistent checkpoint. The act of starting connections is initiated
   // by the restorer
   if (!stateful_restorer_) {
-    clientmgr_->StartConnections(pplan_);
+    clientmgr_->StartConnections(*pplan_);
   }
   instance_server_->BroadcastNewPhysicalPlan(*pplan_);
 
@@ -602,7 +584,7 @@ void StMgr::NewPhysicalPlan(proto::system::PhysicalPlan* _pplan) {
   if (reliability_mode_ == config::TopologyConfigVars::EFFECTIVELY_ONCE
       && ckptmgr_client_ == nullptr && stateful_restorer_ == nullptr) {
     CreateCheckpointMgrClient();
-    stateful_restorer_ = new StatefulRestorer(ckptmgr_client_, clientmgr_,
+    stateful_restorer_ = make_shared<StatefulRestorer>(ckptmgr_client_, clientmgr_,
                                tuple_cache_, instance_server_, metrics_manager_client_,
                                std::bind(&StMgr::HandleStatefulRestoreDone, this,
                                          std::placeholders::_1, std::placeholders::_2,
@@ -614,15 +596,11 @@ void StMgr::NewPhysicalPlan(proto::system::PhysicalPlan* _pplan) {
 }
 
 void StMgr::CleanupStreamConsumers() {
-  for (auto iter = stream_consumers_.begin(); iter != stream_consumers_.end(); ++iter) {
-    delete iter->second;
-  }
   stream_consumers_.clear();
 }
 
 void StMgr::CleanupXorManagers() {
-  delete xor_mgrs_;
-  xor_mgrs_ = NULL;
+  xor_mgrs_.reset();
 }
 
 sp_int32 StMgr::ExtractTopologyTimeout(const proto::api::Topology& _topology) {
@@ -668,7 +646,7 @@ void StMgr::PopulateStreamConsumers(
       CHECK(iter != _component_to_task_ids.end());
       const std::vector<sp_int32>& component_task_ids = iter->second;
       if (stream_consumers_.find(p) == stream_consumers_.end()) {
-        stream_consumers_[p] = new StreamConsumers(is, *schema, component_task_ids);
+        stream_consumers_[p] = make_unique<StreamConsumers>(is, *schema, component_task_ids);
       } else {
         stream_consumers_[p]->NewConsumer(is, *schema, component_task_ids);
       }
@@ -691,32 +669,31 @@ void StMgr::PopulateXorManagers(
                              component_task_ids.end());
     }
   }
-  xor_mgrs_ = new XorManager(eventLoop_, _message_timeout, all_spout_tasks);
+  xor_mgrs_ = make_shared<XorManager>(eventLoop_, _message_timeout, all_spout_tasks);
 }
 
-const proto::system::PhysicalPlan* StMgr::GetPhysicalPlan() const { return pplan_; }
+const shared_ptr<proto::system::PhysicalPlan> StMgr::GetPhysicalPlan() const { return pplan_; }
 
 void StMgr::HandleStreamManagerData(const sp_string&,
-                                    proto::stmgr::TupleStreamMessage* _message) {
+                                    unique_ptr<proto::stmgr::TupleStreamMessage> _message) {
   if (stateful_restorer_ && stateful_restorer_->InProgress()) {
     LOG(INFO) << "Dropping data received from stmgr because we are in Restore";
     dropped_during_restore_metrics_->scope(RESTORE_DROPPED_STMGR_BYTES)
            ->incr_by(_message->set().size());
-    __global_protobuf_pool_release__(_message);
     return;
   }
+
   // We received message from another stream manager
   sp_int32 _task_id = _message->task_id();
 
   // We have a shortcut for non-acking case
   if (!is_acking_enabled) {
-    instance_server_->SendToInstance2(_message);
+    instance_server_->SendToInstance2(std::move(_message));
   } else {
     proto::system::HeronTupleSet2* tuple_set = nullptr;
     tuple_set = __global_protobuf_pool_acquire__(tuple_set);
     tuple_set->ParsePartialFromString(_message->set());
     SendInBound(_task_id, tuple_set);
-    __global_protobuf_pool_release__(_message);
   }
 }
 
@@ -792,7 +769,7 @@ void StMgr::ProcessAcksAndFails(sp_int32 _src_task_id, sp_int32 _task_id,
 
 // Called when local tasks generate data
 void StMgr::HandleInstanceData(const sp_int32 _src_task_id, bool _local_spout,
-                               proto::system::HeronTupleSet* _message) {
+                               unique_ptr<proto::system::HeronTupleSet> _message) {
   instance_bytes_received_metrics_->scope(std::to_string(_src_task_id))
       ->incr_by(_message->ByteSize());
 
@@ -813,13 +790,13 @@ void StMgr::HandleInstanceData(const sp_int32 _src_task_id, bool _local_spout,
         make_pair(d->stream().component_name(), d->stream().id());
     auto s = stream_consumers_.find(stream);
     if (s != stream_consumers_.end()) {
-      StreamConsumers* s_consumer = s->second;
+      StreamConsumers& s_consumer = *(s->second);
       for (sp_int32 i = 0; i < d->tuples_size(); ++i) {
         proto::system::HeronDataTuple* _tuple = d->mutable_tuples(i);
         // just to make sure that instances do not set any key
         CHECK_EQ(_tuple->key(), 0);
         out_tasks_.clear();
-        s_consumer->GetListToSend(*_tuple, out_tasks_);
+        s_consumer.GetListToSend(*_tuple, out_tasks_);
         // In addition to out_tasks_, the instance might have asked
         // us to send the tuple to some more tasks
         for (sp_int32 j = 0; j < _tuple->dest_task_ids_size(); ++j) {
@@ -1100,7 +1077,7 @@ void StMgr::RestoreTopologyState(sp_string _checkpoint_id, sp_int64 _restore_txi
   // Start the restore process
   std::unordered_set<sp_int32> local_taskids;
   config::PhysicalPlanHelper::GetTasks(*pplan_, stmgr_id_, local_taskids),
-  stateful_restorer_->StartRestore(_checkpoint_id, _restore_txid, local_taskids, pplan_);
+  stateful_restorer_->StartRestore(_checkpoint_id, _restore_txid, local_taskids, *pplan_);
 }
 
 // Called by TmasterClient when it receives directive from tmaster
@@ -1136,8 +1113,8 @@ void StMgr::HandleStatefulRestoreDone(proto::system::StatusCode _status,
 // Patch new physical plan with internal hydrated topology but keep new topology data:
 // - new topology state
 // - new topology/component config
-void StMgr::PatchPhysicalPlanWithHydratedTopology(proto::system::PhysicalPlan* _pplan,
-                                                  proto::api::Topology* _topology) {
+void StMgr::PatchPhysicalPlanWithHydratedTopology(shared_ptr<proto::system::PhysicalPlan> _pplan,
+                                                  proto::api::Topology const& _topology) {
   // Back up new topology data (state and configs)
   proto::api::TopologyState st = _pplan->topology().state();
 
@@ -1155,7 +1132,7 @@ void StMgr::PatchPhysicalPlanWithHydratedTopology(proto::system::PhysicalPlan* _
 
   // Copy hydrated topology into pplan
   _pplan->clear_topology();
-  _pplan->mutable_topology()->CopyFrom(*_topology);
+  _pplan->mutable_topology()->CopyFrom(_topology);
 
   // Restore new topology data
   _pplan->mutable_topology()->set_state(st);

--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -62,10 +62,10 @@ class CkptMgrClient;
 
 class StMgr {
  public:
-  StMgr(EventLoop* eventLoop, const sp_string& _myhost, sp_int32 _data_port,
+  StMgr(shared_ptr<EventLoop> eventLoop, const sp_string& _myhost, sp_int32 _data_port,
         sp_int32 _local_data_port,
         const sp_string& _topology_name, const sp_string& _topology_id,
-        proto::api::Topology* _topology, const sp_string& _stmgr_id,
+        shared_ptr<proto::api::Topology> _topology, const sp_string& _stmgr_id,
         const std::vector<sp_string>& _instances, const sp_string& _zkhostport,
         const sp_string& _zkroot, sp_int32 _metricsmgr_port, sp_int32 _shell_port,
         sp_int32 _ckptmgr_port, const sp_string& _ckptmgr_id,
@@ -77,11 +77,11 @@ class StMgr {
   void Init();
 
   // Called by tmaster client when a new physical plan is available
-  void NewPhysicalPlan(proto::system::PhysicalPlan* pplan);
+  void NewPhysicalPlan(shared_ptr<proto::system::PhysicalPlan> pplan);
   void HandleStreamManagerData(const sp_string& _stmgr_id,
-                               proto::stmgr::TupleStreamMessage* _message);
+                               unique_ptr<proto::stmgr::TupleStreamMessage> _message);
   void HandleInstanceData(sp_int32 _task_id, bool _local_spout,
-                          proto::system::HeronTupleSet* _message);
+                          unique_ptr<proto::system::HeronTupleSet> _message);
   // Called when an instance does checkpoint and sends its checkpoint
   // to the stmgr to save it
   void HandleStoreInstanceStateCheckpoint(
@@ -92,7 +92,7 @@ class StMgr {
   void DrainDownstreamCheckpoint(sp_int32 _task_id,
                                 proto::ckptmgr::DownstreamStatefulCheckpoint* _message);
 
-  const proto::system::PhysicalPlan* GetPhysicalPlan() const;
+  const shared_ptr<proto::system::PhysicalPlan> GetPhysicalPlan() const;
 
   // Forward the call to the StmgrServer
   virtual void StartBackPressureOnServer(const sp_string& _other_stmgr_id);
@@ -124,9 +124,10 @@ class StMgr {
                                           const std::string& _checkpoint_id);
 
  private:
-  void OnTMasterLocationFetch(proto::tmaster::TMasterLocation* _tmaster, proto::system::StatusCode);
+  void OnTMasterLocationFetch(shared_ptr<proto::tmaster::TMasterLocation> _tmaster,
+          proto::system::StatusCode);
   void OnMetricsCacheLocationFetch(
-         proto::tmaster::MetricsCacheLocation* _tmaster, proto::system::StatusCode);
+         shared_ptr<proto::tmaster::MetricsCacheLocation> _tmaster, proto::system::StatusCode);
   void FetchTMasterLocation();
   void FetchMetricsCacheLocation();
   // A wrapper that calls FetchTMasterLocation. Needed for RegisterTimer
@@ -166,16 +167,17 @@ class StMgr {
 
   sp_int32 ExtractTopologyTimeout(const proto::api::Topology& _topology);
 
-  void CreateTMasterClient(proto::tmaster::TMasterLocation* tmasterLocation);
+  void CreateTMasterClient(shared_ptr<proto::tmaster::TMasterLocation> tmasterLocation);
   void StartStmgrServer();
   void StartInstanceServer();
   void CreateTupleCache();
   // This is called when we receive a valid new Tmaster Location.
   // Performs all the actions necessary to deal with new tmaster.
-  void HandleNewTmaster(proto::tmaster::TMasterLocation* newTmasterLocation);
+  void HandleNewTmaster(shared_ptr<proto::tmaster::TMasterLocation> newTmasterLocation);
   // Broadcast the tmaster location changes to other components. (MM for now)
-  void BroadcastTmasterLocation(proto::tmaster::TMasterLocation* tmasterLocation);
-  void BroadcastMetricsCacheLocation(proto::tmaster::MetricsCacheLocation* tmasterLocation);
+  void BroadcastTmasterLocation(shared_ptr<proto::tmaster::TMasterLocation> tmasterLocation);
+  void BroadcastMetricsCacheLocation(
+          shared_ptr<proto::tmaster::MetricsCacheLocation> tmasterLocation);
 
   // Called when TMaster sends a InitiateStatefulCheckpoint message with a checkpoint_id
   // This will send intiate checkpoint messages to local instances to capture their state.
@@ -198,11 +200,11 @@ class StMgr {
   // Patch new physical plan with internal hydrated topology but keep new topology data:
   // - new topology state
   // - new topology/component config
-  static void PatchPhysicalPlanWithHydratedTopology(proto::system::PhysicalPlan* _pplan,
-                                                    proto::api::Topology* _topology);
+  static void PatchPhysicalPlanWithHydratedTopology(shared_ptr<proto::system::PhysicalPlan> _pplan,
+                                                    proto::api::Topology const& _topology);
 
   shared_ptr<heron::common::HeronStateMgr> state_mgr_;
-  proto::system::PhysicalPlan* pplan_;
+  shared_ptr<proto::system::PhysicalPlan> pplan_;
   sp_string topology_name_;
   sp_string topology_id_;
   sp_string stmgr_id_;
@@ -211,36 +213,37 @@ class StMgr {
   sp_int32 local_data_port_;
   std::vector<sp_string> instances_;
   // Getting data from other streammgrs
-  StMgrServer* stmgr_server_;
+  shared_ptr<StMgrServer> stmgr_server_;
   // Used to get/send data to local instances
-  InstanceServer* instance_server_;
+  shared_ptr<InstanceServer> instance_server_;
   // Pushing data to other streammanagers
-  StMgrClientMgr* clientmgr_;
-  TMasterClient* tmaster_client_;
-  EventLoop* eventLoop_;
+  shared_ptr<StMgrClientMgr> clientmgr_;
+  shared_ptr<TMasterClient> tmaster_client_;
+  shared_ptr<EventLoop> eventLoop_;
 
   // Map of task_id to stmgr_id
   std::unordered_map<sp_int32, sp_string> task_id_to_stmgr_;
   // map of <component, streamid> to its consumers
-  std::unordered_map<std::pair<sp_string, sp_string>, StreamConsumers*> stream_consumers_;
+  std::unordered_map<std::pair<sp_string, sp_string>,
+                     unique_ptr<StreamConsumers>> stream_consumers_;
   // xor managers
-  XorManager* xor_mgrs_;
+  shared_ptr<XorManager> xor_mgrs_;
   // Tuple Cache to optimize message building
-  TupleCache* tuple_cache_;
+  shared_ptr<TupleCache> tuple_cache_;
   // Neighbour Calculator for stateful processing
-  NeighbourCalculator* neighbour_calculator_;
+  shared_ptr<NeighbourCalculator> neighbour_calculator_;
   // Stateful Restorer
-  StatefulRestorer* stateful_restorer_;
+  shared_ptr<StatefulRestorer> stateful_restorer_;
 
   // This is the topology structure
   // that contains the full component objects
-  proto::api::Topology* hydrated_topology_;
+  shared_ptr<proto::api::Topology> hydrated_topology_;
 
   // Metrics Manager
-  heron::common::MetricsMgrSt* metrics_manager_client_;
+  shared_ptr<heron::common::MetricsMgrSt> metrics_manager_client_;
 
   // Checkpoint Manager
-  CkptMgrClient* ckptmgr_client_;
+  shared_ptr<CkptMgrClient> ckptmgr_client_;
 
   // Process related metrics
   shared_ptr<heron::common::MultiAssignableMetric> stmgr_process_metrics_;

--- a/heron/stmgr/src/cpp/manager/stream-consumers.cpp
+++ b/heron/stmgr/src/cpp/manager/stream-consumers.cpp
@@ -35,21 +35,20 @@ namespace stmgr {
 StreamConsumers::StreamConsumers(const proto::api::InputStream& _is,
                                  const proto::api::StreamSchema& _schema,
                                  const std::vector<sp_int32>& _task_ids) {
-  consumers_.push_back(Grouping::Create(_is.gtype(), _is, _schema, _task_ids));
+  consumers_.push_back(std::move(Grouping::Create(_is.gtype(), _is, _schema, _task_ids)));
 }
 
 StreamConsumers::~StreamConsumers() {
   while (!consumers_.empty()) {
-    Grouping* c = consumers_.front();
+    auto c = std::move(consumers_.front());
     consumers_.pop_front();
-    delete c;
   }
 }
 
 void StreamConsumers::NewConsumer(const proto::api::InputStream& _is,
                                   const proto::api::StreamSchema& _schema,
                                   const std::vector<sp_int32>& _task_ids) {
-  consumers_.push_back(Grouping::Create(_is.gtype(), _is, _schema, _task_ids));
+  consumers_.push_back(std::move(Grouping::Create(_is.gtype(), _is, _schema, _task_ids)));
 }
 
 void StreamConsumers::GetListToSend(const proto::system::HeronDataTuple& _tuple,

--- a/heron/stmgr/src/cpp/manager/stream-consumers.h
+++ b/heron/stmgr/src/cpp/manager/stream-consumers.h
@@ -46,7 +46,7 @@ class StreamConsumers {
   void GetListToSend(const proto::system::HeronDataTuple& _tuple, std::vector<sp_int32>& _return);
 
   inline bool isShuffleGrouping() {
-    ShuffleGrouping* grouping = dynamic_cast<ShuffleGrouping *>(consumers_.front());
+      ShuffleGrouping* grouping = dynamic_cast<ShuffleGrouping*>(consumers_.front().get());
 
     if (consumers_.size() == 1 && grouping != nullptr) {
       return true;
@@ -55,7 +55,7 @@ class StreamConsumers {
   }
 
  private:
-  std::list<Grouping*> consumers_;
+  std::list<std::unique_ptr<Grouping>> consumers_;
 };
 
 }  // namespace stmgr

--- a/heron/stmgr/src/cpp/manager/tmaster-client.h
+++ b/heron/stmgr/src/cpp/manager/tmaster-client.h
@@ -31,12 +31,15 @@
 namespace heron {
 namespace stmgr {
 
+using std::shared_ptr;
+
 class TMasterClient : public Client {
  public:
-  TMasterClient(EventLoop* eventLoop, const NetworkOptions& _options, const sp_string& _stmgr_id,
+  TMasterClient(shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options,
+                const sp_string& _stmgr_id,
                 const sp_string& _stmgr_host, sp_int32 _data_port, sp_int32 _local_data_port,
                 sp_int32 _shell_port,
-                VCallback<proto::system::PhysicalPlan*> _pplan_watch,
+                VCallback<shared_ptr<proto::system::PhysicalPlan>> _pplan_watch,
                 VCallback<sp_string> _stateful_checkpoint_watch,
                 VCallback<sp_string, sp_int64> _restore_topology_watch,
                 VCallback<sp_string> _start_stateful_watch);
@@ -70,15 +73,18 @@ class TMasterClient : public Client {
   virtual void HandleClose(NetworkErrorCode status);
 
  private:
-  void HandleRegisterResponse(void*, proto::tmaster::StMgrRegisterResponse* _response,
+  void HandleRegisterResponse(void*, unique_ptr<proto::tmaster::StMgrRegisterResponse> _response,
                               NetworkErrorCode);
-  void HandleHeartbeatResponse(void*, proto::tmaster::StMgrHeartbeatResponse* response,
+  void HandleHeartbeatResponse(void*, unique_ptr<proto::tmaster::StMgrHeartbeatResponse> response,
                                NetworkErrorCode);
 
-  void HandleNewAssignmentMessage(proto::stmgr::NewPhysicalPlanMessage* _message);
-  void HandleStatefulCheckpointMessage(proto::ckptmgr::StartStatefulCheckpoint* _message);
-  void HandleRestoreTopologyStateRequest(proto::ckptmgr::RestoreTopologyStateRequest* _message);
-  void HandleStartStmgrStatefulProcessing(proto::ckptmgr::StartStmgrStatefulProcessing* _msg);
+  void HandleNewAssignmentMessage(unique_ptr<proto::stmgr::NewPhysicalPlanMessage> _message);
+  void HandleStatefulCheckpointMessage(
+                                      unique_ptr<proto::ckptmgr::StartStatefulCheckpoint> _message);
+  void HandleRestoreTopologyStateRequest(
+                                  unique_ptr<proto::ckptmgr::RestoreTopologyStateRequest> _message);
+  void HandleStartStmgrStatefulProcessing(
+                                     unique_ptr<proto::ckptmgr::StartStmgrStatefulProcessing> _msg);
 
   void OnReConnectTimer();
   void OnHeartbeatTimer();
@@ -94,11 +100,11 @@ class TMasterClient : public Client {
   sp_int32 shell_port_;
 
   // Set of instances to be reported to tmaster
-  std::set<proto::system::Instance*> instances_;
+  std::set<unique_ptr<proto::system::Instance>> instances_;
 
   bool to_die_;
   // We invoke this callback upon a new physical plan from tmaster
-  VCallback<proto::system::PhysicalPlan*> pplan_watch_;
+  VCallback<shared_ptr<proto::system::PhysicalPlan>> pplan_watch_;
   // We invoke this callback upon receiving a checkpoint message from tmaster
   // passing in the checkpoint id
   VCallback<sp_string> stateful_checkpoint_watch_;

--- a/heron/stmgr/src/cpp/util/tuple-cache.cpp
+++ b/heron/stmgr/src/cpp/util/tuple-cache.cpp
@@ -31,7 +31,7 @@
 namespace heron {
 namespace stmgr {
 
-TupleCache::TupleCache(EventLoop* eventLoop, sp_uint32 _drain_threshold)
+TupleCache::TupleCache(std::shared_ptr<EventLoop> eventLoop, sp_uint32 _drain_threshold)
     : eventLoop_(eventLoop), drain_threshold_bytes_(_drain_threshold) {
   cache_drain_frequency_ms_ =
       config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrCacheDrainFrequencyMs();

--- a/heron/stmgr/src/cpp/util/tuple-cache.h
+++ b/heron/stmgr/src/cpp/util/tuple-cache.h
@@ -34,7 +34,7 @@ class StMgr;
 
 class TupleCache {
  public:
-  TupleCache(EventLoop* eventLoop, sp_uint32 _drain_threshold);
+  TupleCache(std::shared_ptr<EventLoop> eventLoop, sp_uint32 _drain_threshold);
   virtual ~TupleCache();
 
   template <class T>
@@ -115,7 +115,7 @@ class TupleCache {
 
   // map from task_id to the TupleList
   std::unordered_map<sp_int32, TupleList*> cache_;
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
   std::function<void(sp_int32, proto::system::HeronTupleSet2*)> tuple_drainer_;
   std::function<void(sp_int32, proto::ckptmgr::DownstreamStatefulCheckpoint*)>
                                   checkpoint_drainer_;

--- a/heron/stmgr/src/cpp/util/xor-manager.cpp
+++ b/heron/stmgr/src/cpp/util/xor-manager.cpp
@@ -33,7 +33,7 @@
 namespace heron {
 namespace stmgr {
 
-XorManager::XorManager(EventLoop* eventLoop, sp_int32 _timeout,
+XorManager::XorManager(std::shared_ptr<EventLoop> eventLoop, sp_int32 _timeout,
                        const std::vector<sp_int32>& _task_ids)
     : eventLoop_(eventLoop), timeout_(_timeout) {
   n_buckets_ =
@@ -42,14 +42,12 @@ XorManager::XorManager(EventLoop* eventLoop, sp_int32 _timeout,
   eventLoop_->registerTimer([this](EventLoop::Status status) { this->rotate(status); }, false,
                             _timeout * 1000000);
   for (auto iter = _task_ids.begin(); iter != _task_ids.end(); ++iter) {
-    tasks_[*iter] = new RotatingMap(n_buckets_);
+    tasks_[*iter] = make_unique<RotatingMap>(n_buckets_);
   }
 }
 
 XorManager::~XorManager() {
-  for (auto iter = tasks_.begin(); iter != tasks_.end(); ++iter) {
-    delete iter->second;
-  }
+  tasks_.clear();
 }
 
 void XorManager::rotate(EventLoopImpl::Status) {

--- a/heron/stmgr/src/cpp/util/xor-manager.h
+++ b/heron/stmgr/src/cpp/util/xor-manager.h
@@ -33,7 +33,8 @@ class RotatingMap;
 
 class XorManager {
  public:
-  XorManager(EventLoop* eventLoop, sp_int32 _timeout, const std::vector<sp_int32>& _task_ids);
+  XorManager(std::shared_ptr<EventLoop> eventLoop, sp_int32 _timeout,
+          const std::vector<sp_int32>& _task_ids);
   virtual ~XorManager();
 
   // Create a new entry for the tuple.
@@ -61,11 +62,11 @@ class XorManager {
  private:
   void rotate(EventLoopImpl::Status _status);
 
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
   sp_int32 timeout_;
 
   // map of task_id to a RotatingMap
-  std::unordered_map<sp_int32, RotatingMap*> tasks_;
+  std::unordered_map<sp_int32, unique_ptr<RotatingMap>> tasks_;
 
   // Configs to be read
   sp_int32 n_buckets_;

--- a/heron/stmgr/tests/cpp/server/checkpoint-gateway_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/checkpoint-gateway_unittest.cpp
@@ -154,7 +154,7 @@ unique_ptr<heron::proto::system::Instance> CreateInstance(int32_t _comp, int32_t
   return imap;
 }
 
-heron::proto::system::PhysicalPlan* CreatePplan(int32_t _ncontainers,
+std::shared_ptr<heron::proto::system::PhysicalPlan> CreatePplan(int32_t _ncontainers,
                                                 int32_t _nsbcomp, int32_t _ninstances) {
   int32_t nContainers = _ncontainers;
   int32_t nSpouts = _nsbcomp;
@@ -164,7 +164,7 @@ heron::proto::system::PhysicalPlan* CreatePplan(int32_t _ncontainers,
   auto topology = GenerateDummyTopology("TestTopology", "TestTopology-12345",
                                         nSpouts, nSpoutInstances, nBolts, nBoltInstances,
                                         heron::proto::api::SHUFFLE);
-  auto pplan = new heron::proto::system::PhysicalPlan();
+  auto pplan = std::make_shared<heron::proto::system::PhysicalPlan>();
   pplan->mutable_topology()->CopyFrom(*topology);
   delete topology;
   for (int32_t i = 0; i < nContainers; ++i) {
@@ -200,6 +200,7 @@ heron::proto::system::PhysicalPlan* CreatePplan(int32_t _ncontainers,
 static std::vector<sp_int32> drainer1_tuples;
 static std::vector<sp_int32> drainer2_tuples;
 static std::vector<sp_int32> drainer3_markers;
+
 void drainer1(sp_int32 _task_id, heron::proto::system::HeronTupleSet2* _tup) {
   drainer1_tuples.push_back(_task_id);
   delete _tup;
@@ -210,9 +211,9 @@ void drainer2(heron::proto::stmgr::TupleStreamMessage* _tup) {
   delete _tup;
 }
 
-void drainer3(sp_int32 _task_id, heron::proto::ckptmgr::InitiateStatefulCheckpoint* _ckpt) {
+void drainer3(sp_int32 _task_id,
+        std::unique_ptr<heron::proto::ckptmgr::InitiateStatefulCheckpoint> _ckpt) {
   drainer3_markers.push_back(_task_id);
-  delete _ckpt;
 }
 
 // Test to make sure that without any checkpoint business, things work smoothly
@@ -220,12 +221,14 @@ TEST(CheckpointGateway, emptyckptid) {
   for (int i = 1; i < 4; ++i) {
     for (int j = 1; j < 4; ++j) {
       auto pplan = CreatePplan(2, i, j);
-      auto neighbour_calculator = new heron::stmgr::NeighbourCalculator();
+      auto neighbour_calculator = std::make_shared<heron::stmgr::NeighbourCalculator>();
       neighbour_calculator->Reconstruct(*pplan);
-      EventLoop* dummyLoop = new EventLoopImpl();
-      auto dummy_metrics_client_ = new heron::common::MetricsMgrSt(11001, 100, dummyLoop);
+      auto dummyLoop = std::make_shared<EventLoopImpl>();
+      auto dummy_metrics_client_ =
+              std::make_shared<heron::common::MetricsMgrSt>(11001, 100, dummyLoop);
       dummy_metrics_client_->Start("127.0.0.1", 11000, "_stmgr", "_stmgr");
-      auto gateway = new heron::stmgr::CheckpointGateway(1024 * 1024, neighbour_calculator,
+      auto gateway = std::make_shared<heron::stmgr::CheckpointGateway>(1024 * 1024,
+                                                         neighbour_calculator,
                                                          dummy_metrics_client_,
                                                          drainer1, drainer2, drainer3);
       int nTuples = 100;
@@ -243,17 +246,12 @@ TEST(CheckpointGateway, emptyckptid) {
       drainer1_tuples.clear();
       drainer2_tuples.clear();
       drainer3_markers.clear();
-      delete pplan;
-      delete neighbour_calculator;
-      delete gateway;
-      delete dummy_metrics_client_;
-      delete dummyLoop;
     }
   }
 }
 
 void computeTasks(const heron::proto::system::PhysicalPlan& _pplan,
-                  heron::stmgr::NeighbourCalculator* _neighbour_calculator,
+                  std::shared_ptr<heron::stmgr::NeighbourCalculator> _neighbour_calculator,
                   std::unordered_set<sp_int32>& _local_tasks,
                   std::unordered_set<sp_int32>& _local_spouts,
                   std::unordered_set<sp_int32>& _local_bolts,
@@ -276,12 +274,14 @@ TEST(CheckpointGateway, normaloperation) {
   for (int i = 1; i < 4; ++i) {
     for (int j = 1; j < 4; ++j) {
       auto pplan = CreatePplan(2, i, j);
-      auto neighbour_calculator = new heron::stmgr::NeighbourCalculator();
+      auto neighbour_calculator = std::make_shared<heron::stmgr::NeighbourCalculator>();
       neighbour_calculator->Reconstruct(*pplan);
-      EventLoop* dummyLoop = new EventLoopImpl();
-      auto dummy_metrics_client_ = new heron::common::MetricsMgrSt(11001, 100, dummyLoop);
+      auto dummyLoop = std::make_shared<EventLoopImpl>();
+      auto dummy_metrics_client_ =
+              std::make_shared<heron::common::MetricsMgrSt>(11001, 100, dummyLoop);
       dummy_metrics_client_->Start("127.0.0.1", 11000, "_stmgr", "_stmgr");
-      auto gateway = new heron::stmgr::CheckpointGateway(1024 * 1024, neighbour_calculator,
+      auto gateway = std::make_shared<heron::stmgr::CheckpointGateway>(1024 * 1024,
+                                                         neighbour_calculator,
                                                          dummy_metrics_client_,
                                                          drainer1, drainer2, drainer3);
       // We will pretend to be one of the stmgrs
@@ -351,11 +351,6 @@ TEST(CheckpointGateway, normaloperation) {
       drainer1_tuples.clear();
       drainer2_tuples.clear();
       drainer3_markers.clear();
-      delete pplan;
-      delete neighbour_calculator;
-      delete gateway;
-      delete dummy_metrics_client_;
-      delete dummyLoop;
     }
   }
 }
@@ -365,12 +360,14 @@ TEST(CheckpointGateway, overflow) {
   for (int i = 1; i < 4; ++i) {
     for (int j = 1; j < 4; ++j) {
       auto pplan = CreatePplan(2, i, j);
-      auto neighbour_calculator = new heron::stmgr::NeighbourCalculator();
+      auto neighbour_calculator = std::make_shared<heron::stmgr::NeighbourCalculator>();
       neighbour_calculator->Reconstruct(*pplan);
-      EventLoop* dummyLoop = new EventLoopImpl();
-      auto dummy_metrics_client_ = new heron::common::MetricsMgrSt(11001, 100, dummyLoop);
+      auto dummyLoop = std::make_shared<EventLoopImpl>();
+      auto dummy_metrics_client_ =
+              std::make_shared<heron::common::MetricsMgrSt>(11001, 100, dummyLoop);
       dummy_metrics_client_->Start("127.0.0.1", 11000, "_stmgr", "_stmgr");
-      auto gateway = new heron::stmgr::CheckpointGateway(1024 * 1024, neighbour_calculator,
+      auto gateway = std::make_shared<heron::stmgr::CheckpointGateway>(1024 * 1024,
+                                                         neighbour_calculator,
                                                          dummy_metrics_client_,
                                                          drainer1, drainer2, drainer3);
       // We will pretend to be one of the stmgrs
@@ -447,11 +444,6 @@ TEST(CheckpointGateway, overflow) {
       drainer1_tuples.clear();
       drainer2_tuples.clear();
       drainer3_markers.clear();
-      delete pplan;
-      delete neighbour_calculator;
-      delete gateway;
-      delete dummy_metrics_client_;
-      delete dummyLoop;
     }
   }
 }

--- a/heron/stmgr/tests/cpp/server/dummy_ckptmgr_client.cpp
+++ b/heron/stmgr/tests/cpp/server/dummy_ckptmgr_client.cpp
@@ -29,7 +29,8 @@
 #include "network/network.h"
 #include "server/dummy_ckptmgr_client.h"
 
-DummyCkptMgrClient::DummyCkptMgrClient(EventLoop* _eventLoop, const NetworkOptions& _options,
+DummyCkptMgrClient::DummyCkptMgrClient(std::shared_ptr<EventLoop> _eventLoop,
+                                       const NetworkOptions& _options,
                                        const std::string& _stmgr,
                                        heron::proto::system::PhysicalPlan* _pplan)
   : heron::stmgr::CkptMgrClient(_eventLoop, _options, _pplan->topology().name(),

--- a/heron/stmgr/tests/cpp/server/dummy_ckptmgr_client.h
+++ b/heron/stmgr/tests/cpp/server/dummy_ckptmgr_client.h
@@ -29,7 +29,7 @@
 
 class DummyCkptMgrClient : public heron::stmgr::CkptMgrClient {
  public:
-  DummyCkptMgrClient(EventLoop* eventLoop, const NetworkOptions& _options,
+  DummyCkptMgrClient(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options,
                      const std::string& _stmgr,
                      heron::proto::system::PhysicalPlan* _pplan);
 

--- a/heron/stmgr/tests/cpp/server/dummy_instance.h
+++ b/heron/stmgr/tests/cpp/server/dummy_instance.h
@@ -25,7 +25,7 @@
 
 class DummyInstance : public Client {
  public:
-  DummyInstance(EventLoopImpl* eventLoop, const NetworkOptions& _options,
+  DummyInstance(std::shared_ptr<EventLoopImpl> eventLoop, const NetworkOptions& _options,
                 const sp_string& _topology_name, const sp_string& _topology_id,
                 const sp_string& _instance_id, const sp_string& _component_name, sp_int32 _task_id,
                 sp_int32 _component_index, const sp_string& _stmgr_id);
@@ -39,13 +39,15 @@ class DummyInstance : public Client {
   void Retry() { Start(); }
 
   // Handle incoming message
-  virtual void HandleInstanceResponse(void* ctx,
-                                      heron::proto::stmgr::RegisterInstanceResponse* _message,
-                                      NetworkErrorCode status);
+  virtual void HandleInstanceResponse(
+                                void* ctx,
+                                unique_ptr<heron::proto::stmgr::RegisterInstanceResponse> _message,
+                                NetworkErrorCode status);
   // Handle incoming tuples
-  virtual void HandleTupleMessage(heron::proto::system::HeronTupleSet2* _message);
+  virtual void HandleTupleMessage(unique_ptr<heron::proto::system::HeronTupleSet2> _message);
   // Handle the instance assignment message
-  virtual void HandleNewInstanceAssignmentMsg(heron::proto::stmgr::NewInstanceAssignmentMessage*);
+  virtual void HandleNewInstanceAssignmentMsg(
+                               std::unique_ptr<heron::proto::stmgr::NewInstanceAssignmentMessage>);
 
   sp_string topology_name_;
   sp_string topology_id_;
@@ -70,7 +72,7 @@ class DummyInstance : public Client {
 
 class DummySpoutInstance : public DummyInstance {
  public:
-  DummySpoutInstance(EventLoopImpl* eventLoop, const NetworkOptions& _options,
+  DummySpoutInstance(std::shared_ptr<EventLoopImpl> eventLoop, const NetworkOptions& _options,
                      const sp_string& _topology_name, const sp_string& _topology_id,
                      const sp_string& _instance_id, const sp_string& _component_name,
                      sp_int32 _task_id, sp_int32 _component_index, const sp_string& _stmgr_id,
@@ -80,7 +82,7 @@ class DummySpoutInstance : public DummyInstance {
  protected:
   // Handle incoming message
   virtual void HandleNewInstanceAssignmentMsg(
-      heron::proto::stmgr::NewInstanceAssignmentMessage* _msg);
+      unique_ptr<heron::proto::stmgr::NewInstanceAssignmentMessage> _msg);
   void CreateAndSendTupleMessages();
   virtual void StartBackPressureConnectionCb(Connection* connection) {
     under_backpressure_ = true;
@@ -102,7 +104,7 @@ class DummySpoutInstance : public DummyInstance {
 
 class DummyBoltInstance : public DummyInstance {
  public:
-  DummyBoltInstance(EventLoopImpl* eventLoop, const NetworkOptions& _options,
+  DummyBoltInstance(std::shared_ptr<EventLoopImpl> eventLoop, const NetworkOptions& _options,
                     const sp_string& _topology_name, const sp_string& _topology_id,
                     const sp_string& _instance_id, const sp_string& _component_name,
                     sp_int32 _task_id, sp_int32 _component_index, const sp_string& _stmgr_id,
@@ -113,9 +115,9 @@ class DummyBoltInstance : public DummyInstance {
  protected:
   // Handle incoming message
   // Handle incoming tuples
-  virtual void HandleTupleMessage(heron::proto::system::HeronTupleSet2* _message);
+  virtual void HandleTupleMessage(unique_ptr<heron::proto::system::HeronTupleSet2> _message);
   virtual void HandleNewInstanceAssignmentMsg(
-      heron::proto::stmgr::NewInstanceAssignmentMessage* _msg);
+      unique_ptr<heron::proto::stmgr::NewInstanceAssignmentMessage> _msg);
 
  private:
   sp_int32 expected_msgs_to_recv_;

--- a/heron/stmgr/tests/cpp/server/dummy_instance_server.h
+++ b/heron/stmgr/tests/cpp/server/dummy_instance_server.h
@@ -30,15 +30,15 @@
 
 class DummyInstanceServer : public heron::stmgr::InstanceServer {
  public:
-  DummyInstanceServer(EventLoop* _eventLoop, const NetworkOptions& _options,
+  DummyInstanceServer(std::shared_ptr<EventLoop> _eventLoop, const NetworkOptions& _options,
                    const std::string& _stmgr,
                    heron::proto::system::PhysicalPlan* _pplan,
                    const std::vector<sp_string>& _expected_instances,
-                   heron::common::MetricsMgrSt* _metrics)
+                   std::shared_ptr<heron::common::MetricsMgrSt> const& _metrics)
   : heron::stmgr::InstanceServer(_eventLoop, _options, _pplan->topology().name(),
                               _pplan->topology().id(), _stmgr,
-                              _expected_instances, NULL, _metrics,
-                              new heron::stmgr::NeighbourCalculator(), false),
+                              _expected_instances, nullptr, _metrics,
+                              std::make_shared<heron::stmgr::NeighbourCalculator>(), false),
     pplan_(_pplan), clear_called_(false), all_instances_connected_(false),
     my_stmgr_id_(_stmgr) {
   }

--- a/heron/stmgr/tests/cpp/server/dummy_metricsmgr.cpp
+++ b/heron/stmgr/tests/cpp/server/dummy_metricsmgr.cpp
@@ -30,7 +30,7 @@
 
 #include "server/dummy_metricsmgr.h"
 ///////////////////////////// DummyMtrMgr /////////////////////////////////////////////////
-DummyMtrMgr::DummyMtrMgr(EventLoopImpl* ss, const NetworkOptions& options,
+DummyMtrMgr::DummyMtrMgr(std::shared_ptr<EventLoopImpl> ss, const NetworkOptions& options,
                          const sp_string& stmgr_id, CountDownLatch* tmasterLatch,
                          CountDownLatch* connectionCloseLatch)
     : Server(ss, options),
@@ -56,24 +56,20 @@ void DummyMtrMgr::HandleConnectionClose(Connection*, NetworkErrorCode status) {
   }
 }
 
-void DummyMtrMgr::HandleMetricPublisherRegisterRequest(
-    REQID id, Connection* conn, heron::proto::system::MetricPublisherRegisterRequest* request) {
+void DummyMtrMgr::HandleMetricPublisherRegisterRequest(REQID id, Connection* conn,
+        unique_ptr<heron::proto::system::MetricPublisherRegisterRequest> request) {
   LOG(INFO) << "Got a register request ";
   heron::proto::system::MetricPublisherRegisterResponse response;
   response.mutable_status()->set_status(heron::proto::system::OK);
   SendResponse(id, conn, response);
-  delete request;
 }
 
 void DummyMtrMgr::HandleMetricPublisherPublishMessage(
-    Connection*, heron::proto::system::MetricPublisherPublishMessage* message) {
-  delete message;
-}
+    Connection*, unique_ptr<heron::proto::system::MetricPublisherPublishMessage> message) {}
 
 void DummyMtrMgr::HandleTMasterLocationMessage(
-    Connection*, heron::proto::system::TMasterLocationRefreshMessage* message) {
+    Connection*, unique_ptr<heron::proto::system::TMasterLocationRefreshMessage> message) {
   location_ = message->release_tmaster();
-  delete message;
 
   LOG(INFO) << "Got tmaster location: " << location_->host() << ":" << location_->master_port();
 

--- a/heron/stmgr/tests/cpp/server/dummy_metricsmgr.h
+++ b/heron/stmgr/tests/cpp/server/dummy_metricsmgr.h
@@ -33,7 +33,8 @@ class TMasterLocation;
 
 class DummyMtrMgr : public Server {
  public:
-  DummyMtrMgr(EventLoopImpl* ss, const NetworkOptions& options, const sp_string& stmgr_id,
+  DummyMtrMgr(std::shared_ptr<EventLoopImpl> ss, const NetworkOptions& options,
+              const sp_string& stmgr_id,
               CountDownLatch* tmasterLatch, CountDownLatch* connectionCloseLatch);
   virtual ~DummyMtrMgr();
 
@@ -47,12 +48,12 @@ class DummyMtrMgr : public Server {
   virtual void HandleConnectionClose(Connection* connection, NetworkErrorCode status);
 
   // Handle metrics publisher request
-  virtual void HandleMetricPublisherRegisterRequest(
-      REQID _id, Connection* _conn, heron::proto::system::MetricPublisherRegisterRequest* _request);
+  virtual void HandleMetricPublisherRegisterRequest(REQID _id, Connection* _conn,
+          unique_ptr<heron::proto::system::MetricPublisherRegisterRequest> _request);
   virtual void HandleMetricPublisherPublishMessage(
-      Connection* _conn, heron::proto::system::MetricPublisherPublishMessage* _message);
+      Connection* _conn, unique_ptr<heron::proto::system::MetricPublisherPublishMessage> _message);
   virtual void HandleTMasterLocationMessage(
-      Connection*, heron::proto::system::TMasterLocationRefreshMessage* _message);
+      Connection*, unique_ptr<heron::proto::system::TMasterLocationRefreshMessage> _message);
 
  private:
   sp_string stmgr_id_expected_;

--- a/heron/stmgr/tests/cpp/server/dummy_stmgr.h
+++ b/heron/stmgr/tests/cpp/server/dummy_stmgr.h
@@ -25,7 +25,7 @@
 
 class DummyTMasterClient : public Client {
  public:
-  DummyTMasterClient(EventLoopImpl* eventLoop, const NetworkOptions& _options,
+  DummyTMasterClient(std::shared_ptr<EventLoopImpl> eventLoop, const NetworkOptions& _options,
                      const sp_string& stmgr_id, const sp_string& stmgr_host, sp_int32 stmgr_port,
                      sp_int32 shell_port,
                      const std::vector<std::shared_ptr<heron::proto::system::Instance>>& instances);
@@ -41,8 +41,10 @@ class DummyTMasterClient : public Client {
   virtual void HandleConnect(NetworkErrorCode _status);
   // Handle connection close
   virtual void HandleClose(NetworkErrorCode _status);
-  virtual void HandleRegisterResponse(void*, heron::proto::tmaster::StMgrRegisterResponse* response,
-                                      NetworkErrorCode);
+  virtual void HandleRegisterResponse(
+                                  void*,
+                                  unique_ptr<heron::proto::tmaster::StMgrRegisterResponse> response,
+                                  NetworkErrorCode);
   // Send worker request
   void CreateAndSendRegisterRequest();
 
@@ -57,7 +59,8 @@ class DummyTMasterClient : public Client {
 
 class DummyStMgr : public Server {
  public:
-  DummyStMgr(EventLoopImpl* ss, const NetworkOptions& options, const sp_string& stmgr_id,
+  DummyStMgr(std::shared_ptr<EventLoopImpl> ss, const NetworkOptions& options,
+             const sp_string& stmgr_id,
              const sp_string& stmgr_host, sp_int32 stmgr_port, const sp_string& tmaster_host,
              sp_int32 tmaster_port, sp_int32 shell_port,
              const std::vector<std::shared_ptr<heron::proto::system::Instance>>& instances);
@@ -77,11 +80,11 @@ class DummyStMgr : public Server {
 
   // Handle st mgr hello message
   virtual void HandleStMgrHelloRequest(REQID _id, Connection* _conn,
-                                       heron::proto::stmgr::StrMgrHelloRequest* _request);
+                                      unique_ptr<heron::proto::stmgr::StrMgrHelloRequest> _request);
   virtual void HandleStartBackPressureMessage(Connection*,
-                                              heron::proto::stmgr::StartBackPressureMessage*);
+                                         unique_ptr<heron::proto::stmgr::StartBackPressureMessage>);
   virtual void HandleStopBackPressureMessage(Connection*,
-                                             heron::proto::stmgr::StopBackPressureMessage*);
+                                          unique_ptr<heron::proto::stmgr::StopBackPressureMessage>);
 
  private:
   std::vector<sp_string> other_stmgrs_ids_;

--- a/heron/stmgr/tests/cpp/server/dummy_stmgr_clientmgr.h
+++ b/heron/stmgr/tests/cpp/server/dummy_stmgr_clientmgr.h
@@ -27,7 +27,8 @@
 
 class DummyStMgrClientMgr : public heron::stmgr::StMgrClientMgr {
  public:
-  DummyStMgrClientMgr(EventLoop* _eventLoop, heron::common::MetricsMgrSt* _metrics,
+  DummyStMgrClientMgr(std::shared_ptr<EventLoop> _eventLoop,
+                      std::shared_ptr<heron::common::MetricsMgrSt> const& _metrics,
                       const std::string& _stmgr,
                       heron::proto::system::PhysicalPlan* _pplan)
   : heron::stmgr::StMgrClientMgr(_eventLoop, _pplan->topology().name(),

--- a/heron/stmgr/tests/cpp/server/dummy_tuple_cache.h
+++ b/heron/stmgr/tests/cpp/server/dummy_tuple_cache.h
@@ -25,7 +25,7 @@
 
 class DummyTupleCache : public heron::stmgr::TupleCache {
  public:
-  explicit DummyTupleCache(EventLoop* _eventLoop)
+  explicit DummyTupleCache(std::shared_ptr<EventLoop> _eventLoop)
   : heron::stmgr::TupleCache(_eventLoop, 1024),
     clear_called_(false) { }
   virtual ~DummyTupleCache() { }

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -206,10 +206,10 @@ static heron::proto::system::PackingPlan* GenerateDummyPackingPlan(size_t num_st
 // Method to create the local zk state on the filesystem
 void CreateLocalStateOnFS(heron::proto::api::Topology* topology,
                           heron::proto::system::PackingPlan* packingPlan, sp_string dpath) {
-  EventLoopImpl ss;
+  auto ss = std::make_shared<EventLoopImpl>();
 
   // Write the dummy topology/tmaster location out to the local file system via the state mgr
-  heron::common::HeronLocalFileStateMgr state_mgr(dpath, &ss);
+  heron::common::HeronLocalFileStateMgr state_mgr(dpath, ss);
   state_mgr.CreateTopology(*topology, NULL);
   state_mgr.CreatePackingPlan(topology->name(), *packingPlan, NULL);
 }
@@ -247,7 +247,7 @@ void DummyTimerCb(EventLoop::Status) {
 }
 
 // Function to start the threads
-void StartServer(EventLoopImpl* ss) {
+void StartServer(std::shared_ptr<EventLoopImpl> ss) {
   // In the ss register a dummy timer. This is to make sure that the
   // exit from the loop happens timely. If there are no timers registered
   // with the select server and also no activity on any of the fds registered
@@ -256,14 +256,14 @@ void StartServer(EventLoopImpl* ss) {
   ss->loop();
 }
 
-void StartTMaster(EventLoopImpl*& ss, heron::tmaster::TMaster*& tmaster,
+void StartTMaster(std::shared_ptr<EventLoopImpl>& ss, heron::tmaster::TMaster*& tmaster,
                   std::thread*& tmaster_thread, const sp_string& zkhostportlist,
                   const sp_string& topology_name, const sp_string& topology_id,
                   const sp_string& dpath,
                   sp_int32 tmaster_port, sp_int32 tmaster_controller_port,
                   sp_int32 tmaster_stats_port, sp_int32 metrics_mgr_port,
                   sp_int32 ckptmgr_port) {
-  ss = new EventLoopImpl();
+  ss = std::make_shared<EventLoopImpl>();
   tmaster = new heron::tmaster::TMaster(zkhostportlist, topology_name, topology_id, dpath,
                                   tmaster_controller_port, tmaster_port, tmaster_stats_port,
                                   metrics_mgr_port, ckptmgr_port,
@@ -271,7 +271,8 @@ void StartTMaster(EventLoopImpl*& ss, heron::tmaster::TMaster*& tmaster,
   tmaster_thread = new std::thread(StartServer, ss);
 }
 
-void StartStMgr(EventLoopImpl*& ss, heron::stmgr::StMgr*& mgr, std::thread*& stmgr_thread,
+void StartStMgr(std::shared_ptr<EventLoopImpl>& ss, heron::stmgr::StMgr*& mgr,
+                std::thread*& stmgr_thread,
                 const sp_string& stmgr_host, sp_int32& stmgr_port, sp_int32& local_data_port,
                 const sp_string& topology_name,
                 const sp_string& topology_id, const heron::proto::api::Topology* topology,
@@ -280,10 +281,10 @@ void StartStMgr(EventLoopImpl*& ss, heron::stmgr::StMgr*& mgr, std::thread*& stm
                 sp_int32 shell_port, sp_int32 ckptmgr_port, const sp_string& ckptmgr_id,
                 sp_int64 _high_watermark, sp_int64 _low_watermark) {
   // The topology will be owned and deleted by the strmgr
-  heron::proto::api::Topology* stmgr_topology = new heron::proto::api::Topology();
+  auto stmgr_topology = std::make_shared<heron::proto::api::Topology>();
   stmgr_topology->CopyFrom(*topology);
   // Create the select server for this stmgr to use
-  ss = new EventLoopImpl();
+  ss = std::make_shared<EventLoopImpl>();
   mgr = new heron::stmgr::StMgr(ss, stmgr_host, stmgr_port, local_data_port, topology_name,
                                 topology_id,
                                 stmgr_topology, stmgr_id, workers, zkhostportlist, dpath,
@@ -298,12 +299,13 @@ void StartStMgr(EventLoopImpl*& ss, heron::stmgr::StMgr*& mgr, std::thread*& stm
   stmgr_thread = new std::thread(StartServer, ss);
 }
 
-void StartDummyStMgr(EventLoopImpl*& ss, DummyStMgr*& mgr, std::thread*& stmgr_thread,
+void StartDummyStMgr(std::shared_ptr<EventLoopImpl>& ss, DummyStMgr*& mgr,
+                     std::thread*& stmgr_thread,
                      sp_int32& stmgr_port, sp_int32 tmaster_port, sp_int32 shell_port,
                      const sp_string& stmgr_id,
                      const std::vector<shared_ptr<heron::proto::system::Instance>>& instances) {
   // Create the select server for this stmgr to use
-  ss = new EventLoopImpl();
+  ss = std::make_shared<EventLoopImpl>();
 
   NetworkOptions options;
   options.set_host(LOCALHOST);
@@ -320,11 +322,12 @@ void StartDummyStMgr(EventLoopImpl*& ss, DummyStMgr*& mgr, std::thread*& stmgr_t
   stmgr_thread = new std::thread(StartServer, ss);
 }
 
-void StartDummyMtrMgr(EventLoopImpl*& ss, DummyMtrMgr*& mgr, std::thread*& mtmgr_thread,
+void StartDummyMtrMgr(std::shared_ptr<EventLoopImpl>& ss, DummyMtrMgr*& mgr,
+                      std::thread*& mtmgr_thread,
                       sp_int32& mtmgr_port, const sp_string& stmgr_id, CountDownLatch* tmasterLatch,
                       CountDownLatch* connectionCloseLatch) {
   // Create the select server for this stmgr to use
-  ss = new EventLoopImpl();
+  ss = std::make_shared<EventLoopImpl>();
 
   NetworkOptions options;
   options.set_host(LOCALHOST);
@@ -339,7 +342,7 @@ void StartDummyMtrMgr(EventLoopImpl*& ss, DummyMtrMgr*& mgr, std::thread*& mtmgr
   mtmgr_thread = new std::thread(StartServer, ss);
 }
 
-void StartDummySpoutInstance(EventLoopImpl*& ss, DummySpoutInstance*& worker,
+void StartDummySpoutInstance(std::shared_ptr<EventLoopImpl>& ss, DummySpoutInstance*& worker,
                              std::thread*& worker_thread, sp_int32 stmgr_port,
                              const sp_string& topology_name, const sp_string& topology_id,
                              const sp_string& instance_id, const sp_string& component_name,
@@ -347,7 +350,7 @@ void StartDummySpoutInstance(EventLoopImpl*& ss, DummySpoutInstance*& worker,
                              const sp_string& stream_id, sp_int32 max_msgs_to_send,
                              bool _do_custom_grouping) {
   // Create the select server for this worker to use
-  ss = new EventLoopImpl();
+  ss = std::make_shared<EventLoopImpl>();
   // Create the network option
   NetworkOptions options;
   options.set_host(LOCALHOST);
@@ -362,14 +365,14 @@ void StartDummySpoutInstance(EventLoopImpl*& ss, DummySpoutInstance*& worker,
   worker_thread = new std::thread(StartServer, ss);
 }
 
-void StartDummyBoltInstance(EventLoopImpl*& ss, DummyBoltInstance*& worker,
+void StartDummyBoltInstance(std::shared_ptr<EventLoopImpl>& ss, DummyBoltInstance*& worker,
                             std::thread*& worker_thread, sp_int32 stmgr_port,
                             const sp_string& topology_name, const sp_string& topology_id,
                             const sp_string& instance_id, const sp_string& component_name,
                             sp_int32 task_id, sp_int32 component_index, const sp_string& stmgr_id,
                             sp_int32 expected_msgs_to_recv) {
   // Create the select server for this worker to use
-  ss = new EventLoopImpl();
+  ss = std::make_shared<EventLoopImpl>();
   // Create the network option
   NetworkOptions options;
   options.set_host(LOCALHOST);
@@ -411,7 +414,7 @@ struct CommonResources {
 
   // returns - filled in by init
   sp_string dpath_;
-  std::vector<EventLoopImpl*> ss_list_;
+  std::vector<std::shared_ptr<EventLoopImpl>> ss_list_;
   std::vector<sp_string> stmgrs_id_list_;
   heron::proto::api::Topology* topology_;
   heron::proto::system::PackingPlan* packing_plan_;
@@ -494,7 +497,7 @@ void StartTMaster(CommonResources& common) {
   }
 
   // Start the tmaster
-  EventLoopImpl* tmaster_eventLoop;
+  std::shared_ptr<EventLoopImpl> tmaster_eventLoop;
 
   StartTMaster(tmaster_eventLoop, common.tmaster_, common.tmaster_thread_, common.zkhostportlist_,
                common.topology_name_, common.topology_id_, common.dpath_,
@@ -546,7 +549,7 @@ void DistributeWorkersAcrossStmgrs(CommonResources& common) {
 void StartDummySpoutInstanceHelper(CommonResources& common, sp_int8 spout, sp_int8 spout_instance,
                                    sp_int32 num_msgs_sent_by_spout_instance) {
   // Start the spout
-  EventLoopImpl* worker_ss = NULL;
+  std::shared_ptr<EventLoopImpl> worker_ss;
   DummySpoutInstance* worker = NULL;
   std::thread* worker_thread = NULL;
   sp_string streamid = STREAM_NAME;
@@ -591,7 +594,7 @@ void StartWorkerComponents(CommonResources& common, sp_int32 num_msgs_sent_by_sp
   std::vector<std::thread*> bolt_workers_threads_list;
   for (size_t bolt = 0; bolt < common.num_bolts_; ++bolt) {
     for (size_t bolt_instance = 0; bolt_instance < common.num_bolt_instances_; ++bolt_instance) {
-      EventLoopImpl* worker_ss = NULL;
+      std::shared_ptr<EventLoopImpl> worker_ss;
       DummyBoltInstance* worker = NULL;
       std::thread* worker_thread = NULL;
       sp_string instanceid = CreateInstanceId(bolt, bolt_instance, false);
@@ -622,7 +625,7 @@ void StartWorkerComponents(CommonResources& common, sp_int32 num_msgs_sent_by_sp
 void StartStMgrs(CommonResources& common) {
   // Spawn and start the stmgrs
   for (size_t i = 0; i < common.num_stmgrs_; ++i) {
-    EventLoopImpl* stmgr_ss = NULL;
+    std::shared_ptr<EventLoopImpl> stmgr_ss;
     heron::stmgr::StMgr* mgr = NULL;
     std::thread* stmgr_thread = NULL;
 
@@ -641,7 +644,7 @@ void StartStMgrs(CommonResources& common) {
 
 void StartMetricsMgr(CommonResources& common, CountDownLatch* tmasterLatch,
                      CountDownLatch* connectionCloseLatch) {
-  EventLoopImpl* ss = NULL;
+  std::shared_ptr<EventLoopImpl> ss;
   DummyMtrMgr* mgr = NULL;
   std::thread* metrics_mgr = NULL;
   StartDummyMtrMgr(ss, mgr, metrics_mgr, common.metricsmgr_port_, "stmgr", tmasterLatch,
@@ -677,7 +680,7 @@ void TearCommonResources(CommonResources& common) {
     delete common.bolt_workers_threads_list_[w];
   }
 
-  for (size_t i = 0; i < common.ss_list_.size(); ++i) delete common.ss_list_[i];
+  common.ss_list_.clear();
 
   for (auto itr = common.instanceid_instance_.begin();
        itr != common.instanceid_instance_.end(); ++itr)
@@ -762,7 +765,8 @@ TEST(StMgr, test_pplan_decode) {
   }
 
   // Verify that the pplan was decoded properly
-  const heron::proto::system::PhysicalPlan* pplan0 = common.stmgrs_list_[0]->GetPhysicalPlan();
+  const shared_ptr<heron::proto::system::PhysicalPlan> pplan0 =
+          common.stmgrs_list_[0]->GetPhysicalPlan();
   EXPECT_EQ(pplan0->stmgrs_size(), common.num_stmgrs_);
   for (size_t i = 0; i < common.num_stmgrs_; i++) {
     EXPECT_NE(common.stmgr_ports_.end(),
@@ -921,9 +925,11 @@ TEST(StMgr, test_custom_grouping_route) {
   // threads
   common.tmaster_thread_->join();
   common.metrics_mgr_thread_->join();
+
   for (size_t i = 0; i < common.stmgrs_threads_list_.size(); ++i) {
     common.stmgrs_threads_list_[i]->join();
   }
+
   for (size_t i = 0; i < common.spout_workers_threads_list_.size(); ++i) {
     common.spout_workers_threads_list_[i]->join();
   }
@@ -936,6 +942,7 @@ TEST(StMgr, test_custom_grouping_route) {
     if (common.bolt_workers_list_[w]->get_task_id() < lowest_bolt_task_id) {
       lowest_bolt_task_id = common.bolt_workers_list_[w]->get_task_id();
     }
+
     if (common.bolt_workers_list_[w]->MsgsRecvd() != 0) {
       EXPECT_EQ(
           common.bolt_workers_list_[w]->MsgsRecvd(),
@@ -986,7 +993,7 @@ TEST(StMgr, test_back_pressure_instance) {
   DistributeWorkersAcrossStmgrs(common);
 
   // We'll start one regular stmgr and one dummy stmgr
-  EventLoopImpl* regular_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> regular_stmgr_ss;
   heron::stmgr::StMgr* regular_stmgr = NULL;
   std::thread* regular_stmgr_thread = NULL;
   StartStMgr(regular_stmgr_ss, regular_stmgr, regular_stmgr_thread, common.tmaster_host_,
@@ -998,7 +1005,7 @@ TEST(StMgr, test_back_pressure_instance) {
   common.ss_list_.push_back(regular_stmgr_ss);
 
   // Start a dummy stmgr
-  EventLoopImpl* dummy_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> dummy_stmgr_ss;
   DummyStMgr* dummy_stmgr = NULL;
 
   std::thread* dummy_stmgr_thread = NULL;
@@ -1097,7 +1104,7 @@ TEST(StMgr, test_spout_death_under_backpressure) {
   DistributeWorkersAcrossStmgrs(common);
 
   // We'll start one regular stmgr and one dummy stmgr
-  EventLoopImpl* regular_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> regular_stmgr_ss;
   heron::stmgr::StMgr* regular_stmgr = NULL;
   std::thread* regular_stmgr_thread = NULL;
   StartStMgr(regular_stmgr_ss, regular_stmgr, regular_stmgr_thread, common.tmaster_host_,
@@ -1109,7 +1116,7 @@ TEST(StMgr, test_spout_death_under_backpressure) {
   common.ss_list_.push_back(regular_stmgr_ss);
 
   // Start a dummy stmgr
-  EventLoopImpl* dummy_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> dummy_stmgr_ss;
   DummyStMgr* dummy_stmgr = NULL;
   std::thread* dummy_stmgr_thread = NULL;
   StartDummyStMgr(dummy_stmgr_ss, dummy_stmgr, dummy_stmgr_thread, common.stmgr_ports_[1],
@@ -1236,7 +1243,7 @@ TEST(StMgr, test_back_pressure_stmgr) {
   DistributeWorkersAcrossStmgrs(common);
 
   // We'll start two regular stmgrs and one dummy stmgr
-  EventLoopImpl* regular_stmgr_ss1 = NULL;
+  std::shared_ptr<EventLoopImpl> regular_stmgr_ss1;
   heron::stmgr::StMgr* regular_stmgr1 = NULL;
   std::thread* regular_stmgr_thread1 = NULL;
 
@@ -1248,7 +1255,7 @@ TEST(StMgr, test_back_pressure_stmgr) {
              common.ckptmgr_id_, common.high_watermark_, common.low_watermark_);
   common.ss_list_.push_back(regular_stmgr_ss1);
 
-  EventLoopImpl* regular_stmgr_ss2 = NULL;
+  std::shared_ptr<EventLoopImpl> regular_stmgr_ss2;
   heron::stmgr::StMgr* regular_stmgr2 = NULL;
   std::thread* regular_stmgr_thread2 = NULL;
 
@@ -1263,7 +1270,7 @@ TEST(StMgr, test_back_pressure_stmgr) {
   common.ss_list_.push_back(regular_stmgr_ss2);
 
   // Start a dummy stmgr
-  EventLoopImpl* dummy_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> dummy_stmgr_ss;
   DummyStMgr* dummy_stmgr = NULL;
   std::thread* dummy_stmgr_thread = NULL;
   StartDummyStMgr(dummy_stmgr_ss, dummy_stmgr, dummy_stmgr_thread, common.stmgr_ports_[2],
@@ -1354,7 +1361,7 @@ TEST(StMgr, test_back_pressure_stmgr_reconnect) {
   DistributeWorkersAcrossStmgrs(common);
 
   // We'll start one regular stmgr and one dummy stmgr
-  EventLoopImpl* regular_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> regular_stmgr_ss;
   heron::stmgr::StMgr* regular_stmgr = NULL;
   std::thread* regular_stmgr_thread = NULL;
   StartStMgr(regular_stmgr_ss, regular_stmgr, regular_stmgr_thread, common.tmaster_host_,
@@ -1366,7 +1373,7 @@ TEST(StMgr, test_back_pressure_stmgr_reconnect) {
   common.ss_list_.push_back(regular_stmgr_ss);
 
   // Start a dummy stmgr
-  EventLoopImpl* dummy_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> dummy_stmgr_ss;
   DummyStMgr* dummy_stmgr = NULL;
   std::thread* dummy_stmgr_thread = NULL;
   StartDummyStMgr(dummy_stmgr_ss, dummy_stmgr, dummy_stmgr_thread, common.stmgr_ports_[1],
@@ -1480,7 +1487,7 @@ TEST(StMgr, test_tmaster_restart_on_new_address) {
   DistributeWorkersAcrossStmgrs(common);
 
   // We'll start one regular stmgr and one dummy stmgr
-  EventLoopImpl* regular_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> regular_stmgr_ss;
   heron::stmgr::StMgr* regular_stmgr = NULL;
   std::thread* regular_stmgr_thread = NULL;
   StartStMgr(regular_stmgr_ss, regular_stmgr, regular_stmgr_thread, common.tmaster_host_,
@@ -1498,7 +1505,7 @@ TEST(StMgr, test_tmaster_restart_on_new_address) {
   EXPECT_EQ(static_cast<sp_uint32>(3), metricsMgrTmasterLatch->getCount());
 
   // Start a dummy stmgr
-  EventLoopImpl* dummy_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> dummy_stmgr_ss;
   DummyStMgr* dummy_stmgr = NULL;
   std::thread* dummy_stmgr_thread = NULL;
   StartDummyStMgr(dummy_stmgr_ss, dummy_stmgr, dummy_stmgr_thread, common.stmgr_ports_[1],
@@ -1628,7 +1635,7 @@ TEST(StMgr, test_tmaster_restart_on_same_address) {
   DistributeWorkersAcrossStmgrs(common);
 
   // We'll start one regular stmgr and one dummy stmgr
-  EventLoopImpl* regular_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> regular_stmgr_ss;
   heron::stmgr::StMgr* regular_stmgr = NULL;
   std::thread* regular_stmgr_thread = NULL;
   StartStMgr(regular_stmgr_ss, regular_stmgr, regular_stmgr_thread, common.tmaster_host_,
@@ -1645,7 +1652,7 @@ TEST(StMgr, test_tmaster_restart_on_same_address) {
   EXPECT_EQ(static_cast<sp_uint32>(3), metricsMgrTmasterLatch->getCount());
 
   // Start a dummy stmgr
-  EventLoopImpl* dummy_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> dummy_stmgr_ss;
   DummyStMgr* dummy_stmgr = NULL;
   std::thread* dummy_stmgr_thread = NULL;
   StartDummyStMgr(dummy_stmgr_ss, dummy_stmgr, dummy_stmgr_thread, common.stmgr_ports_[1],
@@ -1768,7 +1775,7 @@ TEST(StMgr, test_metricsmgr_reconnect) {
   StartMetricsMgr(common, metricsMgrTmasterLatch, metricsMgrConnectionCloseLatch);
 
   // lets remember this
-  EventLoopImpl* mmgr_ss = common.ss_list_.back();
+  std::shared_ptr<EventLoopImpl> mmgr_ss = common.ss_list_.back();
 
   // Start the tmaster etc.
   StartTMaster(common);
@@ -1777,7 +1784,7 @@ TEST(StMgr, test_metricsmgr_reconnect) {
   DistributeWorkersAcrossStmgrs(common);
 
   // We'll start one regular stmgr and one dummy stmgr
-  EventLoopImpl* regular_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> regular_stmgr_ss;
   heron::stmgr::StMgr* regular_stmgr = NULL;
   std::thread* regular_stmgr_thread = NULL;
   StartStMgr(regular_stmgr_ss, regular_stmgr, regular_stmgr_thread, common.tmaster_host_,
@@ -1789,7 +1796,7 @@ TEST(StMgr, test_metricsmgr_reconnect) {
   common.ss_list_.push_back(regular_stmgr_ss);
 
   // Start a dummy stmgr
-  EventLoopImpl* dummy_stmgr_ss = NULL;
+  std::shared_ptr<EventLoopImpl> dummy_stmgr_ss;
   DummyStMgr* dummy_stmgr = NULL;
   std::thread* dummy_stmgr_thread = NULL;
   StartDummyStMgr(dummy_stmgr_ss, dummy_stmgr, dummy_stmgr_thread, common.stmgr_ports_[1],

--- a/heron/stmgr/tests/cpp/util/tuple-cache_unittest.cpp
+++ b/heron/stmgr/tests/cpp/util/tuple-cache_unittest.cpp
@@ -100,14 +100,14 @@ class Drainer {
   bool ckpt_message_seen_;
 };
 
-void DoneHandler(EventLoopImpl* _ss, EventLoopImpl::Status) { _ss->loopExit(); }
+void DoneHandler(std::shared_ptr<EventLoopImpl> _ss, EventLoopImpl::Status) { _ss->loopExit(); }
 
 // Test simple data tuples drain
 TEST(TupleCache, test_simple_data_drain) {
   sp_int32 data_tuples_count = 23354;
-  EventLoopImpl ss;
+  auto ss = std::make_shared<EventLoopImpl>();
   sp_uint32 drain_threshold = 1024 * 1024;
-  heron::stmgr::TupleCache* g = new heron::stmgr::TupleCache(&ss, drain_threshold);
+  heron::stmgr::TupleCache* g = new heron::stmgr::TupleCache(ss, drain_threshold);
   std::map<sp_int32, sp_int32> data_tuples;
   data_tuples[1] = data_tuples_count;
   std::map<sp_int32, sp_int32> ack_tuples;
@@ -125,10 +125,10 @@ TEST(TupleCache, test_simple_data_drain) {
   }
 
   // 300 milliseconds second
-  auto cb = [&ss](EventLoopImpl::Status status) { DoneHandler(&ss, status); };
-  ss.registerTimer(std::move(cb), false, 300_ms);
+  auto cb = [&ss](EventLoopImpl::Status status) { DoneHandler(ss, status); };
+  ss->registerTimer(std::move(cb), false, 300_ms);
 
-  ss.loop();
+  ss->loop();
 
   EXPECT_EQ(drainer->Verify(false), true);
   delete drainer;
@@ -140,9 +140,9 @@ TEST(TupleCache, test_data_ack_fail_mix) {
   sp_int32 data_tuples_count = 23354;
   sp_int32 ack_tuples_count = 3543;
   sp_int32 fail_tuples_count = 6564;
-  EventLoopImpl ss;
+  auto ss = std::make_shared<EventLoopImpl>();
   sp_uint32 drain_threshold = 1024 * 1024;
-  heron::stmgr::TupleCache* g = new heron::stmgr::TupleCache(&ss, drain_threshold);
+  heron::stmgr::TupleCache* g = new heron::stmgr::TupleCache(ss, drain_threshold);
   std::map<sp_int32, sp_int32> data_tuples;
   data_tuples[1] = data_tuples_count;
   std::map<sp_int32, sp_int32> ack_tuples;
@@ -174,11 +174,11 @@ TEST(TupleCache, test_data_ack_fail_mix) {
     }
   }
 
-  // 300 milliseconds second
-  auto cb = [&ss](EventLoopImpl::Status status) { DoneHandler(&ss, status); };
-  ss.registerTimer(std::move(cb), false, 300000);
+  // 2000 milliseconds second
+  auto cb = [&ss](EventLoopImpl::Status status) { DoneHandler(ss, status); };
+  ss->registerTimer(std::move(cb), false, 2000000);
 
-  ss.loop();
+  ss->loop();
 
   EXPECT_EQ(drainer->Verify(false), true);
   delete drainer;
@@ -190,9 +190,9 @@ TEST(TupleCache, test_different_stream_mix) {
   sp_int32 data_tuples_count = 23354;  // make sure this is even
   sp_int32 ack_tuples_count = 3544;    // make sure this is even
   sp_int32 fail_tuples_count = 6564;   // make sure this is even
-  EventLoopImpl ss;
+  auto ss = std::make_shared<EventLoopImpl>();
   sp_uint32 drain_threshold = 1024 * 1024;
-  heron::stmgr::TupleCache* g = new heron::stmgr::TupleCache(&ss, drain_threshold);
+  heron::stmgr::TupleCache* g = new heron::stmgr::TupleCache(ss, drain_threshold);
   std::map<sp_int32, sp_int32> data_tuples;
   data_tuples[1] = data_tuples_count / 2;
   data_tuples[2] = data_tuples_count / 2;
@@ -242,11 +242,11 @@ TEST(TupleCache, test_different_stream_mix) {
     }
   }
 
-  // 400 milliseconds second
-  auto cb = [&ss](EventLoopImpl::Status status) { DoneHandler(&ss, status); };
-  ss.registerTimer(std::move(cb), false, 300000);
+  // 1000 milliseconds second
+  auto cb = [&ss](EventLoopImpl::Status status) { DoneHandler(ss, status); };
+  ss->registerTimer(std::move(cb), false, 1000000);
 
-  ss.loop();
+  ss->loop();
 
   EXPECT_EQ(drainer->Verify(false), true);
   delete drainer;
@@ -256,9 +256,9 @@ TEST(TupleCache, test_different_stream_mix) {
 // Test drain with checkpoint marker
 TEST(TupleCache, test_checkpoint_drain) {
   sp_int32 data_tuples_count = 23354;
-  EventLoopImpl ss;
+  auto ss = std::make_shared<EventLoopImpl>();
   sp_uint32 drain_threshold = 1024 * 1024;
-  heron::stmgr::TupleCache* g = new heron::stmgr::TupleCache(&ss, drain_threshold);
+  heron::stmgr::TupleCache* g = new heron::stmgr::TupleCache(ss, drain_threshold);
   std::map<sp_int32, sp_int32> data_tuples;
   data_tuples[1] = data_tuples_count;
   std::map<sp_int32, sp_int32> ack_tuples;
@@ -286,10 +286,10 @@ TEST(TupleCache, test_checkpoint_drain) {
   }
 
   // 300 milliseconds second
-  auto cb = [&ss](EventLoopImpl::Status status) { DoneHandler(&ss, status); };
-  ss.registerTimer(std::move(cb), false, 300_ms);
+  auto cb = [&ss](EventLoopImpl::Status status) { DoneHandler(ss, status); };
+  ss->registerTimer(std::move(cb), false, 300_ms);
 
-  ss.loop();
+  ss->loop();
 
   EXPECT_EQ(drainer->Verify(true), true);
   delete drainer;

--- a/heron/stmgr/tests/cpp/util/xor-manager_unittest.cpp
+++ b/heron/stmgr/tests/cpp/util/xor-manager_unittest.cpp
@@ -34,7 +34,7 @@
 sp_string heron_internals_config_filename =
     "../../../../../../../../heron/config/heron_internals.yaml";
 
-EventLoopImpl ss;
+std::shared_ptr<EventLoopImpl> ss = std::make_shared<EventLoopImpl>();
 
 void OneTimer(heron::stmgr::XorManager* _g, std::vector<sp_int64>* _task_ids,
               EventLoopImpl::Status) {
@@ -57,7 +57,7 @@ void TwoTimer(heron::stmgr::XorManager* _g, std::vector<sp_int64>* _task_ids,
   EXPECT_EQ(_g->remove(2, 1), false);
 
   delete _task_ids;
-  ss.loopExit();
+  ss->loopExit();
 }
 
 // Test the anchoring xoring logic and removes
@@ -65,7 +65,7 @@ TEST(XorManager, test_all) {
   std::vector<sp_int32> task_ids;
   task_ids.push_back(1);
   task_ids.push_back(2);
-  heron::stmgr::XorManager* g = new heron::stmgr::XorManager(&ss, 1, task_ids);
+  heron::stmgr::XorManager* g = new heron::stmgr::XorManager(ss, 1, task_ids);
 
   // Create some items
   for (sp_int32 i = 0; i < 100; ++i) {
@@ -113,7 +113,7 @@ TEST(XorManager, test_all) {
   };
 
   // register timer after 1.5 seconds to allow rotation to happen
-  ss.registerTimer(std::move(cb1), false, 1500000);
+  ss->registerTimer(std::move(cb1), false, 1500000);
 
   // Same test with too much rotation
   std::vector<sp_int64>* two_added = new std::vector<sp_int64>();
@@ -132,8 +132,8 @@ TEST(XorManager, test_all) {
 
   // register timer after 5 seconds to allow
   // multiple rotation to happen
-  ss.registerTimer(std::move(cb2), false, 4000000);
-  ss.loop();
+  ss->registerTimer(std::move(cb2), false, 4000000);
+  ss->loop();
 
   delete g;
 }

--- a/heron/tmaster/src/cpp/manager/ckptmgr-client.h
+++ b/heron/tmaster/src/cpp/manager/ckptmgr-client.h
@@ -31,7 +31,7 @@ namespace tmaster {
 
 class CkptMgrClient : public Client {
  public:
-  CkptMgrClient(EventLoop* eventLoop, const NetworkOptions& _options,
+  CkptMgrClient(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options,
                 const sp_string& _topology_name, const sp_string& _topology_id,
                 std::function<void(proto::system::StatusCode)> _clean_response_watcher);
   virtual ~CkptMgrClient();
@@ -41,14 +41,17 @@ class CkptMgrClient : public Client {
   void SendCleanStatefulCheckpointRequest(const std::string& _oldest_ckpt, bool _clean_all);
 
  protected:
-  virtual void HandleCleanStatefulCheckpointResponse(void*,
-                              proto::ckptmgr::CleanStatefulCheckpointResponse* _response,
+  virtual void HandleCleanStatefulCheckpointResponse(
+                              void*,
+                              unique_ptr<proto::ckptmgr::CleanStatefulCheckpointResponse> _response,
                               NetworkErrorCode status);
   virtual void HandleConnect(NetworkErrorCode status);
   virtual void HandleClose(NetworkErrorCode status);
 
  private:
-  void HandleTMasterRegisterResponse(void*, proto::ckptmgr::RegisterTMasterResponse *_response,
+  void HandleTMasterRegisterResponse(
+                                      void*,
+                                      unique_ptr<proto::ckptmgr::RegisterTMasterResponse>_response,
                                       NetworkErrorCode _status);
 
   void SendRegisterRequest();

--- a/heron/tmaster/src/cpp/manager/stats-interface.cpp
+++ b/heron/tmaster/src/cpp/manager/stats-interface.cpp
@@ -32,7 +32,7 @@
 namespace heron {
 namespace tmaster {
 
-StatsInterface::StatsInterface(EventLoop* eventLoop, const NetworkOptions& _options,
+StatsInterface::StatsInterface(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options,
                                shared_ptr<TMetricsCollector> _collector, TMaster* _tmaster)
     : metrics_collector_(_collector), tmaster_(_tmaster) {
   http_server_ = make_unique<HTTPServer>(eventLoop, _options);

--- a/heron/tmaster/src/cpp/manager/stats-interface.h
+++ b/heron/tmaster/src/cpp/manager/stats-interface.h
@@ -35,7 +35,7 @@ class TMaster;
 
 class StatsInterface {
  public:
-  StatsInterface(EventLoop* eventLoop, const NetworkOptions& options,
+  StatsInterface(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options,
                  shared_ptr<TMetricsCollector> _collector, TMaster* tmaster);
   virtual ~StatsInterface();
 

--- a/heron/tmaster/src/cpp/manager/tcontroller.cpp
+++ b/heron/tmaster/src/cpp/manager/tcontroller.cpp
@@ -40,7 +40,8 @@ namespace tmaster {
 /*
  * HTTP service controller.
  */
-TController::TController(EventLoop* eventLoop, const NetworkOptions& options, TMaster* tmaster)
+TController::TController(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options,
+        TMaster* tmaster)
     : tmaster_(tmaster) {
   http_server_ = make_unique<HTTPServer>(eventLoop, options);
   /*

--- a/heron/tmaster/src/cpp/manager/tcontroller.h
+++ b/heron/tmaster/src/cpp/manager/tcontroller.h
@@ -31,11 +31,13 @@
 namespace heron {
 namespace tmaster {
 
+using std::shared_ptr;
+
 class TMaster;
 
 class TController {
  public:
-  TController(EventLoop* eventLoop, const NetworkOptions& options, TMaster* tmaster);
+  TController(shared_ptr<EventLoop> eventLoop, const NetworkOptions& options, TMaster* tmaster);
   virtual ~TController();
 
   // Starts the controller

--- a/heron/tmaster/src/cpp/manager/tmaster.cpp
+++ b/heron/tmaster/src/cpp/manager/tmaster.cpp
@@ -66,7 +66,7 @@ TMaster::TMaster(const std::string& _zk_hostport, const std::string& _topology_n
                  sp_int32 _master_port, sp_int32 _stats_port, sp_int32 metricsMgrPort,
                  sp_int32 _ckptmgr_port,
                  const std::string& _metrics_sinks_yaml, const std::string& _myhost_name,
-                 EventLoop* eventLoop) {
+                 shared_ptr<EventLoop> eventLoop) {
   start_time_ = std::chrono::high_resolution_clock::now();
   zk_hostport_ = _zk_hostport;
   topdir_ = _topdir;

--- a/heron/tmaster/src/cpp/manager/tmaster.h
+++ b/heron/tmaster/src/cpp/manager/tmaster.h
@@ -60,7 +60,7 @@ class TMaster {
           sp_int32 _tmaster_controller_port, sp_int32 _master_port,
           sp_int32 _stats_port, sp_int32 metricsMgrPort, sp_int32 _ckptmgr_port,
           const std::string& metrics_sinks_yaml,
-          const std::string& _myhost_name, EventLoop* eventLoop);
+          const std::string& _myhost_name, shared_ptr<EventLoop> eventLoop);
 
   virtual ~TMaster();
 
@@ -274,7 +274,7 @@ class TMaster {
   HTTPClient* http_client_;
 
   // Copy of the EventLoop
-  EventLoop* eventLoop_;
+  shared_ptr<EventLoop> eventLoop_;
 };
 }  // namespace tmaster
 }  // namespace heron

--- a/heron/tmaster/src/cpp/manager/tmasterserver.cpp
+++ b/heron/tmaster/src/cpp/manager/tmasterserver.cpp
@@ -35,7 +35,7 @@ namespace tmaster {
 using std::unique_ptr;
 using std::shared_ptr;
 
-TMasterServer::TMasterServer(EventLoop* eventLoop, const NetworkOptions& _options,
+TMasterServer::TMasterServer(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& _options,
                              shared_ptr<TMetricsCollector> _collector, TMaster* _tmaster)
     : Server(eventLoop, _options), collector_(_collector), tmaster_(_tmaster) {
   // Install the stmgr handlers
@@ -67,43 +67,40 @@ void TMasterServer::HandleConnectionClose(Connection* _conn, NetworkErrorCode) {
 }
 
 void TMasterServer::HandleStMgrRegisterRequest(REQID _reqid, Connection* _conn,
-                                               proto::tmaster::StMgrRegisterRequest* _request) {
+                                        unique_ptr<proto::tmaster::StMgrRegisterRequest> _request) {
   unique_ptr<StMgrRegisterProcessor> processor =
-      make_unique<StMgrRegisterProcessor>(_reqid, _conn, _request, tmaster_, this);
+      make_unique<StMgrRegisterProcessor>(_reqid, _conn, std::move(_request), tmaster_, this);
   processor->Start();
 }
 
 void TMasterServer::HandleStMgrHeartbeatRequest(REQID _reqid, Connection* _conn,
-                                                proto::tmaster::StMgrHeartbeatRequest* _request) {
+                                      unique_ptr<proto::tmaster::StMgrHeartbeatRequest> _request) {
   unique_ptr<StMgrHeartbeatProcessor> processor =
-      make_unique<StMgrHeartbeatProcessor>(_reqid, _conn, _request, tmaster_, this);
+      make_unique<StMgrHeartbeatProcessor>(_reqid, _conn, std::move(_request), tmaster_, this);
   processor->Start();
 }
 
-void TMasterServer::HandleMetricsMgrStats(Connection*, proto::tmaster::PublishMetrics* _request) {
+void TMasterServer::HandleMetricsMgrStats(Connection*,
+                                          unique_ptr<proto::tmaster::PublishMetrics> _request) {
   collector_->AddMetric(*_request);
-  delete _request;
 }
 
 void TMasterServer::HandleInstanceStateStored(Connection*,
-                                              proto::ckptmgr::InstanceStateStored* _message) {
+                                         unique_ptr<proto::ckptmgr::InstanceStateStored> _message) {
   tmaster_->HandleInstanceStateStored(_message->checkpoint_id(), _message->instance());
-  __global_protobuf_pool_release__(_message);
 }
 
 void TMasterServer::HandleRestoreTopologyStateResponse(Connection* _conn,
-                                     proto::ckptmgr::RestoreTopologyStateResponse* _message) {
+                                unique_ptr<proto::ckptmgr::RestoreTopologyStateResponse> _message) {
   tmaster_->HandleRestoreTopologyStateResponse(_conn, _message->checkpoint_id(),
                                                _message->restore_txid(),
                                                _message->status().status());
-  __global_protobuf_pool_release__(_message);
 }
 
 void TMasterServer::HandleResetTopologyStateMessage(Connection* _conn,
-                                     proto::ckptmgr::ResetTopologyState* _message) {
+                                     unique_ptr<proto::ckptmgr::ResetTopologyState> _message) {
   tmaster_->ResetTopologyState(_conn, _message->dead_stmgr(),
                                _message->dead_taskid(), _message->reason());
-  __global_protobuf_pool_release__(_message);
 }
 }  // namespace tmaster
 }  // namespace heron

--- a/heron/tmaster/src/cpp/manager/tmasterserver.h
+++ b/heron/tmaster/src/cpp/manager/tmasterserver.h
@@ -36,7 +36,7 @@ class TMetricsCollector;
 
 class TMasterServer : public Server {
  public:
-  TMasterServer(EventLoop* eventLoop, const NetworkOptions& options,
+  TMasterServer(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options,
           shared_ptr<TMetricsCollector> _collector, TMaster* _tmaster);
   virtual ~TMasterServer();
 
@@ -47,21 +47,22 @@ class TMasterServer : public Server {
  private:
   // Various handlers for different requests
   void HandleStMgrRegisterRequest(REQID _id, Connection* _conn,
-                                  proto::tmaster::StMgrRegisterRequest* _request);
+                                  unique_ptr<proto::tmaster::StMgrRegisterRequest> _request);
   void HandleStMgrHeartbeatRequest(REQID _id, Connection* _conn,
-                                   proto::tmaster::StMgrHeartbeatRequest* _request);
-  void HandleMetricsMgrStats(Connection*, proto::tmaster::PublishMetrics* _request);
+                                   unique_ptr<proto::tmaster::StMgrHeartbeatRequest> _request);
+  void HandleMetricsMgrStats(Connection*, unique_ptr<proto::tmaster::PublishMetrics> _request);
 
   // Message sent by stmgr to tell tmaster that a particular checkpoint message
   // was saved. This way the tmaster can keep track of which all instances have saved their
   // state for any given checkpoint id.
-  void HandleInstanceStateStored(Connection*, proto::ckptmgr::InstanceStateStored* _message);
+  void HandleInstanceStateStored(Connection*,
+                                 unique_ptr<proto::ckptmgr::InstanceStateStored> _message);
   // Handle response from stmgr for the RestoreTopologyStateRequest
   void HandleRestoreTopologyStateResponse(Connection*,
-                                     proto::ckptmgr::RestoreTopologyStateResponse* _message);
+                                 unique_ptr<proto::ckptmgr::RestoreTopologyStateResponse> _message);
   // Stmgr can request tmaster to reset the state of the topology in case it finds any errors.
   void HandleResetTopologyStateMessage(Connection*,
-                                     proto::ckptmgr::ResetTopologyState* _message);
+                                     unique_ptr<proto::ckptmgr::ResetTopologyState> _message);
 
   // our tmaster
   shared_ptr<TMetricsCollector> collector_;

--- a/heron/tmaster/src/cpp/manager/tmetrics-collector.cpp
+++ b/heron/tmaster/src/cpp/manager/tmetrics-collector.cpp
@@ -48,7 +48,7 @@ typedef heron::proto::tmaster::PublishMetrics PublishMetrics;
 namespace heron {
 namespace tmaster {
 
-TMetricsCollector::TMetricsCollector(sp_int32 _max_interval, EventLoop* eventLoop,
+TMetricsCollector::TMetricsCollector(sp_int32 _max_interval, std::shared_ptr<EventLoop> eventLoop,
                                      const std::string& metrics_sinks_yaml)
     : max_interval_(_max_interval),
       eventLoop_(eventLoop),

--- a/heron/tmaster/src/cpp/manager/tmetrics-collector.h
+++ b/heron/tmaster/src/cpp/manager/tmetrics-collector.h
@@ -42,7 +42,7 @@ using std::shared_ptr;
 class TMetricsCollector {
  public:
   // _max_interval is how far along we keep individual metric blobs.
-  TMetricsCollector(sp_int32 _max_interval, EventLoop* eventLoop,
+  TMetricsCollector(sp_int32 _max_interval, std::shared_ptr<EventLoop> eventLoop,
                     const std::string& metrics_sinks_yaml);
 
   // Deletes all stored ComponentMetrics.
@@ -252,7 +252,7 @@ class TMetricsCollector {
   sp_int32 max_interval_;
   sp_int32 nintervals_;
   sp_int32 interval_;
-  EventLoop* eventLoop_;
+  std::shared_ptr<EventLoop> eventLoop_;
   std::string metrics_sinks_yaml_;
   std::unique_ptr<common::TMasterMetrics> tmetrics_info_;
   time_t start_time_;

--- a/heron/tmaster/src/cpp/processor/stmgr-heartbeat-processor.cpp
+++ b/heron/tmaster/src/cpp/processor/stmgr-heartbeat-processor.cpp
@@ -31,9 +31,9 @@ namespace heron {
 namespace tmaster {
 
 StMgrHeartbeatProcessor::StMgrHeartbeatProcessor(REQID reqid, Connection* conn,
-                                                 proto::tmaster::StMgrHeartbeatRequest* request,
-                                                 TMaster* tmaster, Server* server)
-    : Processor(reqid, conn, request, tmaster, server) {}
+                                         unique_ptr<proto::tmaster::StMgrHeartbeatRequest> request,
+                                         TMaster* tmaster, Server* server)
+    : Processor(reqid, conn, std::move(request), tmaster, server) {}
 
 StMgrHeartbeatProcessor::~StMgrHeartbeatProcessor() {
   // nothing to be done here
@@ -41,7 +41,7 @@ StMgrHeartbeatProcessor::~StMgrHeartbeatProcessor() {
 
 void StMgrHeartbeatProcessor::Start() {
   proto::tmaster::StMgrHeartbeatRequest* request =
-      static_cast<proto::tmaster::StMgrHeartbeatRequest*>(request_);
+      static_cast<proto::tmaster::StMgrHeartbeatRequest*>(request_.get());
 
   proto::system::Status* status = tmaster_->UpdateStMgrHeartbeat(
       GetConnection(), request->heartbeat_time(), request->release_stats());

--- a/heron/tmaster/src/cpp/processor/stmgr-heartbeat-processor.h
+++ b/heron/tmaster/src/cpp/processor/stmgr-heartbeat-processor.h
@@ -31,7 +31,8 @@ namespace tmaster {
 class StMgrHeartbeatProcessor : public Processor {
  public:
   StMgrHeartbeatProcessor(REQID _reqid, Connection* _conn,
-                          proto::tmaster::StMgrHeartbeatRequest* _request, TMaster* _tmaster,
+                          unique_ptr<proto::tmaster::StMgrHeartbeatRequest> _request,
+                          TMaster* _tmaster,
                           Server* _server);
   virtual ~StMgrHeartbeatProcessor();
 

--- a/heron/tmaster/src/cpp/processor/stmgr-register-processor.cpp
+++ b/heron/tmaster/src/cpp/processor/stmgr-register-processor.cpp
@@ -32,9 +32,9 @@ namespace heron {
 namespace tmaster {
 
 StMgrRegisterProcessor::StMgrRegisterProcessor(REQID _reqid, Connection* _conn,
-                                               proto::tmaster::StMgrRegisterRequest* _request,
-                                               TMaster* _tmaster, Server* _server)
-    : Processor(_reqid, _conn, _request, _tmaster, _server) {}
+                                         unique_ptr<proto::tmaster::StMgrRegisterRequest> _request,
+                                         TMaster* _tmaster, Server* _server)
+    : Processor(_reqid, _conn, std::move(_request), _tmaster, _server) {}
 
 StMgrRegisterProcessor::~StMgrRegisterProcessor() {
   // nothing to be done here
@@ -44,7 +44,7 @@ void StMgrRegisterProcessor::Start() {
   // We got a new stream manager registering to us
   // Get the relevant info and ask tmaster to register
   proto::tmaster::StMgrRegisterRequest* request =
-      static_cast<proto::tmaster::StMgrRegisterRequest*>(request_);
+      static_cast<proto::tmaster::StMgrRegisterRequest*>(request_.get());
   std::vector<shared_ptr<proto::system::Instance>> instances;
   for (sp_int32 i = 0; i < request->instances_size(); ++i) {
     auto instance = std::make_shared<proto::system::Instance>();

--- a/heron/tmaster/src/cpp/processor/stmgr-register-processor.h
+++ b/heron/tmaster/src/cpp/processor/stmgr-register-processor.h
@@ -31,7 +31,8 @@ namespace tmaster {
 class StMgrRegisterProcessor : public Processor {
  public:
   StMgrRegisterProcessor(REQID _reqid, Connection* _conn,
-                         proto::tmaster::StMgrRegisterRequest* _request, TMaster* _tmaster,
+                         unique_ptr<proto::tmaster::StMgrRegisterRequest> _request,
+                         TMaster* _tmaster,
                          Server* _server);
   virtual ~StMgrRegisterProcessor();
 

--- a/heron/tmaster/src/cpp/processor/tmaster-processor.cpp
+++ b/heron/tmaster/src/cpp/processor/tmaster-processor.cpp
@@ -28,11 +28,13 @@
 namespace heron {
 namespace tmaster {
 
-Processor::Processor(REQID _reqid, Connection* _conn, google::protobuf::Message* _request,
+Processor::Processor(REQID _reqid, Connection* _conn,
+                     unique_ptr<google::protobuf::Message> _request,
                      TMaster* _tmaster, Server* _server)
-    : request_(_request), tmaster_(_tmaster), server_(_server), reqid_(_reqid), conn_(_conn) {}
+    : request_(std::move(_request)), tmaster_(_tmaster), server_(_server),
+      reqid_(_reqid), conn_(_conn) {}
 
-Processor::~Processor() { delete request_; }
+Processor::~Processor() {}
 
 void Processor::SendResponse(const google::protobuf::Message& _response) {
   server_->SendResponse(reqid_, conn_, _response);

--- a/heron/tmaster/src/cpp/processor/tmaster-processor.h
+++ b/heron/tmaster/src/cpp/processor/tmaster-processor.h
@@ -31,7 +31,8 @@ class TMaster;
 
 class Processor {
  public:
-  Processor(REQID _reqid, Connection* _conn, google::protobuf::Message* _request, TMaster* _tmaster,
+  Processor(REQID _reqid, Connection* _conn, unique_ptr<google::protobuf::Message> _request,
+            TMaster* _tmaster,
             Server* _server);
   virtual ~Processor();
   virtual void Start() = 0;
@@ -40,7 +41,7 @@ class Processor {
   void SendResponse(const google::protobuf::Message& _response);
   Connection* GetConnection() { return conn_; }
   void CloseConnection();
-  google::protobuf::Message* request_;
+  unique_ptr<google::protobuf::Message> request_;
   TMaster* tmaster_;
   Server* server_;
 

--- a/heron/tmaster/src/cpp/server/tmaster-main.cpp
+++ b/heron/tmaster/src/cpp/server/tmaster-main.cpp
@@ -51,11 +51,11 @@ int main(int argc, char* argv[]) {
     FLAGS_zkhostportlist = "";
   }
 
-  EventLoopImpl ss;
+  auto ss = std::make_shared<EventLoopImpl>();
 
   // Read heron internals config from local file
   // Create the heron-internals-config-reader to read the heron internals config
-  heron::config::HeronInternalsConfigReader::Create(&ss,
+  heron::config::HeronInternalsConfigReader::Create(ss,
     FLAGS_config_file, FLAGS_override_config_file);
 
   heron::common::Initialize(argv[0], FLAGS_topology_id.c_str());
@@ -67,7 +67,7 @@ int main(int argc, char* argv[]) {
   heron::tmaster::TMaster tmaster(FLAGS_zkhostportlist, FLAGS_topology_name, FLAGS_topology_id,
                                   FLAGS_zkroot, FLAGS_controller_port, FLAGS_master_port,
                                   FLAGS_stats_port, FLAGS_metricsmgr_port,
-                                  FLAGS_ckptmgr_port, FLAGS_metrics_sinks_yaml, FLAGS_myhost, &ss);
-  ss.loop();
+                                  FLAGS_ckptmgr_port, FLAGS_metrics_sinks_yaml, FLAGS_myhost, ss);
+  ss->loop();
   return 0;
 }

--- a/heron/tmaster/tests/cpp/server/dummystmgr.h
+++ b/heron/tmaster/tests/cpp/server/dummystmgr.h
@@ -34,7 +34,8 @@ namespace testing {
 
 class DummyStMgr : public Client {
  public:
-  DummyStMgr(EventLoop* eventLoop, const NetworkOptions& options, const sp_string& stmgr_id,
+  DummyStMgr(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options,
+             const sp_string& stmgr_id,
              const sp_string& myhost, sp_int32 myport,
              const std::vector<proto::system::Instance*>& instances);
   ~DummyStMgr();
@@ -51,14 +52,16 @@ class DummyStMgr : public Client {
   virtual void HandleClose(NetworkErrorCode status);
 
  private:
-  void HandleRegisterResponse(void*, proto::tmaster::StMgrRegisterResponse* response,
+  void HandleRegisterResponse(void*, unique_ptr<proto::tmaster::StMgrRegisterResponse> response,
                               NetworkErrorCode);
-  void HandleHeartbeatResponse(void*, proto::tmaster::StMgrHeartbeatResponse* response,
+  void HandleHeartbeatResponse(void*, unique_ptr<proto::tmaster::StMgrHeartbeatResponse> response,
                                NetworkErrorCode);
-  void HandleNewAssignmentMessage(proto::stmgr::NewPhysicalPlanMessage* message);
+  void HandleNewAssignmentMessage(unique_ptr<proto::stmgr::NewPhysicalPlanMessage> message);
   void HandleNewPhysicalPlan(const proto::system::PhysicalPlan& pplan);
-  void HandleRestoreTopologyStateRequest(proto::ckptmgr::RestoreTopologyStateRequest* message);
-  void HandleStartProcessingMessage(proto::ckptmgr::StartStmgrStatefulProcessing* message);
+  void HandleRestoreTopologyStateRequest(
+                                   unique_ptr<proto::ckptmgr::RestoreTopologyStateRequest> message);
+  void HandleStartProcessingMessage(
+                                  unique_ptr<proto::ckptmgr::StartStmgrStatefulProcessing> message);
 
   void OnReConnectTimer();
   void OnHeartbeatTimer();

--- a/heron/tmaster/tests/cpp/server/dummytmaster.cpp
+++ b/heron/tmaster/tests/cpp/server/dummytmaster.cpp
@@ -32,7 +32,7 @@
 namespace heron {
 namespace testing {
 
-DummyTMaster::DummyTMaster(EventLoop* eventLoop, const NetworkOptions& options)
+DummyTMaster::DummyTMaster(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options)
   : Server(eventLoop, options) {
   InstallRequestHandler(&DummyTMaster::HandleRegisterRequest);
 }
@@ -48,11 +48,10 @@ void DummyTMaster::HandleConnectionClose(Connection* _conn, NetworkErrorCode) {
 }
 
 void DummyTMaster::HandleRegisterRequest(REQID _id, Connection* _conn,
-                                         proto::tmaster::StMgrRegisterRequest* _request) {
+                                        unique_ptr<proto::tmaster::StMgrRegisterRequest> _request) {
   std::vector<std::shared_ptr<proto::system::Instance>> instances;
   stmgrs_[_request->stmgr().id()] =
           std::make_shared<tmaster::StMgrState>(_conn, _request->stmgr(), instances, *this);
-  delete _request;
   proto::tmaster::StMgrRegisterResponse response;
   response.mutable_status()->set_status(proto::system::OK);
   SendResponse(_id, _conn, response);

--- a/heron/tmaster/tests/cpp/server/dummytmaster.h
+++ b/heron/tmaster/tests/cpp/server/dummytmaster.h
@@ -36,7 +36,7 @@ namespace testing {
 
 class DummyTMaster : public Server {
  public:
-  DummyTMaster(EventLoop* eventLoop, const NetworkOptions& options);
+  DummyTMaster(std::shared_ptr<EventLoop> eventLoop, const NetworkOptions& options);
   ~DummyTMaster();
 
   const tmaster::StMgrMap& stmgrs() const { return stmgrs_; }
@@ -47,7 +47,7 @@ class DummyTMaster : public Server {
 
  private:
   void HandleRegisterRequest(REQID _id, Connection* _conn,
-                             proto::tmaster::StMgrRegisterRequest* _request);
+                             unique_ptr<proto::tmaster::StMgrRegisterRequest> _request);
   void HandleHeartbeatRequest(REQID _id, Connection* _conn,
                               proto::tmaster::StMgrHeartbeatRequest* _request);
   tmaster::StMgrMap stmgrs_;

--- a/integration_test/src/python/test_runner/main.py
+++ b/integration_test/src/python/test_runner/main.py
@@ -33,7 +33,7 @@ from heron.common.src.python.utils import log
 # The location of default configure file
 DEFAULT_TEST_CONF_FILE = "integration_test/src/python/test_runner/resources/test.json"
 
-RETRY_ATTEMPTS = 15
+RETRY_ATTEMPTS = 25
 #seconds
 RETRY_INTERVAL = 10
 

--- a/integration_test/src/python/topology_test_runner/main.py
+++ b/integration_test/src/python/topology_test_runner/main.py
@@ -37,7 +37,7 @@ from heron.statemgrs.src.python.filestatemanager import FileStateManager
 DEFAULT_TEST_CONF_FILE = "integration_test/src/python/topology_test_runner/resources/test.json"
 
 #seconds
-RETRY_ATTEMPTS = 15
+RETRY_ATTEMPTS = 25
 RETRY_INTERVAL = 10
 WAIT_FOR_DEACTIVATION = 5
 


### PR DESCRIPTION
This PR contains the following changes:

1. Stream Manager has been migrated to mainly use smart pointers instead of manual memory management.

2. The way how we use object pool has been changed. Previously we had several places where we released objects back to the pool, but those objects were not previously acquired from the pool. This might cause memory leaks. This PR reduces the overall amount of use cases where we use pool-based allocations. Actually, now there are just three most "high load" message types (`HeronTupleSet2`, `HeronTupleSet`, `TupleStreamMessage`) left which are managed by the memory pool. And for such use cases i verified that we release back only objects which has been previously acquired from the pool. All other message types are not on the "high load" path, so i switched them back to use system memory allocator and smart pointers.

Testing.
It successfully passed unit and integration tests.
Also tested both `StreamManager` and `TMaster` on my laptop by running a `WordCountTopology` under `valgrind` within 24 hours. I haven't found any memory leaks in the `valgrind` logs.