### PR TITLE
adjusting packages for javadocs

### DIFF
--- a/storm-compatibility/src/java/BUILD
+++ b/storm-compatibility/src/java/BUILD
@@ -34,10 +34,8 @@ java_doc(
     name = "heron-storm-javadoc",
     libs = [":storm-compatibility-java"],
     pkgs = [
-        "backtype",
-        "clojure",
+        "java",
         "org",
-        "storm",
     ],
     title = "Heron Storm Compatibility Api Documentation",
 )


### PR DESCRIPTION
I don't know if this is the correct fix, but this PR does resolve the issue causing the build to fail.   But figured I use these changes to get a conversation started.  The reason the `java_doc` command was failing for the storm-compatibility target is because the source files were getting structured in the resulting jar differently than expected. The reason for this is unknown to me still.  

If you execute *on this branch*
```
$ bazel build storm-compatibility/src/java:heron-storm-javadoc
```
The output will be a zip file with the javadocs at 
```
bazel-bin/storm-compatibility/src/java/heron-storm-javadoc.zip.source
```
If you `cd` into the above directory you will see that some javadoc files are under the folder `org` and others are under `java` if you `cd` into `java` you will see other packages such as `backtype` or `storm` which is why the javadoc command could not find the source files.  See my abbreviated tree output from the file `bazel-bin/storm-compatibility/src/java/heron-storm-javadoc.zip.source` below:

```
$ heron-storm-javadoc.zip.source joshfischer$ tree
.
├── META-INF
│   └── MANIFEST.MF
├── java
│   ├── backtype
│   │   └── storm
│   │       ├── Config.java
│   │       ├── Constants.java
│   │       ├── ILocalCluster.java
   left out for brevity....
│   │       │       ├── BaseBasicBolt.java
│   │       │       ├── BaseComponent.java
│   │       │       ├── BaseRichBolt.java
│   │       │       └── BaseRichSpout.java
│   │       ├── tuple
│   │       │   ├── Fields.java
│   │       │   ├── Tuple.java
│   │       │   ├── TupleImpl.java
│   │       │   └── Values.java
│   │       └── utils
│   │           ├── ConfigUtils.java
│   │           ├── DefaultMaxSpoutPendingTuner.java
│   │           ├── ListDelegate.java
│   │           └── Utils.java
│   ├── clojure
│   │   └── lang
│   │       └── Atom.java
│   └── storm
│       └── trident
│           ├── spout
│           │   └── ISpoutPartition.java
│           └── state
│               └── Serializer.java
└── org
    └── apache
        └── storm
            ├── Config.java
            ├── Constants.java
       .. left out for brevity
            │   └── Utils.java
            └── windowing
                ├── TimestampExtractor.java
                ├── TupleWindow.java
                ├── TupleWindowImpl.java
                └── Window.java
```

So the java_doc rule couldn't find the module `backtype` because it was under the `java` folder in the jar.  Either way this PR fixes the problem.