### PR TITLE
Updated Docusaurus config to ignore Javadocs CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,12 +130,7 @@ atlassian-ide-plugin.xml
 com_crashlytics_export_strings.xml
 
 # generated for the website
-website/node_modules/
-website/public/
-
-website2/website/public
-website2/website/static/api
-website2/website/venv/
+generated-site/
 
 # Visual Studio Code
 .vscode

--- a/website2/.gitignore
+++ b/website2/.gitignore
@@ -1,12 +1,16 @@
 .DS_Store
 
-node_modules
+website/node_modules
 
 lib/core/metadata.js
 lib/core/MetadataBlog.js
 
+website/public/
+website/static/api/
+website/venv/
 website/translated_docs
 website/build/
 website/yarn.lock
 website/node_modules
 website/i18n/*
+website/scripts/bazelrc

--- a/website2/website/Makefile
+++ b/website2/website/Makefile
@@ -1,3 +1,5 @@
+.PHONY : start javadocs python-docs buildsite publish clean
+
 start:
 	yarn start
 
@@ -7,10 +9,12 @@ javadocs:
 python-docs:
 	@scripts/python-doc-gen.sh 0.0.0
 
-buildsite:
-	@scripts/javadocs.sh
-	@scripts/python-doc-gen.sh 0.0.0
+buildsite: javadocs python-docs
 	@scripts/build-site.sh
 
 publish:
 	@scripts/publish_site.sh
+
+clean:
+	rm -rf static/api/*
+	rm -rf build/*

--- a/website2/website/scripts/build-site.sh
+++ b/website2/website/scripts/build-site.sh
@@ -28,6 +28,7 @@ npm run-script build
 
 node ./scripts/replace.js
 
-rm -rf ${ROOT_DIR}/generated-site/content/*
 ## copy generated site
+rm -rf ${ROOT_DIR}/generated-site/content/*
+mkdir -p ${ROOT_DIR}/generated-site/content/
 cp -R build/incubator-heron/* ${ROOT_DIR}/generated-site/content

--- a/website2/website/scripts/build-site.sh
+++ b/website2/website/scripts/build-site.sh
@@ -28,14 +28,6 @@ npm run-script build
 
 node ./scripts/replace.js
 
-rm -rf ${ROOT_DIR}/generated-site/content
-mkdir -p ${ROOT_DIR}/generated-site/content/api/java
-mkdir -p ${ROOT_DIR}/generated-site/content/api/python
+rm -rf ${ROOT_DIR}/generated-site/content/*
 ## copy generated site
 cp -R build/incubator-heron/* ${ROOT_DIR}/generated-site/content
-## copy java docs
-cp -R ${ROOT_DIR}/website2/website/public/api/java/* ${ROOT_DIR}/generated-site/content/api/java/
-## copy pydocs
-cp -R ${ROOT_DIR}/website2/website/static/api/python/* ${ROOT_DIR}/generated-site/content/api/python/
-## remove bazelrc for dockerfile
-rm ${ROOT_DIR}/website2/website/scripts/bazelrc

--- a/website2/website/scripts/javadocs.sh
+++ b/website2/website/scripts/javadocs.sh
@@ -21,10 +21,7 @@ JAVADOC=javadoc
 FLAGS="-quiet -Xdoclint:none"
 
 HERON_ROOT_DIR=$(git rev-parse --show-toplevel)
-# for display on GitHub website
-JAVADOC_OUTPUT_DIR=$HERON_ROOT_DIR/website2/website/public/api/java
-# for display on local Hugo server
-JAVADOC_OUTPUT_LOCAL_DIR=$HERON_ROOT_DIR/website2/website/static/api
+JAVADOC_OUTPUT_DIR=$HERON_ROOT_DIR/website2/website/static/api/java
 GEN_PROTO_DIR=$HERON_ROOT_DIR/bazel-bin/heron/proto/_javac
 
 # The path of the customized landing page for the Javadocs
@@ -66,16 +63,5 @@ $JAVADOC $FLAGS \
   -overview $OVERVIEW_HTML_FILE \
   -d $JAVADOC_OUTPUT_DIR $GEN_FILES $HERON_SRC_FILES $BACKTYPE_SRC_FILES $APACHE_SRC_FILES || true
 
-# Generated Java API doc needs to be copied to $JAVADOC_OUTPUT_LOCAL_DIR
-# for the following two reasons:
-# 1. When one is developing website locally, They should
-#    be able to click into API doc link and view API doc to
-#    check if the correct API link is given.
-# 2. ``wget`` needs to verify if links to Java API doc are valid when we are
-#    serving the website locally. This means that Hugo should be able to display
-#    Java API doc properly.
-
-cp -r $JAVADOC_OUTPUT_DIR $JAVADOC_OUTPUT_LOCAL_DIR
 echo "Javadocs generated at $JAVADOC_OUTPUT_DIR"
-echo "Javadocs copied to: $JAVADOC_OUTPUT_LOCAL_DIR"
 exit 0

--- a/website2/website/siteConfig.js
+++ b/website2/website/siteConfig.js
@@ -107,9 +107,16 @@ const siteConfig = {
     theme: 'default',
   },
 
+  // Ignores CSS files found in the static folder.
+  // Any CSS files not listed here will be added to the Docusaurus main.css
   separateCss: [
-      `${baseUrl}public/api/java/stylesheet.css`,
+      `${baseUrl}static/css/custom.css`,
       `${baseUrl}static/api/stylesheet.css`,
+      `${baseUrl}static/api/java/jquery/jquery-ui.css`,
+      `${baseUrl}static/api/java/jquery/jquery-ui.min.css`,
+      `${baseUrl}static/api/java/jquery/jquery-ui.structure.min.css`,
+      `${baseUrl}static/api/java/jquery/jquery-ui.structure.css`,
+      `${baseUrl}static/api/java/stylesheet.css`,
   ],
 
   // Add custom scripts here that would be placed in <script> tags.

--- a/website2/website/siteConfig.js
+++ b/website2/website/siteConfig.js
@@ -107,6 +107,11 @@ const siteConfig = {
     theme: 'default',
   },
 
+  separateCss: [
+      `${baseUrl}public/api/java/stylesheet.css`,
+      `${baseUrl}static/api/stylesheet.css`,
+  ],
+
   // Add custom scripts here that would be placed in <script> tags.
   scripts: [
     'https://buttons.github.io/buttons.js',

--- a/website2/website/siteConfig.js
+++ b/website2/website/siteConfig.js
@@ -111,7 +111,6 @@ const siteConfig = {
   // Any CSS files not listed here will be added to the Docusaurus main.css
   separateCss: [
       `${baseUrl}static/css/custom.css`,
-      `${baseUrl}static/api/stylesheet.css`,
       `${baseUrl}static/api/java/jquery/jquery-ui.css`,
       `${baseUrl}static/api/java/jquery/jquery-ui.min.css`,
       `${baseUrl}static/api/java/jquery/jquery-ui.structure.min.css`,


### PR DESCRIPTION
Working on a solution to fix #3543 

The Javadoc provided stylesheet.css files are conflicting with our Docusaurus custom pages.