### PR TITLE
Update osx documentation (3453)

### DIFF
--- a/website2/docs/compiling-osx.md
+++ b/website2/docs/compiling-osx.md
@@ -34,7 +34,7 @@ $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/inst
 
 ### Step 2 -- Install Bazel
 ```bash
-wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel-0.26.0-installer-darwin-x86_64.sh
+wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/3.0.0/bazel-3.0.0-installer-darwin-x86_64.sh
 chmod +x /tmp/bazel.sh
 /tmp/bazel.sh --user
 ```


### PR DESCRIPTION
As specified here: https://github.com/apache/incubator-heron/issues/3452#issuecomment-625435818, heron now requires bazel version 3.0.0