### PR TITLE
Set to Kryo serializer when registerKryoSerialization is called

### DIFF
--- a/heron/api/src/java/org/apache/heron/api/Config.java
+++ b/heron/api/src/java/org/apache/heron/api/Config.java
@@ -480,11 +480,19 @@ public class Config extends HashMap<String, Object> {
   }
 
   public static void registerKryoSerialization(Map<String, Object> conf, Class klass) {
+    // Set to Kryo Seralizer when this function is caled. In Storm API, Kryo seralizer is
+    // the default but it is not in Heron. This implicit set could make migration easier
+    // since it is more consistent.
+    setSerializationClassName("org.apache.heron.api.serializer.KryoSerializer");
     getRegisteredKryoSerializations(conf).add(klass.getName());
   }
 
   public static void registerKryoSerialization(
       Map<String, Object> conf, Class klass, Class<? extends Serializer> serializerClass) {
+    // Set to Kryo Seralizer when this function is caled. In Storm API, Kryo seralizer is
+    // the default but it is not in Heron. This implicit set could make migration easier
+    // since it is more consistent.
+    setSerializationClassName("org.apache.heron.api.serializer.KryoSerializer");
     Map<String, String> register = new HashMap<>();
     register.put(klass.getName(), serializerClass.getName());
     getRegisteredKryoSerializations(conf).add(register);

--- a/heron/api/src/java/org/apache/heron/api/Config.java
+++ b/heron/api/src/java/org/apache/heron/api/Config.java
@@ -110,6 +110,15 @@ public class Config extends HashMap<String, Object> {
    * The serialization class that is used to serialize/deserialize tuples
    */
   public static final String TOPOLOGY_SERIALIZER_CLASSNAME = "topology.serializer.classname";
+
+  /**
+   * The serializers available for TOPOLOGY_SERIALIZER_CLASSNAME.
+   */
+  public static final String HERON_JAVA_SERIALIZER_CLASS_NAME =
+      "org.apache.heron.api.serializer.JavaSerializer";
+  public static final String HERON_KRYO_SERIALIZER_CLASS_NAME =
+      "org.apache.heron.api.serializer.KryoSerializer";
+
   /**
    * Class that specifies how to create a Kryo instance for serialization. Heron will then apply
    * topology.kryo.register. The default implementation
@@ -480,19 +489,19 @@ public class Config extends HashMap<String, Object> {
   }
 
   public static void registerKryoSerialization(Map<String, Object> conf, Class klass) {
-    // Set to Kryo Seralizer when this function is caled. In Storm API, Kryo seralizer is
+    // Set to Kryo Seralizer when this function is called. In Storm API, Kryo seralizer is
     // the default but it is not in Heron. This implicit set could make migration easier
     // since it is more consistent.
-    setSerializationClassName("org.apache.heron.api.serializer.KryoSerializer");
+    setSerializationClassName(conf, HERON_KRYO_SERIALIZER_CLASS_NAME);
     getRegisteredKryoSerializations(conf).add(klass.getName());
   }
 
   public static void registerKryoSerialization(
       Map<String, Object> conf, Class klass, Class<? extends Serializer> serializerClass) {
-    // Set to Kryo Seralizer when this function is caled. In Storm API, Kryo seralizer is
+    // Set to Kryo Seralizer when this function is called. In Storm API, Kryo seralizer is
     // the default but it is not in Heron. This implicit set could make migration easier
     // since it is more consistent.
-    setSerializationClassName("org.apache.heron.api.serializer.KryoSerializer");
+    setSerializationClassName(conf, HERON_KRYO_SERIALIZER_CLASS_NAME);
     Map<String, String> register = new HashMap<>();
     register.put(klass.getName(), serializerClass.getName());
     getRegisteredKryoSerializations(conf).add(register);


### PR DESCRIPTION
In Storm, users just need to register class serializer. Kryo is the default serializer. However in Heron, the default is Java serializer which doesn't have the functionality. I think it is more consistent to set to KryoSerializer when the registration function is called.

Another option is to set Kryo serializer as the default one. The concern is that some users might be affected by the implicit change.

I am totally open to discussion.