### PR TITLE
Updated to use default Kubernetes client discovery logic

### DIFF
--- a/deploy/kubernetes/general/apiserver.yaml
+++ b/deploy/kubernetes/general/apiserver.yaml
@@ -27,7 +27,6 @@ metadata:
   namespace: default
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -44,7 +43,6 @@ subjects:
   namespace: default
 
 ---
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -97,13 +95,8 @@ spec:
               -D heron.uploader.dlog.topologies.namespace.uri=distributedlog://zookeeper:2181/heron
               -D heron.statefulstorage.classname=org.apache.heron.statefulstorage.dlog.DlogStorage
               -D heron.statefulstorage.dlog.namespace.uri=distributedlog://zookeeper:2181/heron
-        - name: kubectl-proxy
-          image: heron/kubectl:latest
-          command: ["sh", "-c"]
-          args:
-            - >
-              kubectl proxy -p 8001
----    
+
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/kubernetes/general/bookkeeper.statefulset.yaml
+++ b/deploy/kubernetes/general/bookkeeper.statefulset.yaml
@@ -34,8 +34,8 @@ data:
     #BK_statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
     # use hostname as bookie id for StatefulSets deployment
     BK_useHostNameAsBookieID: "true"
----
 
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -122,6 +122,7 @@ spec:
         resources:
           requests:
             storage: 10Gi
+
 ---
 # A headless service to create DNS records
 apiVersion: v1

--- a/deploy/kubernetes/general/bookkeeper.statefulset_empty.yaml
+++ b/deploy/kubernetes/general/bookkeeper.statefulset_empty.yaml
@@ -34,8 +34,8 @@ data:
     #BK_statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
     # use hostname as bookie id for StatefulSets deployment
     BK_useHostNameAsBookieID: "true"
----
 
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/deploy/kubernetes/general/bookkeeper.yaml
+++ b/deploy/kubernetes/general/bookkeeper.yaml
@@ -32,8 +32,8 @@ data:
   BK_zkServers: zookeeper
   # TODO: Issue 458: https://github.com/apache/bookkeeper/issues/458
   #BK_statsProviderClass: org.apache.bookkeeper.stats.PrometheusMetricsProvider
----
 
+---
 ## BookKeeper servers need to access the local disks and the pods
 ## cannot be moved across different nodes.
 ## For this reason, we run BK as a daemon set, one for each node in the
@@ -107,7 +107,6 @@ spec:
             path: /mnt/disks/ssd1
 
 ---
-
 ##
 ## Define the Bookie headless service
 ## In practice, in this case, it is only useful to have a view of

--- a/deploy/kubernetes/general/tools.yaml
+++ b/deploy/kubernetes/general/tools.yaml
@@ -85,8 +85,8 @@ spec:
             limits:
               cpu: "400m"
               memory: "512M"
----
 
+---
 ##
 ## Service to expose the heron-ui
 ##

--- a/deploy/kubernetes/general/zookeeper.yaml
+++ b/deploy/kubernetes/general/zookeeper.yaml
@@ -30,8 +30,8 @@ spec:
     matchLabels:
       app: zk
   minAvailable: 1
----
 
+---
 ## Define a StatefulSet for ZK servers
 apiVersion: apps/v1
 kind: StatefulSet
@@ -107,7 +107,6 @@ spec:
           emptyDir: {}
 
 ---
-
 ##
 ## Define the ZooKeeper headless service
 ##

--- a/deploy/kubernetes/gke/gcs-apiserver.yaml
+++ b/deploy/kubernetes/gke/gcs-apiserver.yaml
@@ -27,7 +27,6 @@ metadata:
   namespace: default
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -44,7 +43,6 @@ subjects:
   namespace: default
 
 ---
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -106,15 +104,8 @@ spec:
                 configMapKeyRef:
                   name: heron-apiserver-config
                   key: gcs.bucket
-        - name: kubectl-proxy
-          image: heron/kubectl:latest
-          command: ["sh", "-c"]
-          args:
-            - >
-              kubectl proxy -p 8001
 
 ---
-
 ##
 ## Service to expose the heron API server
 ##

--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -50,8 +50,8 @@ data:
   BK_enableTaskExecutionStats: "true"
   BK_statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
   {{- end }}
----
 
+---
 ## BookKeeper servers need to access the local disks and the pods
 ## cannot be moved across different nodes.
 ## For this reason, we run BK as a daemon set, one for each node in the
@@ -195,8 +195,8 @@ spec:
           requests:
             storage: {{ $bookieStorageCapacity }}
 {{- end }}
----
 
