### PR TITLE
Change url of javadoc

### DIFF
--- a/tools/rules/javadoc.bzl
+++ b/tools/rules/javadoc.bzl
@@ -20,7 +20,7 @@ def _impl(ctx):
     transitive_jar_paths = [j.path for j in transitive_jar_set.to_list()]
     dir = ctx.outputs.zip.path + ".dir"
     source = ctx.outputs.zip.path + ".source"
-    external_docs = ["http://docs.oracle.com/javase/8/docs/api"] + ctx.attr.external_docs
+    external_docs = ["https://docs.oracle.com/javase/8/docs/api"] + ctx.attr.external_docs
     cmd = [
         "rm -rf %s" % source,
         "mkdir %s" % source,


### PR DESCRIPTION
Fix change url of javadoc

```
2 warnings generated.
ERROR: /Users/thinker0/line/heron/heron/api/src/java/BUILD:8:1: error executing shell command: '/bin/bash -c rm -rf bazel-out/darwin-fastbuild/bin/heron/api/src/java/heron-api-javadoc.zip.source && mkdir bazel-out/darwin-fastbuild/bin/heron/api/src/java/heron-api-javadoc.zip.source && unzip -...' failed (Exit 1)
javadoc: warning - URL http://docs.oracle.com/javase/8/docs/api/package-list was redirected to https://docs.oracle.com/javase/8/docs/api/package-list -- Update the command-line options to suppress this warning.
javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
1 error
1 warning
```