### PR TITLE
Bug: Read override config file in heron executor

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -1109,10 +1109,15 @@ class HeronExecutor(object):
     Receive updates to the packing plan from the statemgrs and update processes as needed.
     """
     Log.info("Start state manager watches")
+
+    with open(self.override_config_file, 'r') as stream:
+      overrides = yaml.load(stream)
+    overrides["heron.statemgr.connection.string"] = self.state_manager_connection
+
     statemgr_config = StateMgrConfig()
     statemgr_config.set_state_locations(configloader.load_state_manager_locations(
         self.cluster, state_manager_config_file=self.state_manager_config_file,
-        overrides={"heron.statemgr.connection.string": self.state_manager_connection}))
+        **overrides))
     try:
       self.state_managers = statemanagerfactory.get_all_state_managers(statemgr_config)
       for state_manager in self.state_managers:

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -1112,6 +1112,8 @@ class HeronExecutor(object):
 
     with open(self.override_config_file, 'r') as stream:
       overrides = yaml.load(stream)
+      if overrides is None:
+        overrides = dict()
     overrides["heron.statemgr.connection.string"] = self.state_manager_connection
 
     statemgr_config = StateMgrConfig()

--- a/heron/statemgrs/src/python/configloader.py
+++ b/heron/statemgrs/src/python/configloader.py
@@ -28,7 +28,7 @@ import yaml
 # pylint: disable=dangerous-default-value
 
 def load_state_manager_locations(cluster, state_manager_config_file='heron-conf/statemgr.yaml',
-                                 overrides={}):
+                                 **overrides):
   """ Reads configs to determine which state manager to use and converts them to state manager
   locations. Handles a subset of config wildcard substitution supported in the substitute method in
   org.apache.heron.spi.common.Misc.java"""
@@ -47,8 +47,7 @@ def load_state_manager_locations(cluster, state_manager_config_file='heron-conf/
   config = __replace(config, wildcards, state_manager_config_file)
 
   # merge with overrides
-  if overrides:
-    config.update(overrides)
+  config.update(overrides)
 
   # need to convert from the format in statemgr.yaml to the format that the python state managers
   # takes. first, set reasonable defaults to local


### PR DESCRIPTION
Heron executor should read config from `override.yaml` when connecting to the statemgr. More details in #3287.