### PR TITLE
Distribution Dockerfile missing ncat and other cleanup

### DIFF
--- a/docker/dist/Dockerfile.dist.centos7
+++ b/docker/dist/Dockerfile.dist.centos7
@@ -17,19 +17,17 @@
 
 FROM centos:centos7
 
-RUN yum -y upgrade
-RUN yum -y install python; yum clean all
-RUN yum -y install unzip; yum clean all
-RUN yum -y install which; yum clean all
-RUN yum -y install curl; yum clean all
-RUN yum -y install nmap-ncat; yum clean all
-RUN yum -y install python python3-setuptools; yum clean all
-
-RUN yum install epel-release; yum clean all
-RUN yum update -y
-RUN yum install -y supervisor; yum clean all
-
-RUN yum -y install java-11-openjdk java-11-openjdk-devel; yum clean all
+RUN yum install epel-release \
+    && yum -y update \
+    && yum -y install \
+    curl \
+    java-11-openjdk \
+    supervisor \
+    nmap-ncat \
+    python \
+    unzip \
+    which \
+    && yum clean all
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
 

--- a/docker/dist/Dockerfile.dist.centos7
+++ b/docker/dist/Dockerfile.dist.centos7
@@ -17,19 +17,17 @@
 
 FROM centos:centos7
 
-RUN yum install epel-release \
+RUN yum -y install epel-release \
     && yum -y update \
     && yum -y install \
     curl \
-    java-11-openjdk \
+    java-11-openjdk-headless \
     supervisor \
     nmap-ncat \
     python \
     unzip \
     which \
     && yum clean all
-
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
 
 ADD artifacts /heron
 

--- a/docker/dist/Dockerfile.dist.debian10
+++ b/docker/dist/Dockerfile.dist.debian10
@@ -15,15 +15,16 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-FROM openjdk:11.0.6-slim-buster
+FROM openjdk:11.0.6-jre-slim-buster
 
-RUN apt-get update && apt-get -y install \
-      netcat-openbsd \
-      curl \
-      python \
-      python2.7-dev \
-      supervisor \
-      unzip
+RUN apt-get update \
+    && apt-get -y install \
+    curl \
+    netcat-openbsd \
+    python \
+    supervisor \
+    unzip \
+    && apt-get clean
 
 ADD artifacts /heron
 

--- a/docker/dist/Dockerfile.dist.debian9
+++ b/docker/dist/Dockerfile.dist.debian9
@@ -15,18 +15,17 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-FROM openjdk:11-jdk-slim-stretch
+FROM openjdk:11-jre-slim-stretch
 
-RUN apt-get -y update && apt-get -y install \
+RUN apt-get -y update \
+    && apt-get -y install \
+    curl \
     netcat-openbsd \
     python \
-    python-dev \
+    supervisor \
     unzip \
-    curl \
-    vim \
-    supervisor && \
-    apt-get clean all && \
-    rm -rf /var/lib/apt/lists/*
+    && apt-get clean all \
+    && rm -rf /var/lib/apt/lists/*
 
 ADD artifacts /heron
 

--- a/docker/dist/Dockerfile.dist.ubuntu14.04
+++ b/docker/dist/Dockerfile.dist.ubuntu14.04
@@ -17,16 +17,20 @@
 
 FROM ubuntu:14.04
 
-RUN apt-get -y update && apt-get -y install \
+RUN apt-get -y update \
+    && apt-get -y install \
+    curl \
+    netcat-openbsd \
     python \
-    python3 \
-    unzip \
     software-properties-common \
     supervisor \
-    curl
+    unzip \
+    && apt-get clean
 
-RUN add-apt-repository ppa:openjdk-r/ppa && apt-get -y update && \
-    apt-get -y install openjdk-11-jdk-headless
+RUN add-apt-repository ppa:openjdk-r/ppa \
+    && apt-get -y update \
+    && apt-get -y install openjdk-11-jre-headless \
+    && apt-get clean
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 RUN update-ca-certificates -f

--- a/docker/dist/Dockerfile.dist.ubuntu16.04
+++ b/docker/dist/Dockerfile.dist.ubuntu16.04
@@ -17,20 +17,22 @@
 
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y software-properties-common
+RUN apt-get -y update \
+    && apt-get install -y \
+    curl \
+    netcat-openbsd \
+    python \
+    software-properties-common \
+    supervisor \
+    unzip \
+    && apt-get clean
 
 RUN add-apt-repository ppa:openjdk-r/ppa
 
-RUN apt-get -y install \
-    python \
-    python3 \
-    unzip \
-    software-properties-common \
-    curl \
-    supervisor
-
-RUN apt-get update && apt-get -y install \
-    openjdk-11-jdk-headless
+RUN apt-get update \
+    && apt-get -y install \
+    openjdk-11-jre-headless \
+    && apt-get clean
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 RUN update-ca-certificates -f

--- a/docker/dist/Dockerfile.dist.ubuntu18.04
+++ b/docker/dist/Dockerfile.dist.ubuntu18.04
@@ -23,7 +23,6 @@ RUN apt-get -y update \
     netcat-openbsd \
     openjdk-11-jre-headless \
     python \
-    software-properties-common \
     supervisor \
     unzip \
     && apt-get clean

--- a/docker/dist/Dockerfile.dist.ubuntu18.04
+++ b/docker/dist/Dockerfile.dist.ubuntu18.04
@@ -17,9 +17,16 @@
 
 FROM ubuntu:18.04
 
-RUN apt-get update
-RUN apt-get -y install \
-    unzip software-properties-common curl python python3 supervisor openjdk-11-jdk-headless
+RUN apt-get -y update \
+    && apt-get -y install \
+    curl \
+    netcat-openbsd \
+    openjdk-11-jre-headless \
+    python \
+    software-properties-common \
+    supervisor \
+    unzip \
+    && apt-get clean
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 RUN update-ca-certificates -f

--- a/docker/dist/Dockerfile.dist.ubuntu20.04
+++ b/docker/dist/Dockerfile.dist.ubuntu20.04
@@ -19,9 +19,16 @@ FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install \
-    unzip software-properties-common curl python python3 supervisor openjdk-11-jdk-headless
+RUN apt-get -y update \
+    && apt-get -y install \
+    curl \
+    openjdk-11-jre-headless \
+    netcat-openbsd \
+    python \
+    software-properties-common \
+    supervisor \
+    unzip \
+    && apt-get clean
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 RUN update-ca-certificates -f

--- a/docker/dist/Dockerfile.dist.ubuntu20.04
+++ b/docker/dist/Dockerfile.dist.ubuntu20.04
@@ -25,7 +25,6 @@ RUN apt-get -y update \
     openjdk-11-jre-headless \
     netcat-openbsd \
     python \
-    software-properties-common \
     supervisor \
     unzip \
     && apt-get clean


### PR DESCRIPTION
1. Fixes #3548 
2. Now using JRE instead of JDK for distribution images
3. Package install cleanup to reduce resulting docker image size. Especially when not squashed.
4. Removed `python-dev` packages
5. Removed `python3` packages