+---
 ##
 ## Define the Bookie headless service
 ## In practice, in this case, it is only useful to have a view of

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -26,8 +26,8 @@ metadata:
 data:
   HERON_APISERVER_MEM_MIN: {{ $apiServerMemory | quote }}
   HERON_APISERVER_MEM_MAX: {{ $apiServerMemory | quote }}
----
 
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -161,12 +161,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-tools-config
-        - name: kubectl-proxy
-          image: {{ .Values.kubectlImage }}
-          command: ["sh", "-c"]
-          args:
-            - >
-              kubectl proxy -p 8001
+
 ---
 ##
 ## Service to expose the heron-ui

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -29,7 +29,6 @@ platform: minikube
 
 # Heron image to use
 image: heron/heron:VERSION
-kubectlImage: heron/kubectl:latest
 
 # Heron image pull policy
 imagePullPolicy: IfNotPresent

--- a/deploy/kubernetes/minikube/apiserver.yaml
+++ b/deploy/kubernetes/minikube/apiserver.yaml
@@ -28,7 +28,6 @@ metadata:
   namespace: default
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -45,7 +44,6 @@ subjects:
   namespace: default
 
 ---
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,13 +82,8 @@ spec:
               -D heron.uploader.dlog.topologies.namespace.uri=distributedlog://zookeeper:2181/heron
               -D heron.statefulstorage.classname=org.apache.heron.statefulstorage.dlog.DlogStorage
               -D heron.statefulstorage.dlog.namespace.uri=distributedlog://zookeeper:2181/heron
-        - name: kubectl-proxy
-          image: heron/kubectl:latest
-          command: ["sh", "-c"]
-          args:
-            - >
-              kubectl proxy -p 8001
----    
+
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/AppsV1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/AppsV1Controller.java
@@ -46,8 +46,8 @@ import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1ContainerPort;
 import io.kubernetes.client.openapi.models.V1EnvVar;
@@ -81,7 +81,7 @@ public class AppsV1Controller extends KubernetesController {
       final ApiClient apiClient = io.kubernetes.client.util.Config.defaultClient();
       Configuration.setDefaultApiClient(apiClient);
       appsClient = new AppsV1Api(apiClient);
-    } catch (Exception e) {
+    } catch (IOException e) {
       LOG.log(Level.SEVERE, "Failed to setup Kubernetes client" + e);
       throw new RuntimeException(e);
     }
@@ -195,7 +195,8 @@ public class AppsV1Controller extends KubernetesController {
       "{\"op\":\"replace\",\"path\":\"/spec/replicas\",\"value\":%s}";
 
   V1StatefulSet getStatefulSet() throws ApiException {
-    return appsClient.readNamespacedStatefulSet(getTopologyName(), getNamespace(), null, null, null);
+    return appsClient.readNamespacedStatefulSet(getTopologyName(), getNamespace(),
+        null, null, null);
   }
 
   boolean deleteStatefulSet() {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesCompat.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesCompat.java
@@ -27,8 +27,9 @@ import org.apache.heron.scheduler.TopologyRuntimeManagementException;
 
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+
 import okhttp3.Response;
 
 public class KubernetesCompat {
@@ -41,7 +42,7 @@ public class KubernetesCompat {
       final ApiClient apiClient = io.kubernetes.client.util.Config.defaultClient();
       Configuration.setDefaultApiClient(apiClient);
       coreClient = new CoreV1Api(apiClient);
-    } catch (Exception e) {
+    } catch (IOException e) {
       LOG.log(Level.SEVERE, "Failed to setup Kubernetes client" + e);
       throw new RuntimeException(e);
     }

--- a/heron/schedulers/tests/java/BUILD
+++ b/heron/schedulers/tests/java/BUILD
@@ -64,6 +64,7 @@ kubernetes_deps_files = [
     "//heron/schedulers/src/java:kubernetes-scheduler-java",
     "//heron/schedulers/src/java:scheduler-utils-java",
     "//third_party/java:kubernetes-java-client",
+    "@org_slf4j_slf4j_api//jar",
 ]
 
 nomad_sdk_deps = [


### PR DESCRIPTION
The defaultClient() call incorporates the following logic:
If `$KUBECONFIG` is defined, use that config file.
If `$HOME/.kube/config` can be found, use that.
If the in-cluster service account can be found, assume in cluster config.
Default to `localhost:8080` as a last resort.

With this code change, we'd no longer be using the scheduler config item for K8s scheduler URI. But the config item is used to create Job Links. So I couldn't get rid of that config item.

Any thoughts on how I could fully remove the scheduler URI config item?
Do you think the defaultClient() code is good enough? It seemed to work in my Minikube testing and I figured worst case that last option would point to kubectl-proxy  if we update it to use port 8080. I assume if someone needs to run the Heron API Server outside of the k8s cluster, then can configure with the `$KUBECONFIG` environment variable.
