### PR TITLE
Add a script to start docker container with development environment

### DIFF
--- a/docker/compile/Dockerfile.centos7
+++ b/docker/compile/Dockerfile.centos7
@@ -41,9 +41,9 @@ RUN yum -y install \
       zip \
       unzip \
       wget \
-      which
-
-RUN yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel
+      which \
+      java-1.8.0-openjdk \
+      java-1.8.0-openjdk-devel
 
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0
 

--- a/docker/compile/Dockerfile.ubuntu18.04
+++ b/docker/compile/Dockerfile.ubuntu18.04
@@ -31,9 +31,10 @@ RUN apt-get update && apt-get -y install \
       python-dev \
       wget \
       zip \
-      unzip
-
-RUN apt-get -y install openjdk-8-jdk-headless
+      virtualenv \
+      unzip \
+      git \
+      openjdk-8-jdk-headless
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 

--- a/docker/compile/Dockerfile.ubuntu18.04
+++ b/docker/compile/Dockerfile.ubuntu18.04
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get -y install \
       virtualenv \
       unzip \
       git \
+      curl \
       openjdk-8-jdk-headless
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64

--- a/docker/scripts/dev-env.sh
+++ b/docker/scripts/dev-env.sh
@@ -23,22 +23,23 @@
 # To create a clean development environment with docker and run it,
 # execute the following scripts in the source directory of Heron:
 #   sh docker/scripts/dev-env.sh
-# After the container is started, enter the source code directory
-# and build with bazel (assuming it's a ubuntu container):
-#   cd heron
+#
+# After the container is started, build Heron with bazel
+# (ubuntu config is used in the example):
 #   ./bazel_configure.py
 #   bazel build --config=ubuntu heron/...
-# To enter an existing container after leaving it, find the container
+#
+# To enter an existing container with a new shell, find the container
 # id with this command:
 #   docker ps -a
-# Then enter the container by
-#   docker start -ai CONTAINER_ID
+# And then :
+#   docker exec -it CONTAINER_ID bash
 
 set -o nounset
 set -o errexit
 
 # Default platform is ubuntu18.04. Other available platforms
-# include centos7
+# include centos7, debian9
 TARGET_PLATFORM=${1:-"ubuntu18.04"}
 SCRATCH_DIR=${2:-"$HOME/.heron-docker"}
 REPOSITORY="heron-dev"
@@ -76,8 +77,10 @@ echo "Building docker container for Heron development environment on $TARGET_PLA
 docker build -t $REPOSITORY:$TARGET_PLATFORM -f $DOCKER_FILE $SCRATCH_DIR
 
 echo "Running container and mapping the current dir to /heron"
-docker run -i \
+docker run -it \
     -e TARGET_PLATFORM=$TARGET_PLATFORM \
     -e SCRATCH_DIR="/scratch" \
     -v $PROJECT_DIR:/heron \
+    -w "/heron" \
+    --network host \
     -t $REPOSITORY:$TARGET_PLATFORM bash

--- a/docker/scripts/dev-env.sh
+++ b/docker/scripts/dev-env.sh
@@ -73,14 +73,15 @@ DOCKER_FILE=$(dockerfile_path_for_platform $TARGET_PLATFORM)
 verify_dockerfile_exists $DOCKER_FILE
 copy_extra_files
 
-echo "Building docker container for Heron development environment on $TARGET_PLATFORM"
+echo "Building docker image for Heron development environment on $TARGET_PLATFORM"
 docker build -t $REPOSITORY:$TARGET_PLATFORM -f $DOCKER_FILE $SCRATCH_DIR
 
-echo "Running container and mapping the current dir to /heron"
-docker run -it \
+echo "Creating and starting container and mapping the current dir to /heron"
+docker container run -it \
     -e TARGET_PLATFORM=$TARGET_PLATFORM \
     -e SCRATCH_DIR="/scratch" \
     -v $PROJECT_DIR:/heron \
     -w "/heron" \
-    --network host \
+    -p 8888:8888 \
+    -p 8889:8889 \
     -t $REPOSITORY:$TARGET_PLATFORM bash

--- a/docker/scripts/docker-dev-env.sh
+++ b/docker/scripts/docker-dev-env.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This is a script to start a docker container that has all
+# tools needed to compire Heron. Developer should be able to
+# compile Heron in the container without any setup works.
+# usage:
+# To create a clean development environment, enter the source
+# code directory of Heron and then execute the following scripts: 
+#   sh docker/scripts/docker-dev-env.sh
+# To enter an existing container, find the container id with:
+#   docker ps -a
+# Then enter the container by
+#   docker start -ai CONTAINER_ID
+# After the container is started, enter the source code directory
+# and build with bazel (assuming it's a ubuntu container):
+#   cd heron
+#   bazel build --config=ubuntu heron/...
+
+set -o nounset
+set -o errexit
+
+# Default platform is ubuntu18.04. Other available platforms
+# include centos7
+TARGET_PLATFORM=${1:-"ubuntu18.04"}
+SCRATCH_DIR="docker"
+
+
+realpath() {
+  echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+}
+
+DOCKER_DIR=$(dirname $(dirname $(realpath $0)))
+PROJECT_DIR=$(dirname $DOCKER_DIR)
+
+verify_dockerfile_exists() {
+  if [ ! -f $1 ]; then
+    echo "The Dockerfiler $1 does not exist"
+    exit 1
+  fi
+}
+
+dockerfile_path_for_platform() {
+  echo "$SCRATCH_DIR/compile/Dockerfile.$1"
+}
+
+DOCKER_FILE=$(dockerfile_path_for_platform $TARGET_PLATFORM)
+verify_dockerfile_exists $DOCKER_FILE
+
+echo $DOCKER_FILE
+
+echo "Building docker container for development environment"
+docker build -t heron-dev:$TARGET_PLATFORM -f $DOCKER_FILE $SCRATCH_DIR
+
+echo "Running container and mapping the current dir to /heron"
+docker run -i \
+    -e TARGET_PLATFORM=$TARGET_PLATFORM \
+    -e SCRATCH_DIR="/scratch" \
+    -v $PROJECT_DIR:/heron \
+    -t heron-dev:$TARGET_PLATFORM bash


### PR DESCRIPTION
Mac dev environment could be tricky to set up since it requires Xcode's toolchain, and it is not easy to troubleshoot. This docker script can be useful for compiling source code without any setup other than installing Docker.

To use the script to create a docker image and run it:
$ sh docker/scripts/dev-env.sh

Write down the Docker container id (you can also find it with this command: "docker ps -a"). Next time you can run "docker container exec -it CONTAINER_ID bash" to start a new shell in the same container.

In the container:
$ ./bazel_config.py
$ bazel build --config=ubuntu heron/...

This is just the first version. There are a lot of room to improve. Any feedback is welcome~
