### PR TITLE
add downloader-core filegroup

### DIFF
--- a/heron/downloaders/src/java/BUILD
+++ b/heron/downloaders/src/java/BUILD
@@ -27,6 +27,13 @@ filegroup(
   srcs = glob(["**/DownloadRunner.java"]),
 )
 
+filegroup(
+  name = "downloader-core",
+  srcs = glob(["**/Downloader.java",
+               "**/Extractor.java",
+               "**/Registry.java"])
+)
+
 java_binary(
   name = 'heron-downloader-unshaded',
   srcs = [":downloader-main"],

--- a/integration_test/src/python/topology_test_runner/resources/test.json
+++ b/integration_test/src/python/topology_test_runner/resources/test.json
@@ -47,13 +47,6 @@
       "restartArgs"  : "True",
       "expectedTopoResultRelativePath" : "fields_grouping/FieldsGroupingResults.json",
       "checkType" : "topology_structure"
-    },
-    {
-      "topologyName" : "IntegrationTopologyTest_StatefulBasicTopologyOneTask",
-      "classPath"    : "stateful_basic_topology_one_task.StatefulBasicTopologyOneTask",
-      "expectedTopoResultRelativePath" : "stateful_basic_topology_one_task/StatefulBasicTopologyOneTaskTopo.json",
-      "expectedStateResultRelativePath" : "stateful_basic_topology_one_task/StatefulBasicTopologyOneTaskState.json",
-      "checkType" : "checkpoint_state"
     }
   ]
 }


### PR DESCRIPTION
Adding this new filegroup allows other people building downloaders jar without including unexpected dependencies, such as distributed-log etc. 