### PR TITLE
Add metrics for communicator size in metrics manager

### DIFF
--- a/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/MetricsManager.java
+++ b/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/MetricsManager.java
@@ -199,7 +199,7 @@ public class MetricsManager {
               : TypeUtils.getInteger(restartAttempts));
 
       // Update the list of Communicator in Metrics Manager Server
-      metricsManagerServer.addSinkCommunicator(sinkExecutor.getCommunicator());
+      metricsManagerServer.addSinkCommunicator(sinkId, sinkExecutor.getCommunicator());
     }
   }
 
@@ -537,12 +537,11 @@ public class MetricsManager {
       // If the thread name is a key of SinkExecutors, then it is a thread running IMetricsSink
       if (sinkExecutors.containsKey(thread.getName())) {
         sinkId = thread.getName();
-        // Remove the old sink executor
-        SinkExecutor oldSinkExecutor = sinkExecutors.remove(sinkId);
         // Remove the unneeded Communicator bind with Metrics Manager Server
-        metricsManagerServer.removeSinkCommunicator(oldSinkExecutor.getCommunicator());
+        metricsManagerServer.removeSinkCommunicator(sinkId);
 
-        // Close the sink
+        // Remove the old sink executor and close the sink
+        SinkExecutor oldSinkExecutor = sinkExecutors.remove(sinkId);
         SysUtils.closeIgnoringExceptions(oldSinkExecutor);
 
         thisSinkRetryAttempts = sinksRetryAttempts.remove(sinkId);
@@ -565,7 +564,7 @@ public class MetricsManager {
         sinksRetryAttempts.put(sinkId, thisSinkRetryAttempts);
 
         // Update the list of Communicator in Metrics Manager Server
-        metricsManagerServer.addSinkCommunicator(newSinkExecutor.getCommunicator());
+        metricsManagerServer.addSinkCommunicator(sinkId, newSinkExecutor.getCommunicator());
 
         // Restart it
         executors.execute(newSinkExecutor);

--- a/heron/metricsmgr/tests/java/org/apache/heron/metricsmgr/MetricsManagerServerTest.java
+++ b/heron/metricsmgr/tests/java/org/apache/heron/metricsmgr/MetricsManagerServerTest.java
@@ -83,9 +83,10 @@ public class MetricsManagerServerTest {
    */
   @Test
   public void testAddSinkCommunicator() {
+    String name = "test_communicator";
     Communicator<MetricsRecord> sinkCommunicator = new Communicator<>();
-    metricsManagerServer.addSinkCommunicator(sinkCommunicator);
-    Assert.assertTrue(metricsManagerServer.removeSinkCommunicator(sinkCommunicator));
+    metricsManagerServer.addSinkCommunicator(name, sinkCommunicator);
+    Assert.assertTrue(metricsManagerServer.removeSinkCommunicator(name));
   }
 
   /**
@@ -93,9 +94,10 @@ public class MetricsManagerServerTest {
    */
   @Test
   public void testRemoveSinkCommunicator() {
+    String name = "test_communicator";
     Communicator<MetricsRecord> sinkCommunicator = new Communicator<>();
-    metricsManagerServer.addSinkCommunicator(sinkCommunicator);
-    Assert.assertTrue(metricsManagerServer.removeSinkCommunicator(sinkCommunicator));
+    metricsManagerServer.addSinkCommunicator(name, sinkCommunicator);
+    Assert.assertTrue(metricsManagerServer.removeSinkCommunicator(name));
   }
 
   /**
@@ -103,10 +105,11 @@ public class MetricsManagerServerTest {
    */
   @Test
   public void testMetricsManagerServer() throws InterruptedException {
+    String name = "test_communicator";
     CountDownLatch offersLatch = new CountDownLatch(MESSAGE_SIZE);
     Communicator<MetricsRecord> sinkCommunicator =
         CommunicatorTestHelper.spyCommunicator(new Communicator<MetricsRecord>(), offersLatch);
-    metricsManagerServer.addSinkCommunicator(sinkCommunicator);
+    metricsManagerServer.addSinkCommunicator(name, sinkCommunicator);
 
     serverTester.start();
 


### PR DESCRIPTION
These new metrics could be useful for debugging memory usage in the metrics manager.