### PR TITLE
[STREAMCOMP-2885] broadcast GCC completition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,10 @@ tools/jdk/ijar
 .idea/sqlDataSources.xml
 .idea/dynamic.xml
 
+# Intellij bazel plugin
+.ijwb
+.clwb
+
 ## Maven generated files
 .classpath.txt
 
@@ -134,6 +138,7 @@ website2/website/static/api
 
 # Visual Studio Code
 .vscode
+vs.code-workspace
 
 # integration_test
 results/

--- a/heron/instance/src/java/org/apache/heron/instance/InstanceControlMsg.java
+++ b/heron/instance/src/java/org/apache/heron/instance/InstanceControlMsg.java
@@ -26,11 +26,13 @@ public final class InstanceControlMsg {
   private PhysicalPlanHelper newPhysicalPlanHelper;
   private CheckpointManager.RestoreInstanceStateRequest restoreInstanceStateRequest;
   private CheckpointManager.StartInstanceStatefulProcessing startInstanceStatefulProcessing;
+  private CheckpointManager.StatefulConsistentCheckpointSaved statefulConsistentCheckpointSaved;
 
   private InstanceControlMsg(Builder builder) {
     this.newPhysicalPlanHelper = builder.newPhysicalPlanHelper;
     this.restoreInstanceStateRequest = builder.restoreInstanceStateRequest;
     this.startInstanceStatefulProcessing = builder.startInstanceStatefulProcessing;
+    this.statefulConsistentCheckpointSaved = builder.statefulConsistentCheckpointSaved;
   }
 
   public static Builder newBuilder() {
@@ -39,6 +41,10 @@ public final class InstanceControlMsg {
 
   public PhysicalPlanHelper getNewPhysicalPlanHelper() {
     return newPhysicalPlanHelper;
+  }
+
+  public CheckpointManager.StatefulConsistentCheckpointSaved getStatefulCheckpointSavedMessage() {
+    return this.statefulConsistentCheckpointSaved;
   }
 
   public boolean isNewPhysicalPlanHelper() {
@@ -65,6 +71,7 @@ public final class InstanceControlMsg {
     private PhysicalPlanHelper newPhysicalPlanHelper;
     private CheckpointManager.RestoreInstanceStateRequest restoreInstanceStateRequest;
     private CheckpointManager.StartInstanceStatefulProcessing startInstanceStatefulProcessing;
+    private CheckpointManager.StatefulConsistentCheckpointSaved statefulConsistentCheckpointSaved;
 
     private Builder() {
 
@@ -84,6 +91,12 @@ public final class InstanceControlMsg {
     public Builder setStartInstanceStatefulProcessing(
         CheckpointManager.StartInstanceStatefulProcessing request) {
       this.startInstanceStatefulProcessing = request;
+      return this;
+    }
+
+    public Builder setStatefulCheckpointSaved(
+        CheckpointManager.StatefulConsistentCheckpointSaved message) {
+      this.statefulConsistentCheckpointSaved = message;
       return this;
     }
 

--- a/heron/instance/src/java/org/apache/heron/instance/Slave.java
+++ b/heron/instance/src/java/org/apache/heron/instance/Slave.java
@@ -123,6 +123,15 @@ public class Slave implements Runnable, AutoCloseable {
           if (instanceControlMsg.isNewPhysicalPlanHelper()) {
             handleNewPhysicalPlan(instanceControlMsg);
           }
+
+          if (instanceControlMsg.getStatefulCheckpointSavedMessage() != null) {
+            String checkpointId = instanceControlMsg
+                .getStatefulCheckpointSavedMessage()
+                .getConsistentCheckpoint()
+                .getCheckpointId();
+
+            LOG.log(Level.INFO, "checkpoint: {0} has become globally consistent", checkpointId);
+          }
         }
       }
     };

--- a/heron/instance/src/java/org/apache/heron/network/StreamManagerClient.java
+++ b/heron/instance/src/java/org/apache/heron/network/StreamManagerClient.java
@@ -120,6 +120,7 @@ public class StreamManagerClient extends HeronClient {
     registerOnMessage(CheckpointManager.InitiateStatefulCheckpoint.newBuilder());
     registerOnMessage(CheckpointManager.RestoreInstanceStateRequest.newBuilder());
     registerOnMessage(CheckpointManager.StartInstanceStatefulProcessing.newBuilder());
+    registerOnMessage(CheckpointManager.StatefulConsistentCheckpointSaved.newBuilder());
   }
 
 
@@ -205,6 +206,8 @@ public class StreamManagerClient extends HeronClient {
       handleRestoreInstanceStateRequest((CheckpointManager.RestoreInstanceStateRequest) message);
     } else if (message instanceof CheckpointManager.StartInstanceStatefulProcessing) {
       handleStartStatefulRequest((CheckpointManager.StartInstanceStatefulProcessing) message);
+    } else if (message instanceof CheckpointManager.StatefulConsistentCheckpointSaved) {
+      handleCheckpointSaved((CheckpointManager.StatefulConsistentCheckpointSaved) message);
     } else {
       throw new RuntimeException("Unknown kind of message received from Stream Manager");
     }
@@ -282,6 +285,16 @@ public class StreamManagerClient extends HeronClient {
 
     InstanceControlMsg instanceControlMsg = InstanceControlMsg.newBuilder()
         .setStartInstanceStatefulProcessing(request)
+        .build();
+    inControlQueue.offer(instanceControlMsg);
+  }
+
+  private void handleCheckpointSaved(
+      CheckpointManager.StatefulConsistentCheckpointSaved message) {
+    LOG.info("Received a StatefulCheckpointSaved message: " + message);
+
+    InstanceControlMsg instanceControlMsg = InstanceControlMsg.newBuilder()
+        .setStatefulCheckpointSaved(message)
         .build();
     inControlQueue.offer(instanceControlMsg);
   }

--- a/heron/proto/ckptmgr.proto
+++ b/heron/proto/ckptmgr.proto
@@ -108,6 +108,12 @@ message StartStatefulCheckpoint {
   required string checkpoint_id = 1;
 }
 
+// Message broadcasted to stmgr (will then be forwarded to instances) after when checkpoint becomes
+// "globally consistent"
+message StatefulConsistentCheckpointSaved {
+  required StatefulConsistentCheckpoint consistent_checkpoint = 1;
+}
+
 // Message sent by tmaster to stmgr asking them to reset their instances
 // to this checkpoint
 message RestoreTopologyStateRequest {

--- a/heron/stmgr/src/cpp/manager/instance-server.cpp
+++ b/heron/stmgr/src/cpp/manager/instance-server.cpp
@@ -498,6 +498,15 @@ void InstanceServer::BroadcastNewPhysicalPlan(const proto::system::PhysicalPlan&
   }
 }
 
+void InstanceServer::BroadcastStatefulCheckpointSaved(
+    const proto::ckptmgr::StatefulConsistentCheckpointSaved& _msg) {
+  for (auto & iter : active_instances_) {
+    LOG(INFO) << "Sending checkpoint: " << _msg.consistent_checkpoint().checkpoint_id()
+              << " saved message to instance with task_id: " << iter.second;
+    SendMessage(iter.first, _msg);
+  }
+}
+
 void InstanceServer::SetRateLimit(const proto::system::PhysicalPlan& _pplan,
                                   const std::string& _component,
                                   Connection* _conn) const {

--- a/heron/stmgr/src/cpp/manager/instance-server.h
+++ b/heron/stmgr/src/cpp/manager/instance-server.h
@@ -72,6 +72,9 @@ class InstanceServer : public Server {
 
   void BroadcastNewPhysicalPlan(const proto::system::PhysicalPlan& _pplan);
 
+  void BroadcastStatefulCheckpointSaved(
+      const proto::ckptmgr::StatefulConsistentCheckpointSaved& _msg);
+
   virtual bool HaveAllInstancesConnectedToUs() const {
     return active_instances_.size() == expected_instances_.size();
   }

--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -197,6 +197,10 @@ class StMgr {
   void HandleStatefulRestoreDone(proto::system::StatusCode _status,
                                  std::string _checkpoint_id, sp_int64 _restore_txid);
 
+  // Called when stmgr received StatefulConsistentCheckpointSaved message from TMaster
+  // Then, the stmgr will forward this fact to all heron instances connected to it
+  void BroadcastCheckpointSaved(const proto::ckptmgr::StatefulConsistentCheckpointSaved& _msg);
+
   // Patch new physical plan with internal hydrated topology but keep new topology data:
   // - new topology state
   // - new topology/component config

--- a/heron/stmgr/src/cpp/manager/tmaster-client.h
+++ b/heron/stmgr/src/cpp/manager/tmaster-client.h
@@ -42,7 +42,9 @@ class TMasterClient : public Client {
                 VCallback<shared_ptr<proto::system::PhysicalPlan>> _pplan_watch,
                 VCallback<sp_string> _stateful_checkpoint_watch,
                 VCallback<sp_string, sp_int64> _restore_topology_watch,
-                VCallback<sp_string> _start_stateful_watch);
+                VCallback<sp_string> _start_stateful_watch,
+                VCallback<const proto::ckptmgr::StatefulConsistentCheckpointSaved&>
+                    _broadcast_checkpoint_saved);
   virtual ~TMasterClient();
 
   // Told by the upper layer to disconnect and self destruct
@@ -88,6 +90,9 @@ class TMasterClient : public Client {
   void HandleStartStmgrStatefulProcessing(
           pool_unique_ptr<proto::ckptmgr::StartStmgrStatefulProcessing> _msg);
 
+  void HandleStatefulCheckpointSavedMessage(
+          pool_unique_ptr<proto::ckptmgr::StatefulConsistentCheckpointSaved> _msg);
+
   void OnReConnectTimer();
   void OnHeartbeatTimer();
   void SendRegisterRequest();
@@ -116,6 +121,9 @@ class TMasterClient : public Client {
   // We invoke this callback upon receiving a StartStatefulProcessing message from tmaster
   // passing in the checkpoint id
   VCallback<sp_string> start_stateful_watch_;
+  // This callback will be invoked upon receiving a StatefulConsistentCheckpointSaved message.
+  // We will then forward this message to all the instances connected to this stmgr
+  VCallback<const proto::ckptmgr::StatefulConsistentCheckpointSaved&> broadcast_checkpoint_saved_;
 
   // Configs to be read
   sp_int32 reconnect_tmaster_interval_sec_;

--- a/heron/tmaster/src/cpp/manager/stateful-controller.cpp
+++ b/heron/tmaster/src/cpp/manager/stateful-controller.cpp
@@ -55,7 +55,8 @@ StatefulController::StatefulController(const std::string& _topology_name,
                shared_ptr<heron::common::HeronStateMgr> _state_mgr,
                std::chrono::high_resolution_clock::time_point _tmaster_start_time,
                shared_ptr<common::MetricsMgrSt> _metrics_manager_client,
-               std::function<void(const proto::ckptmgr::StatefulConsistentCheckpoints&)> _ckpt_save_watcher)
+               std::function<void(const proto::ckptmgr::StatefulConsistentCheckpoints&)>
+                   _ckpt_save_watcher)
   : topology_name_(_topology_name),
     ckpt_record_(std::move(_ckpt)),
     state_mgr_(_state_mgr),

--- a/heron/tmaster/src/cpp/manager/stateful-controller.h
+++ b/heron/tmaster/src/cpp/manager/stateful-controller.h
@@ -58,7 +58,7 @@ class StatefulController {
                shared_ptr<heron::common::HeronStateMgr> _state_mgr,
                std::chrono::high_resolution_clock::time_point _tmaster_start_time,
                shared_ptr<common::MetricsMgrSt> _metrics_manager_client,
-               std::function<void(std::string)> _ckpt_save_watcher);
+               std::function<void(const proto::ckptmgr::StatefulConsistentCheckpoints&)> _ckpt_save_watcher);
   virtual ~StatefulController();
   // Start a new restore process
   void StartRestore(const StMgrMap& _stmgrs, bool _ignore_prev_checkpoints);
@@ -102,7 +102,7 @@ class StatefulController {
   unique_ptr<StatefulRestorer> restorer_;
   shared_ptr<common::MetricsMgrSt> metrics_manager_client_;
   shared_ptr<common::MultiCountMetric> count_metrics_;
-  std::function<void(std::string)> ckpt_save_watcher_;
+  std::function<void(const proto::ckptmgr::StatefulConsistentCheckpoints&)> ckpt_save_watcher_;
 };
 }  // namespace tmaster
 }  // namespace heron

--- a/heron/tmaster/src/cpp/manager/stateful-controller.h
+++ b/heron/tmaster/src/cpp/manager/stateful-controller.h
@@ -58,7 +58,8 @@ class StatefulController {
                shared_ptr<heron::common::HeronStateMgr> _state_mgr,
                std::chrono::high_resolution_clock::time_point _tmaster_start_time,
                shared_ptr<common::MetricsMgrSt> _metrics_manager_client,
-               std::function<void(const proto::ckptmgr::StatefulConsistentCheckpoints&)> _ckpt_save_watcher);
+               std::function<void(const proto::ckptmgr::StatefulConsistentCheckpoints&)>
+                   _ckpt_save_watcher);
   virtual ~StatefulController();
   // Start a new restore process
   void StartRestore(const StMgrMap& _stmgrs, bool _ignore_prev_checkpoints);

--- a/heron/tmaster/src/cpp/manager/stmgrstate.cpp
+++ b/heron/tmaster/src/cpp/manager/stmgrstate.cpp
@@ -107,8 +107,15 @@ void StMgrState::NewPhysicalPlan(const proto::system::PhysicalPlan& _pplan) {
 }
 
 void StMgrState::NewStatefulCheckpoint(const proto::ckptmgr::StartStatefulCheckpoint& _request) {
-  LOG(INFO) << "Sending a new stateful checkpoint request to stmgr" << stmgr_->id();
+  LOG(INFO) << "Sending a new stateful checkpoint request to stmgr: " << stmgr_->id();
   server_.SendMessage(connection_, _request);
+}
+
+void StMgrState::SendCheckpointSavedMessage(
+        const proto::ckptmgr::StatefulConsistentCheckpointSaved &_msg) {
+  LOG(INFO) << "Sending checkpoint saved message to stmgr: " << stmgr_->id() << " "
+            << "for checkpoint: " << _msg.consistent_checkpoint().checkpoint_id();
+  server_.SendMessage(connection_, _msg);
 }
 
 /*

--- a/heron/tmaster/src/cpp/manager/stmgrstate.h
+++ b/heron/tmaster/src/cpp/manager/stmgrstate.h
@@ -70,6 +70,8 @@ class StMgrState {
   // Send stateful checkpoint message to the stmgr
   void NewStatefulCheckpoint(const proto::ckptmgr::StartStatefulCheckpoint& _request);
 
+  void SendCheckpointSavedMessage(const proto::ckptmgr::StatefulConsistentCheckpointSaved &_msg);
+
 
   bool TimedOut() const;
 

--- a/heron/tmaster/src/cpp/manager/tmaster.cpp
+++ b/heron/tmaster/src/cpp/manager/tmaster.cpp
@@ -398,8 +398,8 @@ void TMaster::SetupStatefulController(
        config::TopologyConfigHelper::GetStatefulCheckpointIntervalSecsWithDefault(*topology_, 300);
   CHECK_GT(stateful_checkpoint_interval, 0);
 
-  auto cb = [this](std::string _oldest_ckptid) {
-    this->HandleStatefulCheckpointSave(_oldest_ckptid);
+  auto cb = [this](const proto::ckptmgr::StatefulConsistentCheckpoints& new_ckpts) {
+    this->HandleStatefulCheckpointSave(new_ckpts);
   };
   // Instantiate the stateful restorer/coordinator
   stateful_controller_ = make_unique<StatefulController>(topology_->name(), _ckpt, state_mgr_,
@@ -616,8 +616,13 @@ void TMaster::CleanAllStatefulCheckpoint() {
   ckptmgr_client_->SendCleanStatefulCheckpointRequest("", true);
 }
 
-void TMaster::HandleStatefulCheckpointSave(const std::string& _oldest_ckpt) {
-  ckptmgr_client_->SendCleanStatefulCheckpointRequest(_oldest_ckpt, false);
+void TMaster::HandleStatefulCheckpointSave(const proto::ckptmgr::StatefulConsistentCheckpoints &new_ckpts) {
+  // clean oldest checkpoint on save
+  std::string oldest_ckpt_id =
+      new_ckpts.consistent_checkpoints(new_ckpts.consistent_checkpoints_size() - 1)
+        .checkpoint_id();
+
+  ckptmgr_client_->SendCleanStatefulCheckpointRequest(oldest_ckpt_id, false);
 }
 
 // Called when ckptmgr completes the clean stateful checkpoint request

--- a/heron/tmaster/src/cpp/manager/tmaster.h
+++ b/heron/tmaster/src/cpp/manager/tmaster.h
@@ -195,7 +195,8 @@ class TMaster {
                                      const ComponentConfigMap& _config);
 
   // Function called when a new stateful ckpt record is saved
-  void HandleStatefulCheckpointSave(const proto::ckptmgr::StatefulConsistentCheckpoints &new_ckpts);
+  void HandleStatefulCheckpointSave(
+      const proto::ckptmgr::StatefulConsistentCheckpoints &new_ckpts);
 
   // Function called to kill container
   void KillContainer(const std::string& host_name,

--- a/heron/tmaster/src/cpp/manager/tmaster.h
+++ b/heron/tmaster/src/cpp/manager/tmaster.h
@@ -195,7 +195,7 @@ class TMaster {
                                      const ComponentConfigMap& _config);
 
   // Function called when a new stateful ckpt record is saved
-  void HandleStatefulCheckpointSave(const std::string& _oldest_ckpt);
+  void HandleStatefulCheckpointSave(const proto::ckptmgr::StatefulConsistentCheckpoints &new_ckpts);
 
   // Function called to kill container
   void KillContainer(const std::string& host_name,


### PR DESCRIPTION
This PR will make TMaster to broadcast globally consistent checkpoint completion to every Heron task instances. Details in TDD (linked in Jira epic).

Implementation plan (in order)
- [x] TMaster: decouple GCC post-save logic from stateful controller https://github.com/apache/incubator-heron/pull/3329/commits/f4fd38d586758d54f59fc086d92f2ad587abf51b
- [x] define protobuf message envelops
- [x] logic for tmaster sends + stmgr receives
- [x] logic for stmgr sends + heron instance receives