### PR TITLE
Separate gc log files for metrics manage and checkpoint manager by id

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -447,7 +447,7 @@ class HeronExecutor(object):
                       '-XX:+HeapDumpOnOutOfMemoryError',
                       '-XX:+UseConcMarkSweepGC',
                       '-XX:+PrintCommandLineFlags',
-                      '-Xloggc:log-files/gc.metricsmgr.log',
+                      '-Xloggc:log-files/gc.' + metricsManagerId + '.log',
                       '-Djava.net.preferIPv4Stack=true',
                       '-cp',
                       self.metrics_manager_classpath,
@@ -846,6 +846,7 @@ class HeronExecutor(object):
     ckptmgr_main_class = 'org.apache.heron.ckptmgr.CheckpointManager'
 
     ckptmgr_ram_mb = self.checkpoint_manager_ram / (1024 * 1024)
+    ckptmgr_id = self.ckptmgr_ids[self.shard]
     ckptmgr_cmd = [os.path.join(self.heron_java_home, "bin/java"),
                    '-Xms%dM' % ckptmgr_ram_mb,
                    '-Xmx%dM' % ckptmgr_ram_mb,
@@ -864,14 +865,14 @@ class HeronExecutor(object):
                    '-XX:+HeapDumpOnOutOfMemoryError',
                    '-XX:+UseConcMarkSweepGC',
                    '-XX:+UseConcMarkSweepGC',
-                   '-Xloggc:log-files/gc.ckptmgr.log',
+                   '-Xloggc:log-files/gc.' + ckptmgr_id + '.log',
                    '-Djava.net.preferIPv4Stack=true',
                    '-cp',
                    self.checkpoint_manager_classpath,
                    ckptmgr_main_class,
                    '-t' + self.topology_name,
                    '-i' + self.topology_id,
-                   '-c' + self.ckptmgr_ids[self.shard],
+                   '-c' + ckptmgr_id,
                    '-p' + self.checkpoint_manager_port,
                    '-f' + self.stateful_config_file,
                    '-o' + self.override_config_file,

--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -109,12 +109,12 @@ class HeronExecutorTest(unittest.TestCase):
            "-XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=100M " \
            "-XX:+PrintPromotionFailure -XX:+PrintTenuringDistribution -XX:+PrintHeapAtGC " \
            "-XX:+HeapDumpOnOutOfMemoryError -XX:+UseConcMarkSweepGC -XX:+PrintCommandLineFlags " \
-           "-Xloggc:log-files/gc.metricsmgr.log -Djava.net.preferIPv4Stack=true " \
+           "-Xloggc:log-files/gc.metricsmgr-%d.log -Djava.net.preferIPv4Stack=true " \
            "-cp metricsmgr_classpath org.apache.heron.metricsmgr.MetricsManager " \
            "--id=metricsmgr-%d --port=metricsmgr_port " \
            "--topology=topname --cluster=cluster --role=role --environment=environ --topology-id=topid " \
            "--system-config-file=%s --override-config-file=%s --sink-config-file=metrics_sinks_config_file" %\
-           (container_id, INTERNAL_CONF_PATH, OVERRIDE_PATH)
+           (container_id, container_id, INTERNAL_CONF_PATH, OVERRIDE_PATH)
 
   def get_expected_metricscachemgr_command():
       return "heron_java_home/bin/java -Xmx1024M -XX:+PrintCommandLineFlags -verbosegc " \


### PR DESCRIPTION
Currently, if you are running a topology locally, all metrics managers write to the same GC log file which is not useful.

This PR separates the GC files for different metrics managers and checkpoint managers.