### PR TITLE
BUG: bookie statefulset helm template specifies incorrect service name

### DIFF
--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -71,7 +71,7 @@ metadata:
     component: {{ .Release.Name }}-bookie
 spec:
 {{- if or (eq .Values.platform "gke") (eq .Values.platform "minikube") }}
-  serviceName: {{ .Release.Name }}-bookkeeper
+  serviceName: {{ .Release.Name }}-bookie
   replicas: {{ $bookieReplicas }}
 {{- end }}
 

--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -200,6 +200,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if or (eq .Values.platform "gke") (eq .Values.platform "minikube") }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  {{- end }}
   name: {{ .Release.Name }}-bookie
   labels:
     app: {{ .Release.Name }}-bookkeeper


### PR DESCRIPTION
The statefulset's service name:
https://github.com/apache/incubator-heron/blob/master/deploy/kubernetes/helm/templates/bookie.yaml#L74
Doesnt match the actual name of the service:
https://github.com/apache/incubator-heron/blob/master/deploy/kubernetes/helm/templates/bookie.yaml#L203
I believe bookie previously was using the podIPs to connect and the service wasnt actually getting used. Changing the useBookieHostNameAsID to true caused the helm chart to use the service for the first time to connect, which ultimately failed since it was named the wrong name.