### PR TITLE
Updated compile docker images to include `tree` package

### DIFF
--- a/docker/compile/Dockerfile.centos7
+++ b/docker/compile/Dockerfile.centos7
@@ -42,6 +42,7 @@ RUN yum -y install \
       unzip \
       wget \
       which \
+      tree \
       java-1.8.0-openjdk \
       java-1.8.0-openjdk-devel
 

--- a/docker/compile/Dockerfile.debian9
+++ b/docker/compile/Dockerfile.debian9
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get -y install \
       python2.7-dev \
       software-properties-common \
       python-setuptools \
+      tree \
       zip \
       unzip \
       wget

--- a/docker/compile/Dockerfile.ubuntu14.04
+++ b/docker/compile/Dockerfile.ubuntu14.04
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get -y install \
       unzip \
       wget \
       cmake \
+      tree \
       openjdk-8-jdk-headless
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64

--- a/docker/compile/Dockerfile.ubuntu16.04
+++ b/docker/compile/Dockerfile.ubuntu16.04
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get -y install \
       python-software-properties \
       software-properties-common \
       python-setuptools \
+      tree \
       zip \
       unzip \
       wget

--- a/docker/compile/Dockerfile.ubuntu18.04
+++ b/docker/compile/Dockerfile.ubuntu18.04
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get -y install \
       unzip \
       git \
       curl \
+      tree \
       openjdk-8-jdk-headless
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64


### PR DESCRIPTION
The `tree` command is used in some of the scripts/packages/BUILD targets. I'm adding the package in the compile verison of the Dockerfiles for use when using `dev-env.sh` docker script.