### PR TITLE
Add license header to new website files, update license check script …

### DIFF
--- a/scripts/release_check/README.md
+++ b/scripts/release_check/README.md
@@ -8,14 +8,14 @@ Development environment setup is required. Setup instrctuction can be found here
 
 ## Run all release checks
 ```
-sh ./scripts/release_check/full_release_check.sh
+sh ./scripts/release_check/full_release_check.sh [PATH_TO_RAT_JAR_FILE]
 ```
 
 ## Run individual release checks
 
-### To run a license check with Apache Rat. Apache Rat can be downloaded here: http://ftp.wayne.edu/apache//creadur/apache-rat-0.12/apache-rat-0.12-bin.tar.gz
+### To run a license check with Apache Rat. Apache Rat can be downloaded here: http://ftp.wayne.edu/apache/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz. Decompress it if needed.
 ```
-sh ./scripts/release_check/license_check.sh
+sh ./scripts/release_check/license_check.sh [PATH_TO_RAT_JAR_FILE]
 ```
 
 ### To compile source, into Heron release artifacts (MacOS).

--- a/scripts/release_check/full_release_check.sh
+++ b/scripts/release_check/full_release_check.sh
@@ -18,8 +18,20 @@
 
 set -o errexit
 
+if [  $# -lt 1 ]
+  then
+    echo "Usage:"
+    echo "$0 PAT_TO_APACHE_RAT_JAR"
+    echo ""
+    echo "Note: Apache Rat package can be downloaded from:"
+    echo "  http://ftp.wayne.edu/apache/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz"
+    exit 1
+  fi
+
+RAT_JAR_PATH=$1
+
 echo "Check licenses..."
-sh ./scripts/release_check/license_check.sh
+sh ./scripts/release_check/license_check.sh $RAT_JAR_PATH
 
 echo "Build artifacts..."
 sh ./scripts/release_check/build.sh

--- a/scripts/release_check/license_check.sh
+++ b/scripts/release_check/license_check.sh
@@ -19,11 +19,21 @@
 set -o errexit
 
 # Assuming Apache Rat is downloaded and extracted to:
-#   ~/Downloads/apache-rat-0.12/apache-rat-0.12.jar.
+#   ~/Downloads/apache-rat-0.13/apache-rat-0.13.jar.
 # Apache Rat can be downloaded fromm this link:
-#   http://ftp.wayne.edu/apache//creadur/apache-rat-0.12/apache-rat-0.12-bin.tar.gz
-RAT_PATH=~/Downloads/apache-rat-0.12/apache-rat-0.12.jar
+#   http://ftp.wayne.edu/apache/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz
+if [  $# -lt 1 ]
+  then
+    echo "Usage:"
+    echo "$0 PAT_TO_APACHE_RAT_JAR"
+    echo ""
+    echo "Note: Apache Rat package can be downloaded from:"
+    echo "  http://ftp.wayne.edu/apache/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz"
+    exit 1
+  fi
+
+RAT_JAR_PATH=$1
 
 echo "Looking for Rat jar"
-ls $RAT_PATH
-java -jar $RAT_PATH . -E .rat-excludes
+ls $RAT_JAR_PATH
+java -jar $RAT_JAR_PATH . -E .rat-excludes

--- a/website2/Dockerfile
+++ b/website2/Dockerfile
@@ -1,3 +1,19 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
 FROM node:8.11.4
 
 WORKDIR /app/website

--- a/website2/docker-compose.yml
+++ b/website2/docker-compose.yml
@@ -1,3 +1,20 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
 version: "3"
 
 services:


### PR DESCRIPTION
The previous release has been removed from Apache Rat project and changed to 0.13.

- Updated the Apache Rat version
- Update scripts and doc to take a path to the Rat jar file instead of hard coded path
- Add license header to two new files to pass the license check.
