### PR TITLE
Fixing over optimization that stops Return Value Optimization

### DIFF
--- a/heron/tmaster/src/cpp/manager/tmaster.cpp
+++ b/heron/tmaster/src/cpp/manager/tmaster.cpp
@@ -863,7 +863,7 @@ std::unique_ptr<proto::tmaster::StmgrsRegistrationSummaryResponse> TMaster::GetS
     response->add_absent_stmgrs(*it);
   }
 
-  return std::move(response);
+  return response;
 }
 
 shared_ptr<proto::system::PhysicalPlan> TMaster::MakePhysicalPlan() {


### PR DESCRIPTION
Some explanations as to why it is not wise to return using `std::move()`.

https://stackoverflow.com/questions/4986673/c11-rvalues-and-move-semantics-confusion-return-statement
https://developers.redhat.com/blog/2019/04/12/understanding-when-not-to-stdmove-in-c/
