### PR TITLE
Update Kubernetes proxy URLs

### DIFF
--- a/deploy/kubernetes/general/README.md
+++ b/deploy/kubernetes/general/README.md
@@ -75,7 +75,7 @@ $ kubectl proxy -p 8001
 2. Verify we can access the API server:
 
 ```shell
-$ curl http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-apiserver:9000/api/v1/version
+$ curl http://localhost:8001/api/v1/namespaces/default/services/heron-apiserver:9000/proxy/api/v1/version
 {
    "heron.build.git.revision" : "bf9fe93f76b895825d8852e010dffd5342e1f860",
    "heron.build.git.status" : "Clean",
@@ -90,7 +90,7 @@ $ curl http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-apis
 3. Set service_url:
 ```shell
 $ heron config kubernetes \
-set service_url http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-apiserver:9000 \
+set service_url http://localhost:8001/api/v1/namespaces/default/services/heron-apiserver:9000/proxy \
 org.apache.heron.examples.api.AckingTopology acking
 ```
 
@@ -102,5 +102,5 @@ org.apache.heron.examples.api.AckingTopology acking
 
 5. View heron ui:
 ```
-http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-ui:8889
+http://localhost:8001/api/v1/namespaces/default/services/heron-ui:8889/proxy
 ```

--- a/deploy/kubernetes/minikube/README.md
+++ b/deploy/kubernetes/minikube/README.md
@@ -74,7 +74,7 @@ $ kubectl proxy -p 8001
 2. Verify we can access the API server:
 
 ```shell
-$ curl http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-apiserver:9000/api/v1/version
+$ curl http://localhost:8001/api/v1/namespaces/default/services/heron-apiserver:9000/proxy/api/v1/version
 {
    "heron.build.git.revision" : "bf9fe93f76b895825d8852e010dffd5342e1f860",
    "heron.build.git.status" : "Clean",
@@ -89,7 +89,7 @@ $ curl http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-apis
 3. Set service_url:
 ```shell
 $ heron config kubernetes \
-set service_url http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-apiserver:9000 \
+set service_url http://localhost:8001/api/v1/namespaces/default/services/heron-apiserver:9000/proxy \
 ```
 
 4. Submit an example topology:
@@ -100,5 +100,5 @@ org.apache.heron.examples.api.AckingTopology acking
 
 5. View heron ui:
 ```
-http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-ui:8889
+http://localhost:8001/api/v1/namespaces/default/services/heron-ui:8889/proxy
 ```

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -84,7 +84,7 @@ public final class KubernetesConstants {
   }
 
   public static final String JOB_LINK =
-      "/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/#/pod";
+      "/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy/#/pod";
 
 
   public static final Pattern VALID_POD_NAME_REGEX =

--- a/website/content/docs/operators/deployment/schedulers/kubernetes.md
+++ b/website/content/docs/operators/deployment/schedulers/kubernetes.md
@@ -321,7 +321,7 @@ Success! You can now manage Heron topologies on your GKE Kubernetes installation
 
 ```bash
 $ heron submit kubernetes \
-  --service-url=http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-apiserver:9000 \
+  --service-url=http://localhost:8001/api/v1/namespaces/default/services/heron-apiserver:9000/proxy \
   ~/.heron/examples/heron-api-examples.jar \
   org.apache.heron.examples.api.AckingTopology acking
 ```
@@ -445,7 +445,7 @@ That would enable you to manage topologies without setting the `--service-url` f
 
 The [Heron UI](../../../heron-ui) is an in-browser dashboard that you can use to monitor your Heron [topologies](../../../../concepts/topologies). It should already be running in your GKE cluster.
 
-You can access [Heron UI](../../../heron-ui) in your browser by navigating to http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-ui:8889.
+You can access [Heron UI](../../../heron-ui) in your browser by navigating to http://localhost:8001/api/v1/namespaces/default/services/heron-ui:8889/proxy.
 
 ## Heron on Kubernetes configuration
 

--- a/website2/docs/schedulers-k8s-by-hand.md
+++ b/website2/docs/schedulers-k8s-by-hand.md
@@ -319,7 +319,7 @@ Success! You can now manage Heron topologies on your GKE Kubernetes installation
 
 ```bash
 $ heron submit kubernetes \
-  --service-url=http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-apiserver:9000 \
+  --service-url=http://localhost:8001/api/v1/namespaces/default/services/heron-apiserver:9000/proxy \
   ~/.heron/examples/heron-api-examples.jar \
   org.apache.heron.examples.api.AckingTopology acking
 ```
@@ -443,7 +443,7 @@ That would enable you to manage topologies without setting the `--service-url` f
 
 The [Heron UI](user-manuals-heron-ui) is an in-browser dashboard that you can use to monitor your Heron [topologies](heron-topology-concepts). It should already be running in your GKE cluster.
 
-You can access [Heron UI](user-manuals-heron-ui) in your browser by navigating to http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-ui:8889.
+You can access [Heron UI](user-manuals-heron-ui) in your browser by navigating to http://localhost:8001/api/v1/namespaces/default/services/heron-ui:8889/proxy.
 
 ## Heron on Kubernetes configuration
 

--- a/website2/website/versioned_docs/version-0.20.0-incubating/schedulers-k8s-by-hand.md
+++ b/website2/website/versioned_docs/version-0.20.0-incubating/schedulers-k8s-by-hand.md
@@ -320,7 +320,7 @@ Success! You can now manage Heron topologies on your GKE Kubernetes installation
 
 ```bash
 $ heron submit kubernetes \
-  --service-url=http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-apiserver:9000 \
+  --service-url=http://localhost:8001/api/v1/namespaces/default/services/heron-apiserver:9000/proxy \
   ~/.heron/examples/heron-api-examples.jar \
   org.apache.heron.examples.api.AckingTopology acking
 ```
@@ -444,7 +444,7 @@ That would enable you to manage topologies without setting the `--service-url` f
 
 The [Heron UI](user-manuals-heron-ui) is an in-browser dashboard that you can use to monitor your Heron [topologies](heron-topology-concepts). It should already be running in your GKE cluster.
 
-You can access [Heron UI](user-manuals-heron-ui) in your browser by navigating to http://localhost:8001/api/v1/proxy/namespaces/default/services/heron-ui:8889.
+You can access [Heron UI](user-manuals-heron-ui) in your browser by navigating to http://localhost:8001/api/v1/namespaces/default/services/heron-ui:8889/proxy.
 
 ## Heron on Kubernetes configuration
 


### PR DESCRIPTION
Fix https://github.com/apache/incubator-heron/issues/3404

Follow the Kubernetes proxy URLs documented [here](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#manually-constructing-apiserver-proxy-urls) (Note that `proxy` is placed after the service name instead of `/api/v1`):

> http://kubernetes_master_address/api/v1/namespaces/namespace_name/services/service_name[:port_name]/proxy