### PR TITLE
Flip buffers using helper method

### DIFF
--- a/heron/common/src/java/org/apache/heron/common/network/BufferHelper.java
+++ b/heron/common/src/java/org/apache/heron/common/network/BufferHelper.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.common.network;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+
+/**
+ * Helper methods for working with {@link Buffer} objects.
+ */
+public class BufferHelper {
+
+  /**
+   * Flip the provided buffer.
+   * <p>
+   * This wrapper around {@link Buffer#flip()} is required because of
+   * incompatible ABI changes between Java 8 and 11. In Java 8, {@link ByteBuffer#flip()} returns
+   * a {@link Buffer}, whereas in Java 11, this method returns a {@link ByteBuffer}.
+   * <p>
+   * If this function is used, any object of {@link Buffer} (and subclasses) are first cast to
+   * {@link Buffer} objects, then flipped, thus avoiding the binary incompatibility.
+   *
+   * @param buffer The buffer to flip
+   */
+  static void flip(Buffer buffer) {
+    buffer.flip();
+  }
+}

--- a/heron/common/src/java/org/apache/heron/common/network/BufferHelper.java
+++ b/heron/common/src/java/org/apache/heron/common/network/BufferHelper.java
@@ -27,6 +27,9 @@ import java.nio.ByteBuffer;
  */
 final class BufferHelper {
 
+  private BufferHelper() {
+  }
+
   /**
    * Flip the provided buffer.
    * <p>
@@ -41,8 +44,5 @@ final class BufferHelper {
    */
   static void flip(Buffer buffer) {
     buffer.flip();
-  }
-
-  private BufferHelper() {
   }
 }

--- a/heron/common/src/java/org/apache/heron/common/network/BufferHelper.java
+++ b/heron/common/src/java/org/apache/heron/common/network/BufferHelper.java
@@ -42,4 +42,7 @@ public class BufferHelper {
   static void flip(Buffer buffer) {
     buffer.flip();
   }
+
+  private BufferHelper() {
+  }
 }

--- a/heron/common/src/java/org/apache/heron/common/network/BufferHelper.java
+++ b/heron/common/src/java/org/apache/heron/common/network/BufferHelper.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
 /**
  * Helper methods for working with {@link Buffer} objects.
  */
-public class BufferHelper {
+final class BufferHelper {
 
   /**
    * Flip the provided buffer.

--- a/heron/common/src/java/org/apache/heron/common/network/IncomingPacket.java
+++ b/heron/common/src/java/org/apache/heron/common/network/IncomingPacket.java
@@ -76,7 +76,7 @@ public class IncomingPacket {
       }
       // We read the header fully
       headerRead = true;
-      header.flip();
+      BufferHelper.flip(header);
       int size = header.getInt();
       if (size > limit) {
         LOG.log(Level.SEVERE, "packet size " + size + " exceeds limit " + limit);
@@ -86,7 +86,7 @@ public class IncomingPacket {
     }
     int retval = readFromChannel(channel, data);
     if (retval == 0) {
-      data.flip();
+      BufferHelper.flip(data);
     }
     return retval;
   }

--- a/heron/common/src/java/org/apache/heron/common/network/OutgoingPacket.java
+++ b/heron/common/src/java/org/apache/heron/common/network/OutgoingPacket.java
@@ -82,7 +82,7 @@ public class OutgoingPacket {
     buffer.put(message.toByteArray());
 
     // Make the buffer ready for writing out
-    buffer.flip();
+    BufferHelper.flip(buffer);
   }
 
   public static int sizeRequiredToPackString(String str) {


### PR DESCRIPTION
Java 8 and 11 have a small incompatible change in the `java.nio.Buffer` API. This issue crops up if Heron topologies are compiled with JDK 11, but run with Java 8.

Until Java 8, calling the `flip()` method on any object of `Buffer` (or subclasses) returns a `Buffer`. For example, `ByteBuffer#flip()` returns a `Buffer` in Java 8.

In Java 11, all subclasses of `Buffer` return objects of the subclass instead of `Buffer`, i.e. `ByteBuffer#flip()` returns a `ByteBuffer` in Java 11.

To work around this incompatibility between Java versions, we can cast the buffers to `Buffer` before flipping, since we do not care about the return value anyways. This causes the resulting bytecode to be the same regardless of which Java version is used to compile it.

Progress towards #3266 