### PR TITLE
Removing old com.twitter namespace references

### DIFF
--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -133,7 +133,7 @@ spec:
               -D heron.statefulstorage.classname=org.apache.heron.statefulstorage.dlog.DlogStorage
               -D heron.statefulstorage.dlog.namespace.uri=distributedlog://{{ .Release.Name }}-zookeeper:{{ .Values.zookeeper.clientPort }}/heron
               {{- if eq .Values.uploader.class "dlog" }}
-              -D heron.class.uploader=com.twitter.heron.uploader.dlog.DLUploader
+              -D heron.class.uploader=org.apache.heron.uploader.dlog.DLUploader
               -D heron.uploader.dlog.topologies.num.replicas={{ $jobReplicas }}
               -D heron.uploader.dlog.topologies.namespace.uri=distributedlog://{{ .Release.Name }}-zookeeper:{{ .Values.zookeeper.clientPort }}/heron
               {{- else if eq .Values.uploader.class "s3" }}
@@ -145,8 +145,8 @@ spec:
               -D heron.uploader.s3.region={{ .Values.uploader.s3Region }}
               {{- end }}
               {{- if eq .Values.packing "RoundRobin" }}
-              -D heron.class.packing.algorithm=com.twitter.heron.packing.roundrobin.RoundRobinPacking
-              -D heron.class.repacking.algorithm=com.twitter.heron.packing.roundrobin.RoundRobinPacking
+              -D heron.class.packing.algorithm=org.apache.heron.packing.roundrobin.RoundRobinPacking
+              -D heron.class.repacking.algorithm=org.apache.heron.packing.roundrobin.RoundRobinPacking
               {{- else if eq .Values.packing "ResourceCompliantRR" }}
               -D heron.class.packing.algorithm=org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking
               -D heron.class.repacking.algorithm=org.apache.heron.packing.roundrobin.ResourceCompliantRRPacking


### PR DESCRIPTION
The com.twitter names work with the older 0.17 builds, but anything using 0.20 should be using the org.apache namespace.