### PR TITLE
Fix Helm values.yml typo

### DIFF
--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -40,7 +40,7 @@ jobReplicas: 1
 # amount of memory to provide for API server
 apiServerMemory: 512M
 heron:
-  url:/api/v1/namespaces/{{ .Release.Namespace }}/services/{{ .Release.Name }}-ui:8889/proxy
+  url: /api/v1/namespaces/{{ .Release.Namespace }}/services/{{ .Release.Name }}-ui:8889/proxy
 # Topologies uploader
 uploader:
   class: dlog # s3


### PR DESCRIPTION
The yaml was not valid because of a missing space. Helm install would fail without this fix.