### PR TITLE
Fixing the broken website

### DIFF
--- a/website2/docs/cluster-config-instance.md
+++ b/website2/docs/cluster-config-instance.md
@@ -1,3 +1,8 @@
+---
+id: cluster-config-instance
+title: Heron Instance
+sidebar_label: Heron Instance
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: cluster-config-instance
-title: Heron Instance
-sidebar_label: Heron Instance
----
 
 You can configure the behavior of the [Heron
 Instances](heron-architecture#heron-instance) (HIs) in a

--- a/website2/docs/cluster-config-metrics.md
+++ b/website2/docs/cluster-config-metrics.md
@@ -1,3 +1,8 @@
+---
+id: cluster-config-metrics
+title: Metrics Manager
+sidebar_label: Metrics Manager
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: cluster-config-metrics
-title: Metrics Manager
-sidebar_label: Metrics Manager
----
 
 You can configure all of the [Metrics
 Managers](heron-architecture#metrics-manager) (MMs) in a topology

--- a/website2/docs/cluster-config-overview.md
+++ b/website2/docs/cluster-config-overview.md
@@ -1,3 +1,8 @@
+---
+id: cluster-config-overview
+title: Cluster Config Overview
+sidebar_label: Cluster Config Overview
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,12 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: cluster-config-overview
-title: Cluster Config Overview
-sidebar_label: Cluster Config Overview
----
-
 Heron clusters can be configured at two levels:
 
 1. **The system level** --- System-level configurations apply to the whole

--- a/website2/docs/cluster-config-stream.md
+++ b/website2/docs/cluster-config-stream.md
@@ -1,3 +1,8 @@
+---
+id: cluster-config-stream
+title: Stream Manager
+sidebar_label: Stream Manager
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,12 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: cluster-config-stream
-title: Stream Manager
-sidebar_label: Stream Manager
----
-
 
 You can configure the [Stream
 Manager](heron-architecture#stream-manager) (SM) in a

--- a/website2/docs/cluster-config-system-level.md
+++ b/website2/docs/cluster-config-system-level.md
@@ -1,3 +1,8 @@
+---
+id: cluster-config-system-level
+title: System Level Configuration
+sidebar_label: System Level Configuration
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: cluster-config-system-level
-title: System Level Configuration
-sidebar_label: System Level Configuration
----
 
 The parameters in the sections below are set at the system level and thus do not
 apply to any specific component.

--- a/website2/docs/cluster-config-tmaster.md
+++ b/website2/docs/cluster-config-tmaster.md
@@ -1,3 +1,8 @@
+---
+id: cluster-config-tmaster
+title: Topology Master
+sidebar_label: Topology Master
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: cluster-config-tmaster
-title: Topology Master
-sidebar_label: Topology Master
----
 
 You can configure the [Topology
 Master](heron-architecture#topology-master) (TM) for a topology

--- a/website2/docs/compiling-code-organization.md
+++ b/website2/docs/compiling-code-organization.md
@@ -1,3 +1,8 @@
+---
+id: compiling-code-organization
+title: Code Organization
+sidebar_label: Code Organization
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: compiling-code-organization
-title: Code Organization
-sidebar_label: Code Organization
----
 
 This document contains information about the Heron codebase intended primarily
 for developers who want to contribute to Heron. The Heron codebase lives on

--- a/website2/docs/compiling-docker.md
+++ b/website2/docs/compiling-docker.md
@@ -1,3 +1,8 @@
+---
+id: compiling-docker
+title: Compiling With Docker
+sidebar_label: Compiling With Docker
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: compiling-docker
-title: Compiling With Docker
-sidebar_label: Compiling With Docker
----
 
 For developing Heron, you will need to compile it for the environment that you
 want to use it in. If you'd like to use Docker to create that build environment,

--- a/website2/docs/compiling-linux.md
+++ b/website2/docs/compiling-linux.md
@@ -1,3 +1,8 @@
+---
+id: compiling-linux
+title: Compiling on Linux
+sidebar_label: Compiling on Linux
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: compiling-linux
-title: Compiling on Linux
-sidebar_label: Compiling on Linux
----
 
 Heron can currently be built on the following Linux platforms:
 

--- a/website2/docs/compiling-osx.md
+++ b/website2/docs/compiling-osx.md
@@ -1,3 +1,8 @@
+---
+id: compiling-osx
+title: Compiling on OS X
+sidebar_label: Compiling on OS X
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: compiling-osx
-title: Compiling on OS X
-sidebar_label: Compiling on OS X
----
 
 This is a step-by-step guide to building Heron on Mac OS X (versions 10.10 and
   10.11).

--- a/website2/docs/compiling-overview.md
+++ b/website2/docs/compiling-overview.md
@@ -1,3 +1,8 @@
+---
+id: compiling-overview
+title: Compiling Heron
+sidebar_label: Compiling Overview
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: compiling-overview
-title: Compiling Heron
-sidebar_label: Compiling Overview
----
 
 Heron is currently available for [Mac OS X 10.14](compiling-osx),
 [Ubuntu 14.04](compiling-linux), and [CentOS

--- a/website2/docs/compiling-running-tests.md
+++ b/website2/docs/compiling-running-tests.md
@@ -1,3 +1,8 @@
+---
+id: compiling-running-tests
+title: Running Tests
+sidebar_label: Running Tests
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: compiling-running-tests
-title: Running Tests
-sidebar_label: Running Tests
----
 
 Heron uses [Bazel](compiling-overview#installing-bazel) for building
 and running unit tests. Before running tests, first set up your build environment

--- a/website2/docs/deployment-api-server.md
+++ b/website2/docs/deployment-api-server.md
@@ -1,3 +1,8 @@
+---
+id: deployment-api-server
+title: The Heron API Server
+sidebar_label: The Heron API Server
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: deployment-api-server
-title: The Heron API Server
-sidebar_label: The Heron API Server
----
 
 The **Heron API server** is a necessary component
 

--- a/website2/docs/deployment-configuration.md
+++ b/website2/docs/deployment-configuration.md
@@ -1,3 +1,8 @@
+---
+id: deployment-configuration
+title: Configuring a Cluster
+sidebar_label: Configuration
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: deployment-configuration
-title: Configuring a Cluster
-sidebar_label: Configuration
----
 
 To setup a Heron cluster, you need to configure a few files. Each file configures
 a component of the Heron streaming framework.

--- a/website2/docs/deployment-overview.md
+++ b/website2/docs/deployment-overview.md
@@ -1,3 +1,8 @@
+---
+id: deployment-overview
+title: Deployment Overiew
+sidebar_label: Deployment Overiew
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: deployment-overview
-title: Deployment Overiew
-sidebar_label: Deployment Overiew
----
 
 Heron is designed to be run in clustered, scheduler-driven environments. It can
 be run in a `multi-tenant` or `dedicated` clusters. Furthermore, Heron supports

--- a/website2/docs/extending-heron-metric-sink.md
+++ b/website2/docs/extending-heron-metric-sink.md
@@ -1,3 +1,8 @@
+---
+id: extending-heron-metric-sink
+title: Implementing a Custom Metrics Sink
+sidebar_label: Custom Metrics Sink
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: extending-heron-metric-sink
-title: Implementing a Custom Metrics Sink
-sidebar_label: Custom Metrics Sink
----
 
 Each Heron container has its own centralized [Metrics
 Manager](heron-architecture#metrics-manager) (MM), which collects

--- a/website2/docs/extending-heron-scheduler.md
+++ b/website2/docs/extending-heron-scheduler.md
@@ -1,3 +1,8 @@
+---
+id: extending-heron-scheduler
+title: Implementing a Custom Scheduler
+sidebar_label: Custom Scheduler
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: extending-heron-scheduler
-title: Implementing a Custom Scheduler
-sidebar_label: Custom Scheduler
----
 
 To run a Heron topology, you’ll need to set up a scheduler that is responsible 
 for topology management. Note: one scheduler is managing only one topology, 

--- a/website2/docs/getting-started-local-single-node.md
+++ b/website2/docs/getting-started-local-single-node.md
@@ -1,3 +1,8 @@
+---
+id: getting-started-local-single-node
+title: Local (Single Node)
+sidebar_label: Local (Single Node)
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,13 +19,9 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: getting-started-local-single-node
-title: Local (Single Node)
-sidebar_label: Local (Single Node)
----
 
 > The current version of Heron is **{{% heronVersion %}}**
+
 
 The easiest way to get started learning Heron is to install the Heron client tools, which are currently available for:
 

--- a/website2/docs/getting-started-migrate-storm-topologies.md
+++ b/website2/docs/getting-started-migrate-storm-topologies.md
@@ -1,3 +1,8 @@
+---
+id: getting-started-migrate-storm-topologies
+title: Migrate Storm Topologies
+sidebar_label: Migrate Storm Topologies
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: getting-started-migrate-storm-topologies
-title: Migrate Storm Topologies
-sidebar_label: Migrate Storm Topologies
----
 
 Heron is designed to be fully backwards compatible with existing [Apache
 Storm](http://storm.apache.org/index.html) v1 projects, which means that you can

--- a/website2/docs/getting-started-troubleshooting-guide.md
+++ b/website2/docs/getting-started-troubleshooting-guide.md
@@ -1,3 +1,8 @@
+---
+id: getting-started-troubleshooting-guide
+title: Troubleshooting Guide
+sidebar_label: Troubleshooting Guide
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: getting-started-troubleshooting-guide
-title: Troubleshooting Guide
-sidebar_label: Troubleshooting Guide
----
 
 This guide provides basic help for issues frequently encountered when deploying topologies.
 

--- a/website2/docs/guides-data-model.md
+++ b/website2/docs/guides-data-model.md
@@ -1,3 +1,8 @@
+---
+id: guides-data-model
+title: Heron Data Model
+sidebar_label: Heron Data Model
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: guides-data-model
-title: Heron Data Model
-sidebar_label: Heron Data Model
----
 
 Tuple is Heron's core data type. All
 data that is fed into a Heron topology via

--- a/website2/docs/guides-effectively-once-java-topologies.md
+++ b/website2/docs/guides-effectively-once-java-topologies.md
@@ -1,3 +1,8 @@
+---
+id: guides-effectively-once-java-topologies
+title: Effectively Once Java Topologies
+sidebar_label: Effectively Once Java Topologies
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: guides-effectively-once-java-topologies
-title: Effectively Once Java Topologies
-sidebar_label: Effectively Once Java Topologies
----
 
 > **This document pertains to the older, Storm-based, Heron Topology API.** Heron now offers several APIs for building topologies. Topologies created using the Topology API can still run on Heron and there are currently no plans to deprecate this API. We would, however, recommend that you use the Streamlet API for future work.
 

--- a/website2/docs/guides-packing-algorithms.md
+++ b/website2/docs/guides-packing-algorithms.md
@@ -1,3 +1,8 @@
+---
+id: guides-packing-algorithms
+title: Packing Algorithms
+sidebar_label: Packing Algorithms
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: guides-packing-algorithms
-title: Packing Algorithms
-sidebar_label: Packing Algorithms
----
 
 ### Overview
 

--- a/website2/docs/guides-python-topologies.md
+++ b/website2/docs/guides-python-topologies.md
@@ -1,3 +1,8 @@
+---
+id: guides-python-topologies
+title: Python Topologies
+sidebar_label: Python Topologies
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: guides-python-topologies
-title: Python Topologies
-sidebar_label: Python Topologies
----
 
 > The current version of `heronpy` is [{{% heronpyVersion %}}](https://pypi.python.org/pypi/heronpy/{{% heronpyVersion %}}).
 

--- a/website2/docs/guides-simulator-mode.md
+++ b/website2/docs/guides-simulator-mode.md
@@ -1,3 +1,8 @@
+---
+id: guides-simulator-mode
+title: Simulator Mode
+sidebar_label: Simulator Mode
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: guides-simulator-mode
-title: Simulator Mode
-sidebar_label: Simulator Mode
----
 
 Simulator mode is specifically designed for topology developers to easily debug or optimize their 
 topologies.

--- a/website2/docs/guides-topology-tuning.md
+++ b/website2/docs/guides-topology-tuning.md
@@ -1,3 +1,8 @@
+---
+id: guides-topology-tuning
+title: Topology Tuning Guide
+sidebar_label: Topology Tuning Guide
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: guides-topology-tuning
-title: Topology Tuning Guide
-sidebar_label: Topology Tuning Guide
----
 
 ### Overview
 

--- a/website2/docs/guides-troubeshooting-guide.md
+++ b/website2/docs/guides-troubeshooting-guide.md
@@ -1,3 +1,8 @@
+---
+id: guides-troubeshooting-guide
+title: Topology Troubleshooting Guide
+sidebar_label: Topology Troubleshooting Guide
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,12 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: guides-troubeshooting-guide
-title: Topology Troubleshooting Guide
-sidebar_label: Topology Troubleshooting Guide
----
-
 
 ### Overview
 

--- a/website2/docs/guides-tuple-serialization.md
+++ b/website2/docs/guides-tuple-serialization.md
@@ -1,3 +1,8 @@
+---
+id: guides-tuple-serialization
+title: Tuple Serialization
+sidebar_label: Tuple Serialization
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: guides-tuple-serialization
-title: Tuple Serialization
-sidebar_label: Tuple Serialization
----
 
 The tuple is Heron's core data type. Heron's native
 [`Tuple`](/api/org/apache/heron/api/tuple/Tuple.html) interface supports

--- a/website2/docs/guides-ui-guide.md
+++ b/website2/docs/guides-ui-guide.md
@@ -1,3 +1,8 @@
+---
+id: guides-ui-guide
+title: Heron UI Guide
+sidebar_label: Heron UI Guide
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: guides-ui-guide
-title: Heron UI Guide
-sidebar_label: Heron UI Guide
----
 
 ### Overview
 

--- a/website2/docs/heron-architecture.md
+++ b/website2/docs/heron-architecture.md
@@ -1,3 +1,8 @@
+---
+id: heron-architecture
+title: Heron Architecture
+sidebar_label: Heron Architecture
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,12 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: heron-architecture
-title: Heron Architecture
-sidebar_label: Heron Architecture
----
-
 
 Heron is a general-purpose stream processing engine designed for speedy performance,
 low latency, isolation, reliability, and ease of use for developers and administrators

--- a/website2/docs/heron-delivery-semantics.md
+++ b/website2/docs/heron-delivery-semantics.md
@@ -1,3 +1,8 @@
+---
+id: heron-delivery-semantics
+title: Heron Delivery Semantics
+sidebar_label: Heron Delivery Semantics
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: heron-delivery-semantics
-title: Heron Delivery Semantics
-sidebar_label: Heron Delivery Semantics
----
 
 Heron provides support for multiple delivery semantics, and you can select delivery semantics on a topology-by-topology basis. Thus, if you have topologies for which [at-most-once](#available-semantics) semantics are perfectly acceptable, for example, you can run them alongside topologies with more stringent semantics (such as effectively once).
 

--- a/website2/docs/heron-design-goals.md
+++ b/website2/docs/heron-design-goals.md
@@ -1,3 +1,8 @@
+---
+id: heron-design-goals
+title: Heron Design Goals
+sidebar_label: Heron Design Goals
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: heron-design-goals
-title: Heron Design Goals
-sidebar_label: Heron Design Goals
----
 
 From the beginning, Heron was envisioned as a new kind of stream processing
 system, built to meet the most demanding of technological requirements, to

--- a/website2/docs/heron-resources-resources.md
+++ b/website2/docs/heron-resources-resources.md
@@ -1,3 +1,8 @@
+---
+id: heron-resources-resources
+title: Heron Resources
+sidebar_label: Heron Resources
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: heron-resources-resources
-title: Heron Resources
-sidebar_label: Heron Resources
----
 
 Heron Resources outside this documentation:
 

--- a/website2/docs/heron-streamlet-concepts.md
+++ b/website2/docs/heron-streamlet-concepts.md
@@ -1,3 +1,8 @@
+---
+id: heron-streamlet-concepts
+title: Heron Streamlets
+sidebar_label: Heron Streamlets
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: heron-streamlet-concepts
-title: Heron Streamlets
-sidebar_label: Heron Streamlets
----
 
 When it was first released, Heron offered a **Topology API**---heavily indebted to the [Storm API](http://storm.apache.org/about/simple-api.html)---for developing topology logic. In the original Topology API, developers creating topologies were required to explicitly:
 

--- a/website2/docs/heron-topology-concepts.md
+++ b/website2/docs/heron-topology-concepts.md
@@ -1,3 +1,8 @@
+---
+id: heron-topology-concepts
+title: Heron Topologies
+sidebar_label: Heron Topologies
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,13 +19,9 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: heron-topology-concepts
-title: Heron Topologies
-sidebar_label: Heron Topologies
----
 
 > **Don't want to manually create spouts and bolts? Try the Heron Streamlet API.**.  If you find manually creating and connecting spouts and bolts to be overly cumbersome, we recommend trying out the [Heron Streamlet API](topology-development-streamlet-api) for Java, which enables you to create your topology logic using a highly streamlined logic inspired by functional programming concepts. 
+
 
 A Heron **topology** is a [directed acyclic
 graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph) (DAG) used to process

--- a/website2/docs/observability-graphite.md
+++ b/website2/docs/observability-graphite.md
@@ -1,3 +1,8 @@
+---
+id: observability-graphite
+title: Observability with Graphite
+sidebar_label:  Graphite
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,13 +19,8 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: observability-graphite
-title: Observability with Graphite
-sidebar_label:  Graphite
----
 
-o observe Heron's runtime metrics, you can integrate Heron and the Heron UI with
+To observe Heron's runtime metrics, you can integrate Heron and the Heron UI with
 [Graphite](http://graphite.readthedocs.io/en/latest/overview.html) and
 [Grafana](http://grafana.org/).
 

--- a/website2/docs/observability-prometheus.md
+++ b/website2/docs/observability-prometheus.md
@@ -1,3 +1,8 @@
+---
+id: observability-prometheus
+title: Observability with Prometheus
+sidebar_label:  Prometheus
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: observability-prometheus
-title: Observability with Prometheus
-sidebar_label:  Prometheus
----
 
 You can integrate Heron with [Prometheus](https://prometheus.io/) to monitor and gather runtime metrics exported by Heron topologies.
 

--- a/website2/docs/observability-scribe.md
+++ b/website2/docs/observability-scribe.md
@@ -1,3 +1,8 @@
+---
+id: observability-scribe
+title: Observability with Scribe
+sidebar_label:  Scribe
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: observability-scribe
-title: Observability with Scribe
-sidebar_label:  Scribe
----
 
 You can integrate Heron with [Scribe](https://github.com/facebookarchive/scribe/wiki) to monitor and gather runtime metrics exported by Heron topologies.
 

--- a/website2/docs/schedulers-aurora-cluster.md
+++ b/website2/docs/schedulers-aurora-cluster.md
@@ -1,3 +1,8 @@
+---
+id: schedulers-aurora-cluster
+title: Aurora Cluster
+sidebar_label:  Aurora Cluster
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: schedulers-aurora-cluster
-title: Aurora Cluster
-sidebar_label:  Aurora Cluster
----
 
 Heron supports deployment on [Apache Aurora](http://aurora.apache.org/) out of
 the box. A step by step guide on how to setup Heron with Apache Aurora locally 

--- a/website2/docs/schedulers-aurora-local.md
+++ b/website2/docs/schedulers-aurora-local.md
@@ -1,3 +1,8 @@
+---
+id: schedulers-aurora-local
+title: Setting up Heron with Aurora Cluster Locally on Linux
+sidebar_label:  Aurora Locally
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,12 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: schedulers-aurora-local
-title: Setting up Heron with Aurora Cluster Locally on Linux
-sidebar_label:  Aurora Locally
----
-
 
 It is possible to setup Heron with a locally running Apache Aurora cluster.
 This is a step by step guide on how to configure and setup all the necessary

--- a/website2/docs/schedulers-k8s-by-hand.md
+++ b/website2/docs/schedulers-k8s-by-hand.md
@@ -1,3 +1,8 @@
+---
+id: schedulers-k8s-by-hand
+title: Kubernetes by hand
+sidebar_label:  Kubernetes by hand
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: schedulers-k8s-by-hand
-title: Kubernetes by hand
-sidebar_label:  Kubernetes by hand
----
 
 > This document shows you how to install Heron on Kubernetes in a step-by-step, "by hand" fashion. An easier way to install Heron on Kubernetes is to use the [Helm](https://helm.sh) package manager. For instructions on doing so, see [Heron on Kubernetes with Helm](schedulers-k8s-with-helm)).
 

--- a/website2/docs/schedulers-k8s-with-helm.md
+++ b/website2/docs/schedulers-k8s-with-helm.md
@@ -1,3 +1,8 @@
+---
+id: schedulers-k8s-with-helm
+title: Kubernetes with Helm
+sidebar_label:  Kubernetes with Helm
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: schedulers-k8s-with-helm
-title: Kubernetes with Helm
-sidebar_label:  Kubernetes with Helm
----
 
 > If you'd prefer to install Heron on Kubernetes *without* using the [Helm](https://helm.sh) package manager, see the [Heron on Kubernetes by hand](schedulers-k8s-by-hand) document.
 

--- a/website2/docs/schedulers-local.md
+++ b/website2/docs/schedulers-local.md
@@ -1,3 +1,8 @@
+---
+id: schedulers-local
+title: Local Cluster
+sidebar_label:  Local Cluster
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: schedulers-local
-title: Local Cluster
-sidebar_label:  Local Cluster
----
 
 In addition to out-of-the-box schedulers for
 [Aurora](schedulers-aurora-cluster), Heron can also be deployed in a local environment, which

--- a/website2/docs/schedulers-mesos-local-mac.md
+++ b/website2/docs/schedulers-mesos-local-mac.md
@@ -1,3 +1,8 @@
+---
+id: schedulers-mesos-local-mac
+title: Setting up Heron with Mesos Cluster Locally on Mac
+sidebar_label:  Mesos Cluster Locally
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,12 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: schedulers-mesos-local-mac
-title: Setting up Heron with Mesos Cluster Locally on Mac
-sidebar_label:  Mesos Cluster Locally
----
-
 
 This is a step by step guide to run Heron on a Mesos cluster locally.
 

--- a/website2/docs/schedulers-nomad.md
+++ b/website2/docs/schedulers-nomad.md
@@ -1,3 +1,8 @@
+---
+id: schedulers-nomad
+title: Nomad
+sidebar_label:  Nomad
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: schedulers-nomad
-title: Nomad
-sidebar_label:  Nomad
----
 
 Heron supports [Hashicorp](https://hashicorp.com)'s [Nomad](https://nomadproject.io) as a scheduler. You can use Nomad for either small- or large-scale Heron deployments or to run Heron locally in [standalone mode](schedulers-standalone).
 

--- a/website2/docs/schedulers-slurm.md
+++ b/website2/docs/schedulers-slurm.md
@@ -1,3 +1,8 @@
+---
+id: schedulers-slurm
+title: Slurm Cluster (Experimental)
+sidebar_label:  Slurm Cluster
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: schedulers-slurm
-title: Slurm Cluster (Experimental)
-sidebar_label:  Slurm Cluster
----
 
 In addition to out-of-the-box scheduler for
 [Aurora](../aurora), Heron can also be deployed in a HPC cluster with the Slurm Scheduler.

--- a/website2/docs/schedulers-standalone.md
+++ b/website2/docs/schedulers-standalone.md
@@ -1,3 +1,8 @@
+---
+id: schedulers-standalone
+title: Heron Multi-node Standalone Cluster
+sidebar_label:  Heron Multi-node Standalone Cluster
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: schedulers-standalone
-title: Heron Multi-node Standalone Cluster
-sidebar_label:  Heron Multi-node Standalone Cluster
----
 
 Heron enables you to easily run a multi-node cluster in **standalone mode**. The difference between standalone mode and [local mode](schedulers-local) for Heron is that standalone mode involves running multiple compute nodes---using [Hashicorp](https://www.hashicorp.com/)'s [Nomad](https://www.nomadproject.io/) as a scheduler---rather than just one.
 

--- a/website2/docs/schedulers-yarn.md
+++ b/website2/docs/schedulers-yarn.md
@@ -1,3 +1,8 @@
+---
+id: schedulers-yarn
+title: Apache Hadoop YARN Cluster (Experimental)
+sidebar_label:  YARN Cluster
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: schedulers-yarn
-title: Apache Hadoop YARN Cluster (Experimental)
-sidebar_label:  YARN Cluster
----
 
 In addition to out-of-the-box schedulers for [Aurora](schedulers-aurora-cluster), Heron can also be deployed on a
 YARN cluster with the YARN scheduler. The YARN scheduler is implemented using the

--- a/website2/docs/state-managers-local-fs.md
+++ b/website2/docs/state-managers-local-fs.md
@@ -1,3 +1,8 @@
+---
+id: state-managers-local-fs
+title: Local File System
+sidebar_label: Local File System
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: state-managers-local-fs
-title: Local File System
-sidebar_label: Local File System
----
 
 Heron can use the local file system as a state manager for storing various book
 keeping information. Use of local file system is recommended mainly for single

--- a/website2/docs/state-managers-zookeeper.md
+++ b/website2/docs/state-managers-zookeeper.md
@@ -1,3 +1,8 @@
+---
+id: state-managers-zookeeper
+title: Zookeeper
+sidebar_label: Zookeeper
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: state-managers-zookeeper
-title: Zookeeper
-sidebar_label: Zookeeper
----
 
 Heron relies on ZooKeeper for a wide variety of cluster coordination tasks. You
 can use either a shared or dedicated ZooKeeper cluster.

--- a/website2/docs/topology-development-eco-api.md
+++ b/website2/docs/topology-development-eco-api.md
@@ -1,3 +1,8 @@
+---
+id: topology-development-eco-api
+title: The ECO API for Java
+sidebar_label: The ECO API for Java
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,14 +19,8 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: topology-development-eco-api
-title: The ECO API for Java
-sidebar_label: The ECO API for Java
----
 
 > **The Heron ECO API is in beta**. The Heron ECO API can be used to build and test topologies on your local or on a cluster.  The API still needs some testing and feedback from the community to understand how we  should continue to develop ECO.
-
 
 Heron processing topologies can be written using an API called the **Heron ECO API**. The ECO API is currently available to work with spouts and bolts from the following packages:
 

--- a/website2/docs/topology-development-streamlet-api.md
+++ b/website2/docs/topology-development-streamlet-api.md
@@ -1,3 +1,8 @@
+---
+id: topology-development-streamlet-api
+title: The Heron Streamlet API for Java
+sidebar_label: The Heron Streamlet API for Java
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: topology-development-streamlet-api
-title: The Heron Streamlet API for Java
-sidebar_label: The Heron Streamlet API for Java
----
 
  > **The Heron Streamlet API is in beta.** 
  > The Heron Streamlet API is well tested and can be used to build and test topologies locally. The API is not yet fully stable, however, and breaking changes are likely in the coming weeks.

--- a/website2/docs/topology-development-streamlet-scala.md
+++ b/website2/docs/topology-development-streamlet-scala.md
@@ -1,3 +1,8 @@
+---
+id: topology-development-streamlet-scala
+title: The Heron Streamlet API for Scala
+sidebar_label: The Heron Streamlet API for Scala
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: topology-development-streamlet-scala
-title: The Heron Streamlet API for Scala
-sidebar_label: The Heron Streamlet API for Scala
----
 
 ## Getting started
 

--- a/website2/docs/topology-development-topology-api-java.md
+++ b/website2/docs/topology-development-topology-api-java.md
@@ -1,3 +1,8 @@
+---
+id: topology-development-topology-api-java
+title: The Heron Topology API for Java
+sidebar_label: The Heron Topology API for Java
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,13 +19,9 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: topology-development-topology-api-java
-title: The Heron Topology API for Java
-sidebar_label: The Heron Topology API for Java
----
 
 > This document pertains to the older, Storm-based, Heron Topology API.  Heron now offers two separate APIs for building topologies: the original, [Storm](https://storm.apache.org)-based Topology API, and the newer [Streamlet API](../../../concepts/topologies#the-heron-streamlet-api). Topologies created using the Topology API can still run on Heron and there are currently no plans to deprecate this API. We would, however, recommend that you use the Streamlet API for future work.
+
 
 A topology specifies components like spouts and bolts, as well as the relation
 between components and proper configurations. The

--- a/website2/docs/topology-development-topology-api-python.md
+++ b/website2/docs/topology-development-topology-api-python.md
@@ -1,3 +1,8 @@
+---
+id: topology-development-topology-api-python
+title: The Heron Topology API for Python
+sidebar_label: The Heron Topology API for Python
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: topology-development-topology-api-python
-title: The Heron Topology API for Python
-sidebar_label: The Heron Topology API for Python
----
 
 > The current version of `heronpy` is [{{% heronpyVersion %}}](https://pypi.python.org/pypi/heronpy/{{% heronpyVersion %}}).
 

--- a/website2/docs/uploaders-amazon-s3.md
+++ b/website2/docs/uploaders-amazon-s3.md
@@ -1,3 +1,8 @@
+---
+id: uploaders-amazon-s3
+title: Amazon S3
+sidebar_label: Amazon S3
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: uploaders-amazon-s3
-title: Amazon S3
-sidebar_label: Amazon S3
----
 
 If you are running in Amazon AWS, Heron provides out of the box uploader for S3,
 the object storage. S3 uploader is useful when the topologies run in a distributed

--- a/website2/docs/uploaders-hdfs.md
+++ b/website2/docs/uploaders-hdfs.md
@@ -1,3 +1,8 @@
+---
+id: uploaders-hdfs
+title: HDFS
+sidebar_label: HDFS
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: uploaders-hdfs
-title: HDFS
-sidebar_label: HDFS
----
 
 With Heron, you have the option to use HDFS as stable storage for user submitted
 topology jars. Since HDFS replicates the data, it provides a scalable

--- a/website2/docs/uploaders-http.md
+++ b/website2/docs/uploaders-http.md
@@ -1,3 +1,8 @@
+---
+id: uploaders-http
+title: HTTP
+sidebar_label: HTTP
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: uploaders-http
-title: HTTP
-sidebar_label: HTTP
----
 
 When a topology is submitted to Heron, the topology jars will be uploaded to a stable location. 
 The submitter will provide this location to the scheduler and it will pass it to the each 

--- a/website2/docs/uploaders-local-fs.md
+++ b/website2/docs/uploaders-local-fs.md
@@ -1,3 +1,8 @@
+---
+id: uploaders-local-fs
+title: Local File System
+sidebar_label: Local File System
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: uploaders-local-fs
-title: Local File System
-sidebar_label: Local File System
----
 
 When you submit a topology to Heron, the topology jars will be uploaded to a
 stable location. The submitter will provide this location to the scheduler and

--- a/website2/docs/uploaders-scp.md
+++ b/website2/docs/uploaders-scp.md
@@ -1,3 +1,8 @@
+---
+id: uploaders-scp
+title: Secure Copy (SCP)
+sidebar_label: Secure Copy (SCP)
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: uploaders-scp
-title: Secure Copy (SCP)
-sidebar_label: Secure Copy (SCP)
----
 
 For small clusters with simple setups that doesn't have a HDFS like file system, the SCP uploader
 can be used to manage the package files. This uploader uses the `scp` linux command to upload the

--- a/website2/docs/user-manuals-heron-cli.md
+++ b/website2/docs/user-manuals-heron-cli.md
@@ -1,3 +1,8 @@
+---
+id: user-manuals-heron-cli
+title: Managing Topologies with Heron CLI
+sidebar_label: Heron Client
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: user-manuals-heron-cli
-title: Managing Topologies with Heron CLI
-sidebar_label: Heron Client
----
 
 The **Heron CLI** us used to to manage every aspect of the
 [topology lifecycle](heron-topology-concepts#topology-lifecycle).

--- a/website2/docs/user-manuals-heron-explorer.md
+++ b/website2/docs/user-manuals-heron-explorer.md
@@ -1,3 +1,8 @@
+---
+id: user-manuals-heron-explorer
+title: Heron Explorer
+sidebar_label: Heron Explorer
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: user-manuals-heron-explorer
-title: Heron Explorer
-sidebar_label: Heron Explorer
----
 
 The **Heron Explorer** is a CLI tool that you can use to gain insight into a Heron installation, including:
 

--- a/website2/docs/user-manuals-heron-shell.md
+++ b/website2/docs/user-manuals-heron-shell.md
@@ -1,3 +1,8 @@
+---
+id: user-manuals-heron-shell
+title: Heron Shell
+sidebar_label: Heron Shell
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: user-manuals-heron-shell
-title: Heron Shell
-sidebar_label: Heron Shell
----
 
 Heron shell helps debugging a heron topology. It is an HTTP server that runs as a
 separate process in every container.  It exposes many utilities through REST APIs.

--- a/website2/docs/user-manuals-heron-tracker-runbook.md
+++ b/website2/docs/user-manuals-heron-tracker-runbook.md
@@ -1,3 +1,8 @@
+---
+id: user-manuals-heron-tracker-runbook
+title: Heron Tracker
+sidebar_label: Heron Tracker Runbook
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: user-manuals-heron-tracker-runbook
-title: Heron Tracker
-sidebar_label: Heron Tracker Runbook
----
 
 **Heron Tracker** is a web service that continuously gathers a wide
 variety of information about Heron topologies and exposes

--- a/website2/docs/user-manuals-heron-ui.md
+++ b/website2/docs/user-manuals-heron-ui.md
@@ -1,3 +1,8 @@
+---
+id: user-manuals-heron-ui-runbook
+title: Heron UI Runbook
+sidebar_label: Heron UI Runbook
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: user-manuals-heron-ui-runbook
-title: Heron UI Runbook
-sidebar_label: Heron UI Runbook
----
 
 **Heron UI** is a user interface that uses the [Heron Tracker](heron-architecture#heron-tracker) to display detailed,
 colorful visual representations of topologies, including the

--- a/website2/docs/user-manuals-tracker-rest.md
+++ b/website2/docs/user-manuals-tracker-rest.md
@@ -1,3 +1,8 @@
+---
+id: user-manuals-tracker-rest
+title: Heron Tracker REST API
+sidebar_label: Heron Tracker REST API
+---
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -6,9 +11,7 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,11 +19,6 @@
     specific language governing permissions and limitations
     under the License.
 -->
----
-id: user-manuals-tracker-rest
-title: Heron Tracker REST API
-sidebar_label: Heron Tracker REST API
----
 
 ### JSON Interface
 

--- a/website2/website/scripts/python-doc-gen.sh
+++ b/website2/website/scripts/python-doc-gen.sh
@@ -26,14 +26,13 @@ chmod +x ./bazel-0.26.0-installer-linux-x86_64.sh && \
 ./bazel-0.26.0-installer-linux-x86_64.sh --user && \
 export PATH="$PATH:$HOME/bin"
 
-# 
 set -e
 
 HERONPY_VERSION=$1
 HERON_ROOT_DIR=$(git rev-parse --show-toplevel)
 cd ${HERON_ROOT_DIR}
 
-./bazel_configure.py
+# ./bazel_configure.py
 
 # Generate python whl packages, packages will be generated in ${HERON_ROOT_DIR}/bazel-genfiles/scripts/packages/
 bazel build --config=ubuntu scripts/packages:pypkgs
@@ -45,7 +44,6 @@ mkdir -p ./venv/
 VENV=./venv/
 echo $VENV
 PIP_LOCATION=${HERON_ROOT_DIR}/bazel-genfiles/scripts/packages
-
 
 virtualenv "$VENV"
 source "$VENV/bin/activate"


### PR DESCRIPTION
The site was broken because of the commit (`Add license header to md files`). Docusaurus Markdown document should always start with `---` and **header fields that are enclosed by a line --- on either side** 
Source: https://docusaurus.io/docs/en/doc-markdown#markdown-headers

So, making this PR to fix the broken site.

Tested site in ubuntu server and it's working as expected: 
![website2](https://i.imgur.com/hqRXJpA.png)

To test:
```
Install Yarn and Node
git clone git@github.com:apache/incubator-heron.git
cd incubator-heron/website2/website
yarn install
yarn start
Go to localhost:3000
```
