### PR TITLE
Adding missing pkg-config package

### DIFF
--- a/docker/compile/Dockerfile.debian9
+++ b/docker/compile/Dockerfile.debian9
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get -y install \
       libtool \
       libtool-bin \
       libcppunit-dev \
+      pkg-config \
       python-dev \
       python3-dev \
       software-properties-common \


### PR DESCRIPTION
Adding the missing `pkg-config` package which is needed to compile Zookeeper source code.