### PR TITLE
Disable --verbose in integration test

### DIFF
--- a/integration_test/src/python/test_runner/main.py
+++ b/integration_test/src/python/test_runner/main.py
@@ -37,6 +37,8 @@ RETRY_ATTEMPTS = 15
 #seconds
 RETRY_INTERVAL = 10
 
+VERBOSE = False               # Disable verbose by default
+
 successes = []
 failures = []
 
@@ -258,8 +260,10 @@ def submit_topology(heron_cli_path, cli_config_path, cluster, role,
   # Form the command to submit a topology.
   # Note the single quote around the arg for heron.package.core.uri.
   # This is needed to prevent shell expansion.
-  cmd = "%s submit --verbose --config-path=%s %s %s %s %s" %\
-        (heron_cli_path, cli_config_path, cluster_token(cluster, role, env),
+  cmd = "%s submit %s --config-path=%s %s %s %s %s" %\
+        (heron_cli_path, 
+        "--verbose" if VERBOSE else "",
+        cli_config_path, cluster_token(cluster, role, env),
          jar_path, classpath, args)
 
   if pkg_uri is not None:


### PR DESCRIPTION
Currently it takes quite some time to run integration tests. And the extra logs could give CI hosts unnecessary pressure.

Disabling --verbose and hoping CI to be more stable.