### PR TITLE
Improve docker dev env script

### DIFF
--- a/docker/scripts/dev-env-create.sh
+++ b/docker/scripts/dev-env-create.sh
@@ -16,39 +16,38 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# This is a script to start a docker container that has all
-# tools needed to compire Heron. Developer should be able to
-# compile Heron in the container without any setup works.
-# usage:
+# This is a script to create/start a docker container that has all
+# tools needed to build Heron. Developer should be able to
+# build Heron in the container without any other setup works.
+#
+# Usage:
 # To create a clean development environment with docker and run it,
 # execute the following scripts in the source directory of Heron:
-#   sh docker/scripts/dev-env.sh
+#   sh docker/scripts/dev-env-create.sh CONTAINER_NAME [OS]
 #
-# After the container is started, build Heron with bazel
+# After the container is started, you can build Heron with bazel
 # (ubuntu config is used in the example):
 #   ./bazel_configure.py
 #   bazel build --config=ubuntu heron/...
-#
-# To enter an existing container with a new shell, find the container
-# ID with this command first:
-#   docker ps -a
-# The image name looks like: "heron-dev:ubuntu18.04".=
-# After the container is found, execute the following commands to start
-# the container in case it is not started yet, and then start a new
-# terminal in the container:
-#   docker container start CONTAINER_ID
-#   docker exec -it CONTAINER_ID bash
-#
+#   bazel build --config=ubuntu scripts/packages:binpkgs
 
 set -o nounset
 set -o errexit
 
+case $# in
+  0)
+    echo "Missing arguments."
+    echo "Usage: $0 <container_name> [OS]"
+    exit 1
+    ;;
+esac
+
 # Default platform is ubuntu18.04. Other available platforms
 # include centos7, debian9
-TARGET_PLATFORM=${1:-"ubuntu18.04"}
-SCRATCH_DIR=${2:-"$HOME/.heron-docker"}
+TARGET_PLATFORM=${2:-"ubuntu18.04"}
+SCRATCH_DIR="$HOME/.heron-docker"
 REPOSITORY="heron-dev"
-
+CONTAINER_NAME=$1
 
 realpath() {
   echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
@@ -83,6 +82,7 @@ docker build -t $REPOSITORY:$TARGET_PLATFORM -f $DOCKER_FILE $SCRATCH_DIR
 
 echo "Creating and starting container and mapping the current dir to /heron"
 docker container run -it \
+    --name $CONTAINER_NAME --rm \
     -e TARGET_PLATFORM=$TARGET_PLATFORM \
     -e SCRATCH_DIR="/scratch" \
     -v $PROJECT_DIR:/heron \

--- a/docker/scripts/dev-env-run.sh
+++ b/docker/scripts/dev-env-run.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This is a script to start a new session of the docker container
+# created with the dev-env-create.sh script.
+# Usage:
+#   sh docker/scripts/dev-env-run.sh CONTAINER_NAME
+#
+# In case you forgot the container name, you can use this command
+# to list all the existing containers (name is the last column).
+#   docker container ls -a
+
+set -o nounset
+set -o errexit
+
+case $# in
+  0)
+    echo "Missing argument."
+    echo "Usage: $0 <container_name>"
+    exit 1
+    ;;
+esac
+
+CONTAINER_NAME=$1
+
+docker container start $CONTAINER_NAME
+docker exec -it $CONTAINER_NAME bash


### PR DESCRIPTION
The existing script can be used to create a docker image/container of the heron dev environment. However, raw docker commands are needed to go back to the same container. A new script is added to make it easier to use the container dev environment, so that deverlopers can create a container with:

dev-env-create.sh NAME

and return to the container (or start a new shell) with:
dev-env-run.sh NAME
