### PR TITLE
Make Java optional in CLI and check JAVA_BIN

### DIFF
--- a/heron/tools/admin/src/python/main.py
+++ b/heron/tools/admin/src/python/main.py
@@ -121,8 +121,6 @@ def check_environment():
   Check whether the environment variables are set
   :return:
   '''
-  if not config.check_java_home_set():
-    sys.exit(1)
 
   if not config.check_release_file_exists():
     sys.exit(1)

--- a/heron/tools/cli/src/python/execute.py
+++ b/heron/tools/cli/src/python/execute.py
@@ -59,10 +59,15 @@ def heron_class(class_name, lib_jars, extra_jars=None, args=None, java_defines=N
   # the class locally.
   java_opts = ['-D' + opt for opt in java_defines]
 
+  java_path = config.get_java_path()
+  if java_path is None:
+    err_context = "Neither JAVA_BIN or JAVA_HOME are set"
+    return SimpleResult(Status.InvocationError, err_context)
+
   # Construct the command line for the sub process to run
   # Because of the way Python execute works,
   # the java opts must be passed as part of the list
-  all_args = [config.get_java_path(), "-client", "-Xmx1g"] + \
+  all_args = [java_path, "-client", "-Xmx1g"] + \
              java_opts + \
              ["-cp", config.get_classpath(extra_jars + lib_jars)]
 

--- a/heron/tools/cli/src/python/main.py
+++ b/heron/tools/cli/src/python/main.py
@@ -149,9 +149,6 @@ def check_environment():
   Check whether the environment variables are set
   :return:
   '''
-  if not config.check_java_home_set():
-    sys.exit(1)
-
   if not config.check_release_file_exists():
     sys.exit(1)
 

--- a/heron/tools/common/src/python/utils/config.py
+++ b/heron/tools/common/src/python/utils/config.py
@@ -424,24 +424,14 @@ def parse_override_config(namespace):
 
 def get_java_path():
   """Get the path of java executable"""
+  java_bin = os.environ.get("JAVA_BIN")
+  if java_bin:
+    return java_bin
   java_home = os.environ.get("JAVA_HOME")
-  return os.path.join(java_home, BIN_DIR, "java")
-
-
-def check_java_home_set():
-  """Check if the java home set"""
-  # check if environ variable is set
-  if "JAVA_HOME" not in os.environ:
-    Log.error("JAVA_HOME not set")
-    return False
-
-  # check if the value set is correct
-  java_path = get_java_path()
-  if os.path.isfile(java_path) and os.access(java_path, os.X_OK):
-    return True
-
-  Log.error("JAVA_HOME/bin/java either does not exist or not an executable")
-  return False
+  if java_home:
+    return os.path.join(java_home, BIN_DIR, "java")
+  # this could use shutil.which("java") when python2 support is dropped
+  return None
 
 
 def check_release_file_exists():


### PR DESCRIPTION
This is so you only need the variables when they are used when submitting a topology, so you can still use other commands and check the `--help`.

It also uses `JAVA_BIN` before `JAVA_HOME`.