### PR TITLE
Workaround trailing slashes on website

### DIFF
--- a/website2/website/siteConfig.js
+++ b/website2/website/siteConfig.js
@@ -110,7 +110,8 @@ const siteConfig = {
   // Add custom scripts here that would be placed in <script> tags.
   scripts: [
     'https://buttons.github.io/buttons.js',
-    `${baseUrl}js/custom.js`
+    `${baseUrl}js/custom.js`,
+    `${baseUrl}js/fix-location.js`
   ],
 
   // On page navigation for the current documentation page.

--- a/website2/website/static/js/fix-location.js
+++ b/website2/website/static/js/fix-location.js
@@ -1,0 +1,3 @@
+if (window && window.location && window.location.pathname.endsWith('/') && window.location.pathname !== '/') {
+  window.history.replaceState('', '', window.location.pathname.substr(0, window.location.pathname.length - 1))
+}


### PR DESCRIPTION
This is as the website deployment 301s to add trailing slashes, and
Docusurus does not yet support that. Without one of the two yielding,
this workaround strips the trailing slash so the hrefs made still work.

Solution pinched from docusurus issue:
https://github.com/facebook/docusaurus/issues/2394