### PR TITLE
Add a cap to metrics communicator in TMasterSink and MetricsCacheSink

### DIFF
--- a/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/sink/metricscache/MetricsCacheClient.java
+++ b/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/sink/metricscache/MetricsCacheClient.java
@@ -93,12 +93,20 @@ public class MetricsCacheClient extends HeronClient implements Runnable {
     Runnable task = new Runnable() {
       @Override
       public void run() {
-        while (!publishMetricsCommunicator.isEmpty()) {
-          TopologyMaster.PublishMetrics publishMetrics = publishMetricsCommunicator.poll();
+        TopologyMaster.PublishMetrics publishMetrics;
+        synchronized (publishMetricsCommunicator) {
+          publishMetrics = publishMetricsCommunicator.poll();
+        }
+        while (publishMetrics != null) {
           LOG.info(String.format("%d Metrics, %d Exceptions to send to MetricsCache",
               publishMetrics.getMetricsCount(), publishMetrics.getExceptionsCount()));
           LOG.fine("Publish Metrics sending to MetricsCache: " + publishMetrics.toString());
+
           sendMessage(publishMetrics);
+
+          synchronized (publishMetricsCommunicator) {
+            publishMetrics = publishMetricsCommunicator.poll();
+          }
         }
       }
     };

--- a/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/sink/metricscache/MetricsCacheClient.java
+++ b/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/sink/metricscache/MetricsCacheClient.java
@@ -94,19 +94,20 @@ public class MetricsCacheClient extends HeronClient implements Runnable {
       @Override
       public void run() {
         TopologyMaster.PublishMetrics publishMetrics;
-        synchronized (publishMetricsCommunicator) {
-          publishMetrics = publishMetricsCommunicator.poll();
-        }
-        while (publishMetrics != null) {
+        while (true) {
+          synchronized (publishMetricsCommunicator) {
+            publishMetrics = publishMetricsCommunicator.poll();
+          }
+          if (publishMetrics == null) {
+            break;  // No metrics left
+          }
+
           LOG.info(String.format("%d Metrics, %d Exceptions to send to MetricsCache",
               publishMetrics.getMetricsCount(), publishMetrics.getExceptionsCount()));
           LOG.fine("Publish Metrics sending to MetricsCache: " + publishMetrics.toString());
 
           sendMessage(publishMetrics);
 
-          synchronized (publishMetricsCommunicator) {
-            publishMetrics = publishMetricsCommunicator.poll();
-          }
         }
       }
     };

--- a/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/sink/metricscache/MetricsCacheSink.java
+++ b/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/sink/metricscache/MetricsCacheSink.java
@@ -83,6 +83,8 @@ import org.apache.heron.spi.metricsmgr.sink.SinkContext;
 public class MetricsCacheSink implements IMetricsSink {
   private static final Logger LOG = Logger.getLogger(MetricsCacheSink.class.getName());
 
+  private static final int MAX_COMMUNICATOR_SIZE = 128;
+
   // These configs would be read from metrics-sink-configs.yaml
   private static final String KEY_TMASTER_LOCATION_CHECK_INTERVAL_SEC =
       "metricscache-location-check-interval-sec";
@@ -232,10 +234,27 @@ public class MetricsCacheSink implements IMetricsSink {
 
     metricsCommunicator.offer(publishMetrics.build());
 
+
+
     // Update metrics
     sinkContext.exportCountMetric(RECORD_PROCESS_COUNT, 1);
     sinkContext.exportCountMetric(METRICS_COUNT, publishMetrics.getMetricsCount());
     sinkContext.exportCountMetric(EXCEPTIONS_COUNT, publishMetrics.getExceptionsCount());
+
+    checkCommunicator(metricsCommunicator, MAX_COMMUNICATOR_SIZE);
+  }
+
+  // Check if the communicator is full/overflow. Poll and drop extra elements that
+  // are over the queue limit from the head.
+  public static void checkCommunicator(Communicator<TopologyMaster.PublishMetrics> communicator,
+                                        int maxSize) {
+    synchronized (communicator) {
+      int size = communicator.size();
+
+      for (int i = 0; i < size - maxSize; ++i) {
+        communicator.poll();
+      }
+    }
   }
 
   @Override

--- a/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/sink/tmaster/TMasterClient.java
+++ b/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/sink/tmaster/TMasterClient.java
@@ -89,19 +89,19 @@ public class TMasterClient extends HeronClient implements Runnable {
       @Override
       public void run() {
         TopologyMaster.PublishMetrics publishMetrics;
-        synchronized (publishMetricsCommunicator) {
-          publishMetrics = publishMetricsCommunicator.poll();
-        }
-        while (publishMetrics != null) {
+        while (true) {
+          synchronized (publishMetricsCommunicator) {
+            publishMetrics = publishMetricsCommunicator.poll();
+          }
+          if (publishMetrics == null) {
+            break;  // No metrics left
+          }
+
           LOG.info(String.format("%d Metrics, %d Exceptions to send to TMaster",
               publishMetrics.getMetricsCount(), publishMetrics.getExceptionsCount()));
           LOG.fine("Publish Metrics sending to TMaster: " + publishMetrics.toString());
 
           sendMessage(publishMetrics);
-
-          synchronized (publishMetricsCommunicator) {
-            publishMetrics = publishMetricsCommunicator.poll();
-          }
         }
       }
     };

--- a/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/sink/tmaster/TMasterClient.java
+++ b/heron/metricsmgr/src/java/org/apache/heron/metricsmgr/sink/tmaster/TMasterClient.java
@@ -88,12 +88,20 @@ public class TMasterClient extends HeronClient implements Runnable {
     Runnable task = new Runnable() {
       @Override
       public void run() {
-        while (!publishMetricsCommunicator.isEmpty()) {
-          TopologyMaster.PublishMetrics publishMetrics = publishMetricsCommunicator.poll();
+        TopologyMaster.PublishMetrics publishMetrics;
+        synchronized (publishMetricsCommunicator) {
+          publishMetrics = publishMetricsCommunicator.poll();
+        }
+        while (publishMetrics != null) {
           LOG.info(String.format("%d Metrics, %d Exceptions to send to TMaster",
               publishMetrics.getMetricsCount(), publishMetrics.getExceptionsCount()));
           LOG.fine("Publish Metrics sending to TMaster: " + publishMetrics.toString());
+
           sendMessage(publishMetrics);
+
+          synchronized (publishMetricsCommunicator) {
+            publishMetrics = publishMetricsCommunicator.poll();
+          }
         }
       }
     };

--- a/heron/metricsmgr/tests/java/org/apache/heron/metricsmgr/sink/metricscache/MetricsCacheSinkTest.java
+++ b/heron/metricsmgr/tests/java/org/apache/heron/metricsmgr/sink/metricscache/MetricsCacheSinkTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.heron.api.metric.MultiCountMetric;
+import org.apache.heron.common.basics.Communicator;
 import org.apache.heron.common.basics.SingletonRegistry;
 import org.apache.heron.common.basics.SysUtils;
 import org.apache.heron.common.config.SystemConfig;
@@ -187,5 +188,31 @@ public class MetricsCacheSinkTest {
     assertEquals(newLoc, metricsCacheSink.getCurrentMetricsCacheLocationInService());
 
     metricsCacheSink.close();
+  }
+
+  @Test
+  public void testCheckCommunicator() {
+    Communicator<TopologyMaster.PublishMetrics> communicator = new Communicator<>();
+    int initSize = 16;
+    int capSize = 10;
+
+    TopologyMaster.PublishMetrics.Builder publishMetrics =
+        TopologyMaster.PublishMetrics.newBuilder();
+    for (int i = 0; i < initSize; ++i) {
+      communicator.offer(publishMetrics.build());
+    }
+    assertEquals(communicator.size(), initSize);
+
+    MetricsCacheSink.checkCommunicator(communicator, initSize + 1);
+    assertEquals(communicator.size(), initSize);
+
+    MetricsCacheSink.checkCommunicator(communicator, initSize);
+    assertEquals(communicator.size(), initSize);
+
+    MetricsCacheSink.checkCommunicator(communicator, initSize - 1);
+    assertEquals(communicator.size(), initSize - 1);
+
+    MetricsCacheSink.checkCommunicator(communicator, capSize);
+    assertEquals(communicator.size(), capSize);
   }
 }

--- a/heron/metricsmgr/tests/java/org/apache/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
+++ b/heron/metricsmgr/tests/java/org/apache/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.heron.api.metric.MultiCountMetric;
+import org.apache.heron.common.basics.Communicator;
 import org.apache.heron.common.basics.SingletonRegistry;
 import org.apache.heron.common.basics.SysUtils;
 import org.apache.heron.common.config.SystemConfig;
@@ -185,6 +186,32 @@ public class TMasterSinkTest {
     assertEquals(newLoc, tMasterSink.getCurrentTMasterLocationInService());
 
     tMasterSink.close();
+  }
+
+  @Test
+  public void testCheckCommunicator() {
+    Communicator<TopologyMaster.PublishMetrics> communicator = new Communicator<>();
+    int initSize = 16;
+    int capSize = 10;
+
+    TopologyMaster.PublishMetrics.Builder publishMetrics =
+        TopologyMaster.PublishMetrics.newBuilder();
+    for (int i = 0; i < initSize; ++i) {
+      communicator.offer(publishMetrics.build());
+    }
+    assertEquals(communicator.size(), initSize);
+
+    TMasterSink.checkCommunicator(communicator, initSize + 1);
+    assertEquals(communicator.size(), initSize);
+
+    TMasterSink.checkCommunicator(communicator, initSize);
+    assertEquals(communicator.size(), initSize);
+
+    TMasterSink.checkCommunicator(communicator, initSize - 1);
+    assertEquals(communicator.size(), initSize - 1);
+
+    TMasterSink.checkCommunicator(communicator, capSize);
+    assertEquals(communicator.size(), capSize);
   }
 }
 


### PR DESCRIPTION
Without the cap, when MetricsCacheSink is enabled but MetricsCache is not running, the communication will keep growing.

The same thing could happen with TMaster but it is less likely to have the problem.