### PR TITLE
Add redirect from github pages to new apache site

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,7 +24,8 @@ publish:
 
 github:
   description: "Apache Heron (Incubating) is a realtime, distributed, fault-tolerant stream processing engine from Twitter"
-  ghp_branch:  gh-pages
+  ghp_branch:  master
+  ghp_path: ~
   homepage: https://heron.incubator.apache.org/
   labels:
     - heron

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,6 +25,7 @@ publish:
 
 github:
   description: "Apache Heron (Incubating) is a realtime, distributed, fault-tolerant stream processing engine from Twitter"
+  ghp_branch:  gh-pages
   homepage: https://heron.incubator.apache.org/
   labels:
     - heron

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,7 +21,6 @@ staging:
 
 publish:
   whoami: asf-site
-  hostname: http://heronstreaming.io
 
 github:
   description: "Apache Heron (Incubating) is a realtime, distributed, fault-tolerant stream processing engine from Twitter"

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ under the License.
 
 <html>
 <meta charset="utf-8">
-<title>Redirecting to https://example.com/</title>
+<title>Redirecting to https://heron.incubator.apache.org</title>
 <meta http-equiv="refresh" content="0; URL=https://heron.incubator.apache.org/">
 <link rel="canonical" href="https://heron.incubator.apache.org">
 </html>

--- a/index.html
+++ b/index.html
@@ -18,9 +18,12 @@ under the License.
 -->
 
 <html>
-<meta charset="utf-8">
-<title>Redirecting to https://heron.incubator.apache.org</title>
-<meta http-equiv="refresh" content="0; URL=https://heron.incubator.apache.org/">
-<link rel="canonical" href="https://heron.incubator.apache.org">
+<head>
+    <meta http-equiv="refresh" content="2;url=https://heron.incubator.apache.org" />
+    <title>goto heron.incubator.apache.org</title>
+</head>
+<body>
+this is a landing page for the main heron.incubator.apache.org website. Click <a href="https://heron.incubator.apache.org">here</a> to go to the main site.
+</body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -18,5 +18,9 @@ under the License.
 -->
 
 <html>
+<meta charset="utf-8">
+<title>Redirecting to https://example.com/</title>
+<meta http-equiv="refresh" content="0; URL=https://heron.incubator.apache.org/">
+<link rel="canonical" href="https://heron.incubator.apache.org">
 </html>
 

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ under the License.
     <title>goto heron.incubator.apache.org</title>
 </head>
 <body>
-this is a landing page for the main heron.incubator.apache.org website. Click <a href="https://heron.incubator.apache.org">here</a> to go to the main site.
+This is a landing page for the main heron.incubator.apache.org website. Click <a href="https://heron.incubator.apache.org">here</a> to go to the main site if it does not redirect you automatically.
 </body>
 </html>
 


### PR DESCRIPTION
Some users have been impacted by moving the Heron docs to apache infra.  This is an attempt to get a redirect from github pages to route to apache infra.  