### PR TITLE
Fixing IDE setup script with Bazel: Do Not Merge

### DIFF
--- a/scripts/get_all_heron_paths.sh
+++ b/scripts/get_all_heron_paths.sh
@@ -17,9 +17,9 @@
 
 set -eu
 
-function query() {
-  ./output/bazel query "$@"
-}
+#function query() {
+#  ./output/bazel query "$@"
+#}
 
 set +e
 # Build everything
@@ -44,7 +44,7 @@ function get_heron_thirdparty_dependencies() {
   # bazel-genfiles/external for third_party deps
   # bazel-heron/bazel-out/host/bin/third_party for extra_action proto jars in third_party
   # bazel-heron/bazel-out/host/genfiles/external more third_party deps
-  echo "$(find {bazel-bin/heron/proto,bazel-genfiles/external,bazel-incubator-heron/bazel-out/host/bin/third_party,bazel-incubator-heron/bazel-out/host/genfiles/external}/. -name "*jar" -type f | sort -u)";
+  echo "$(find {bazel-bin/heron/proto,bazel-genfiles/external,bazel-incubator-heron/bazel-out/host/bin/third_party,bazel-incubator-heron/bazel-out/host/bin/external}/. -name "*jar" -type f | sort -u)";
 }
 
 function get_heron_bazel_deps(){
@@ -88,20 +88,20 @@ function get_target_of() {
 }
 
 # Returns the target that consume file $1
-function get_consuming_target() {
-  # Here to the god of bazel, I should probably offer one or two memory chips for that
-  local target=$(get_target_of $1)
-  # Get the rule that generated this file.
-  local generating_target=$(query "kind(rule, deps(${target}, 1)) - ${target}")
-  [[ -n $generating_target ]] || echo "Couldn't get generating target for ${target}" 1>&2
-  local java_library=$(query "rdeps(//heron/..., ${generating_target}, 1) - ${generating_target}")
-  echo "${java_library}"
-}
+#function get_consuming_target() {
+#  # Here to the god of bazel, I should probably offer one or two memory chips for that
+#  local target=$(get_target_of $1)
+#  # Get the rule that generated this file.
+#  local generating_target=$(query "kind(rule, deps(${target}, 1)) - ${target}")
+#  [[ -n $generating_target ]] || echo "Couldn't get generating target for ${target}" 1>&2
+#  local java_library=$(query "rdeps(//heron/..., ${generating_target}, 1) - ${generating_target}")
+#  echo "${java_library}"
+#}
 
 # Returns the library that contains the generated file $1
-function get_containing_library() {
-  get_consuming_target $1 | sed 's|:|/lib|' | sed 's|^//|bazel-bin/|' | sed 's|$|.jar|'
-}
+#function get_containing_library() {
+#  get_consuming_target $1 | sed 's|:|/lib|' | sed 's|^//|bazel-bin/|' | sed 's|$|.jar|'
+#}
 
 function collect_generated_binary_deps() {
   local proto_deps=$(find bazel-bin/heron/proto -type f | grep "jar$");
@@ -112,7 +112,7 @@ function collect_generated_paths() {
   # uniq to avoid doing blaze query on duplicates.
   for path in $(find bazel-genfiles/ -name "*.java" | sed 's|/\{0,1\}bazel-genfiles/\{1,2\}|//|' | uniq); do
     source_path=$(echo ${path} | sed 's|//|bazel-genfiles/|' | sed 's|/com/.*$||')
-    echo "$(get_containing_library ${path}):${source_path}"
+#    echo "$(get_containing_library ${path}):${source_path}"
   done | sort -u
 }
 


### PR DESCRIPTION
This is my attempt to fix the IDE setup script.  I commented out some code that was breaking the initialization script when starting both intellij and eclipse.   I can understand what the code is doing, but I'm not sure why it is needed for loading Heron into an IDE. I'll as of now I can run the script, it compiles Heron and opens up Intellij for me without errors.   I'm double checking and asking for feedback to make sure I didn't comment out any needed code.  Please review. 
Below is my output on a mac.

I check that the iml file exists, delete the `.iml` file from the folder, run the script and check that the `.iml` file has been created again.   The IDE also opens up for me and seems to be working as expected.

```
Joshs-MacBook-Pro-2:incubator-heron joshfischer$ ls | grep heron.iml
heron.iml
Joshs-MacBook-Pro-2:incubator-heron joshfischer$ rm heron.iml 
Joshs-MacBook-Pro-2:incubator-heron joshfischer$ ./scripts/setup-intellij.sh 
changing to /Users/joshfischer/Source/apache/incubator-heron/scripts/..
WARNING: /Users/joshfischer/Source/apache/incubator-heron/heron/healthmgr/tests/java/BUILD:52:12: in srcs attribute of java_library rule //heron/healthmgr/tests/java:healthmgr-tests: please do not import '//heron/healthmgr/src/java:org/apache/heron/healthmgr/HealthManager.java' directly. You should either move the file to this package or depend on an appropriate rule there
INFO: Analyzed 759 targets (0 packages loaded, 0 targets configured).
INFO: Found 759 targets...
INFO: Elapsed time: 0.465s, Critical Path: 0.06s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
Bazel build successful!!
Path is /Users/joshfischer/Source/apache/incubator-heron
Generating IDEA project...
Loading: 0 packages loaded
Done. IDEA module file: heron.iml
Opening Heron project in IDEA...
Done.
Joshs-MacBook-Pro-2:incubator-heron joshfischer$ ls | grep heron.iml
heron.iml