### PR TITLE
Annotate 3rd party and UI libraries in rat excludes with licenses

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -16,8 +16,9 @@ heron\.iml
 # Directories
 bazel-.*
 m4
-website
 META-INF
+# website and website2 are not part of the release
+website
 
 # UI resources
 # Apache 2.0 licenses & MIT Licenses

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -13,28 +13,39 @@ autogen\.sh
 description
 heron\.iml
 
-# UI resources
-jquery.*\.js
-bootstrap\.min\.css
-glyphicons-halflings-regular\.svg
-bootstrap\.min\.js
-d3.*\.js
-html5-trunk\.js
-list\.min.*.js
-moment\.min.*\.js
-underscore-min.*\.js
-underscore-min.*\.map
-
 # Directories
 bazel-.*
 m4
 website
 META-INF
 
-# Thirdparty
-cpplint\.py
-kashmir
-semver
+# UI resources
+# Apache 2.0 licenses & MIT Licenses
+jquery.*\.js
+# Apache 2.0 licenses & MIT Licenses
+bootstrap\.min\.css
+bootstrap\.min\.js
+# MIT licenses
+glyphicons-halflings-regular\.svg
+# MIT licenses & BSD 3-Clause licenses
+d3.*\.js
+# MIT licenses
+html5-trunk\.js
+# MIT licenses
+list\.min.*.js
+# MIT licenses
+moment\.min.*\.js
+# MIT licenses
+underscore-min.*\.js
+underscore-min.*\.map
 
-# Unrecognizable license
+
+# Thirdparty
+# 3-Clause BSD License
+cpplint\.py
+# BSD 3-Clause licenses
 cloudpickle.py
+# Boost Software License, Version 1.0
+kashmir
+# BSD License
+semver


### PR DESCRIPTION
For issue https://github.com/apache/incubator-heron/issues/3305

license check passes:

sh ./scripts/release_check/license_check.sh ~/Downloads/apache-rat-0.12/apache-rat-0.12.jar