### PR TITLE
Fix Heron Shell PID Extractor

### DIFF
--- a/heron/shell/src/python/handlers/pidhandler.py
+++ b/heron/shell/src/python/handlers/pidhandler.py
@@ -39,5 +39,5 @@ class PidHandler(tornado.web.RequestHandler):
         ['ps', 'auxwwww'],
         ['grep', instance_id],
         ['grep', 'java'],
-        ['awk', '\'{print $2}\'']])).strip())
+        ['awk', '{print $2}']])).strip())
     self.finish()

--- a/heron/shell/src/python/handlers/pidhandler.py
+++ b/heron/shell/src/python/handlers/pidhandler.py
@@ -35,9 +35,5 @@ class PidHandler(tornado.web.RequestHandler):
   def get(self, instance_id):
     ''' get method '''
     self.content_type = 'application/json'
-    self.write(json.dumps(utils.chain([
-        ['ps', 'auxwwww'],
-        ['grep', instance_id],
-        ['grep', 'java'],
-        ['awk', '{print $2}']])).strip())
+    self.write(json.dumps(utils.chain([['cat', "%s.pid" % instance_id]])).strip())
     self.finish()


### PR DESCRIPTION
I'm getting the following error when trying to get the PID from Heron shell
```>>> functools.reduce(pipe, [None] + cmd)
<subprocess.Popen object at 0x7fdf75323e90>
>>> awk: cmd. line:1: '{print $2}'
awk: cmd. line:1: ^ invalid char ''' in expression
grep: write error: Broken pipe
```

But then I saw #3094 ... so I guess different OS have different tolerance over quotations. I'm changing the PID extraction logic to read the PID file instead to avoid this. 
