### PR TITLE
Use netcat-bsd in Debian

### DIFF
--- a/docker/base/Dockerfile.base.debian9
+++ b/docker/base/Dockerfile.base.debian9
@@ -18,7 +18,7 @@
 FROM openjdk:8-jdk-slim
 
 RUN apt-get -y update && apt-get -y install \
-    netcat \
+    netcat-openbsd \
     python \
     unzip \
     curl \

--- a/docker/dist/Dockerfile.dist.debian9
+++ b/docker/dist/Dockerfile.dist.debian9
@@ -18,7 +18,7 @@
 FROM openjdk:8-jdk-slim
 
 RUN apt-get -y update && apt-get -y install \
-    netcat \
+    netcat-openbsd \
     python \
     unzip \
     curl \


### PR DESCRIPTION
Standard netcat is under GNU license. Switch to BSD version.