### PR TITLE
Increase the process restart retry to 150

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -297,7 +297,7 @@ class HeronExecutor(object):
     self.init_from_parsed_args(parsed_args)
 
     self.shell_env = shell_env
-    self.max_runs = 100
+    self.max_runs = 150
     self.interval_between_runs = 10
 
     # Read the heron_internals.yaml for logging dir


### PR DESCRIPTION
During a recent incident, we found that the retry 100 times setting is slightly tight for some failure cases. 

This PR increases the max_retry to 150 to give tmaser, stmgr and instances longer grace period of waiting for each other recovering from failure cases.