### PR TITLE
License work

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -235,6 +235,24 @@ See project link for details.
       -> tools/rules/javadoc.bzl
     k8s-zookeeper-docker(https://github.com/muxinc/k8s-zookeeper-docker/blob/master/LICENSE)
       -> docker/base/scripts/generate-zookeeper-config.sh
+    bazel_rules_pex(v0.3.0,https://github.com/benley/bazel_rules_pex/blob/master/LICENSE.txt)
+      -> tools/rules/pex/pex_rules.bzl
+      -> tools/rules/pex/wrapper/pex_wrapper.py
+    bazel_authors(https://github.com/bazelbuild/bazel/blob/master/LICENSE)
+      -> scripts/setup-eclipse.sh
+      -> scripts/detect_os_type.sh
+      -> scripts/get_all_heron_paths.sh
+      -> scripts/packages/template_bin.sh
+      -> scripts/packages/self_extract_binary.bzl
+      -> scripts/packages/package_info_generator.sh
+      -> scripts/packages/tests_template_bin.sh
+      -> scripts/packages/bin_common.sh
+      -> third_party/java/bazel/extra_actions_base.proto
+    Twitter
+      -> heron/shell/src/python/handlers/healthhandler.py
+    Google
+      -> third_party/java/jarjar/src/main/resources/com/tonicsystems/jarjar/help.txt
+
 
 ========================================================================
 Third party MIT licenses
@@ -264,6 +282,17 @@ The following components are provided under the MIT License. See project link fo
     normalize.css(v2.1.0, v3.0.1, https://github.com/necolas/normalize.css/blob/master/LICENSE.md)
       -> heron/tools/ui/resources/static/css/bootstrap.css
       -> heron/tools/ui/resources/static/css/bootstrap.min.css
+    Docusaurus(v1.13.0, https://github.com/facebook/docusaurus/blob/master/LICENSE)
+      -> website2/website/core/Footer.js
+      -> website2/website/siteConfig.js
+      -> website2/website/pages/en/users.js
+      -> website2/website/pages/en/index.js
+      -> website2/website/pages/en/help.js
+      -> website2/website/pages/en/versions.js
+    Sizzle(https://github.com/jquery/sizzle/blob/master/LICENSE.txt)
+      -> heron/shell/assets/jquery.js
+    Modernizr(http://www.modernizr.com)
+      -> heron/tools/ui/resources/static/js/bootstrap.js
 
 ========================================================================
 Third party BSD 3-Clause licenses
@@ -282,6 +311,8 @@ See project link for details.
       -> third_party/python/cpplint/cpplint.py
     d3(v3.4.11, https://github.com/d3/d3/blob/master/LICENSE)
       -> heron/tools/ui/resources/static/js/d3.min.3.4.11.js
+    Sizzle(https://github.com/jquery/sizzle/blob/master/LICENSE.txt)
+          -> heron/shell/assets/jquery.js
 
 ========================================================================
 Third party Boost Software License, Version 1.0 licenses
@@ -292,3 +323,13 @@ See project link for details.
 
     kashmir(https://github.com/Corvusoft/kashmir-dependency/blob/master/LICENSE_1_0.txt)
       -> third_party/kashmir/*
+
+========================================================================
+Third party GNU General Public License, Version 3.0 licenses
+========================================================================
+
+The following components are provided under the GNU General Public License, Version 3.0.
+See project link for details.
+
+    Sizzle(https://github.com/jquery/sizzle/blob/master/LICENSE.txt)
+          -> heron/shell/assets/jquery.js

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Heron
-Copyright 2018 The Apache Software Foundation
+Copyright 2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
@nwangtw This is an attempt to address the licensing issues brought up in our last release.  
The email thread for the last release is [here](https://mail-archives.apache.org/mod_mbox/incubator-general/201907.mbox/%3CCAFkuAo0heb65W6%2BX%3DNgmLxK0XY4WPK0cuM5EWxWW%2B%3DHDhNrotA%40mail.gmail.com%3E).  This is my first attempt to work on the licenses in the project.  Hopefully it is not too far off and will get us a step closer to releasing binaries for the project.

For convenience I picked through to copy and paste comments from the last release thread on general@incubator that addressed issues with the licenses in the project below this line

```
The third party licenses could use a little work. The License text should be included in LICENSE or pulled into the licenses directory. Any required copyright attribution should be in the NOTICE. Please create an issue to fix these for the next release. 
RAT Check. The *.md files should have Apache License Headers and CONTRIBUTING.md is link where the target is missing in the release.
 Please create an issue to fix .rat-excludes and fix the md files license. Please create an issue to annotate .rat-excludes to explain any that are excludes related to other licensing.
```
```
NOTICE has incorrect year (please update for next time)
LICENSE is missing a number of permissive licenses (I didn't check ones
Justin had already covered but third_party\python\semver seems to be
missing from list of BSD licensed software though it does appear in your
rat excludes - please add for next release)
```
```
Licence is misisng
-  MIT licensed software copyright  Facebook [1][2][3][4][5][6]
- ALv2 files [7][8]
- ALv2 files [9][10][11][12][13][14][15][16]
- this ALv2 file [17]
- this  ALv2 file [18]
- this ALv2 file [19]
- this file [20] includes Sizzle (MIT, BSD, and GPL Licenses)
- this file [21] includes modernizr (MIT licensed)

(I just did a search for the word copyright and match what was listed in the LICENSE file if you’re wondering how I found these)

1. ./website2/website/core/Footer.js
2. ./website2/website/siteConfig.js
3. ./website2/website/pages/en/users.js
4. ./website2/website/pages/en/index.js
5. ./website2/website/pages/en/help.js
6. ./website2/website/pages/en/versions.js
7. ./tools/rules/pex/pex_rules.bzl
8. ./tools/rules/pex/wrapper/pex_wrapper.py
9. ./scripts/setup-eclipse.sh
10. ./scripts/detect_os_type.sh
11. ./scripts/get_all_heron_paths.sh
12. ./scripts/packages/template_bin.sh
13. ./scripts/packages/self_extract_binary.bzl
14. ./scripts/packages/package_info_generator.sh
15. ./scripts/packages/tests_template_bin.sh
16. ./scripts/packages/bin_common.sh
17. ../heron/shell/src/python/handlers/healthhandler.py
18. ./third_party/java/bazel/extra_actions_base.proto
19. ./third_party/java/jarjar/src/main/resources/com/tonicsystems/jarjar/help.txt
20. ./heron/shell/assets/jquery.js
21 ./heron/tools/ui/resources/static/js/bootstrap.js

```