### PR TITLE
Bug: Read override config in Metrics Manager

### DIFF
--- a/heron/metricscachemgr/src/java/org/apache/heron/metricscachemgr/MetricsCacheManager.java
+++ b/heron/metricscachemgr/src/java/org/apache/heron/metricscachemgr/MetricsCacheManager.java
@@ -342,7 +342,8 @@ public class MetricsCacheManager {
     LOG.info("System Config: " + systemConfig);
 
     // read sink config file
-    MetricsSinksConfig sinksConfig = new MetricsSinksConfig(metricsSinksConfigFilename);
+    MetricsSinksConfig sinksConfig = new MetricsSinksConfig(metricsSinksConfigFilename,
+                                                            overrideConfigFilename);
     LOG.info("Sinks Config: " + sinksConfig.toString());
 
     // build config from cli

--- a/heron/metricscachemgr/tests/java/org/apache/heron/metricscachemgr/metricscache/MetricsCacheTest.java
+++ b/heron/metricscachemgr/tests/java/org/apache/heron/metricscachemgr/metricscache/MetricsCacheTest.java
@@ -42,7 +42,7 @@ public class MetricsCacheTest {
     SystemConfig systemConfig = SystemConfig.newBuilder(true)
         .putAll(CONFIG_SYSTEM_PATH, true)
         .build();
-    MetricsSinksConfig sinksConfig = new MetricsSinksConfig(CONFIG_SINK_PATH);
+    MetricsSinksConfig sinksConfig = new MetricsSinksConfig(CONFIG_SINK_PATH, null);
 
     // initialize metric cache, except looper
     MetricsCache mc = new MetricsCache(systemConfig, sinksConfig, new NIOLooper());

--- a/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/MetricsManager.java
+++ b/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/MetricsManager.java
@@ -382,14 +382,15 @@ public class MetricsManager {
     LoggingHelper.addLoggingHandler(new ErrorReportLoggingHandler());
 
     LOG.info(String.format("Starting Metrics Manager for topology %s with topologyId %s with "
-            + "Metrics Manager Id %s, Merics Manager Port: %d, for cluster/role/env %s.",
+            + "Metrics Manager Id %s, Metrics Manager Port: %d, for cluster/role/env %s.",
         topologyName, topologyId, metricsmgrId, metricsPort,
         String.format("%s/%s/%s", cluster, role, environment)));
 
     LOG.info("System Config: " + systemConfig);
 
     // Populate the config
-    MetricsSinksConfig sinksConfig = new MetricsSinksConfig(metricsSinksConfigFilename);
+    MetricsSinksConfig sinksConfig = new MetricsSinksConfig(metricsSinksConfigFilename,
+                                                            overrideConfigFilename);
 
     LOG.info("Sinks Config:" + sinksConfig.toString());
 

--- a/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/MetricsSinksConfig.java
+++ b/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/MetricsSinksConfig.java
@@ -52,11 +52,13 @@ public class MetricsSinksConfig {
       Map<Object, Object> overrideConfig = (Map<Object, Object>) yaml.load(overrideStream);
 
       if (sinkConfig == null) {
-        throw new RuntimeException("Could not parse metrics-sinks config file");
+        throw new RuntimeException(
+            "Could not parse metrics-sinks config file " + metricsSinksConfigFilename);
       }
 
       if (overrideConfig == null) {
-        throw new RuntimeException("Could not parse override config file");
+        throw new RuntimeException(
+            "Could not parse override config file " + overrideConfigFilename);
       }
 
       Map<Object, Object> allConfig = new HashMap<>();

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/nomad/NomadScheduler.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/nomad/NomadScheduler.java
@@ -19,7 +19,6 @@
 
 package org.apache.heron.scheduler.nomad;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -581,8 +580,9 @@ public class NomadScheduler implements IScheduler {
   static String getPrometheusMetricsFile(Config config) {
     MetricsSinksConfig metricsSinksConfig;
     try {
-      metricsSinksConfig = new MetricsSinksConfig(Context.metricsSinksFile(config));
-    } catch (FileNotFoundException e) {
+      metricsSinksConfig = new MetricsSinksConfig(Context.metricsSinksFile(config),
+                                                  Context.overrideFile(config));
+    } catch (IOException e) {
       return null;
     }
 


### PR DESCRIPTION
The metrics manager has its own method of reading sink config, it does not use the [Config#loadConfig](https://github.com/apache/incubator-heron/blob/5ee2490c025c7684c097962cf6d25f54ead73cf4/heron/spi/src/java/org/apache/heron/spi/common/ConfigLoader.java#L61) method from the SPI. It should read `override.yaml` when reading sink config. #3287 has more details.