### PR TITLE
WIP: Add k8s integration tests to CI

### DIFF
--- a/heron/config/src/yaml/conf/kubernetes/statemgr.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/statemgr.yaml
@@ -19,7 +19,7 @@
 heron.class.state.manager: org.apache.heron.statemgr.zookeeper.curator.CuratorStateManager
 
 # local state manager connection string
-heron.statemgr.connection.string:  <zookeeper_host:zookeeper_port>
+heron.statemgr.connection.string:  127.0.0.1:2181
 
 # path of the root address to store the state in a local file system
 heron.statemgr.root.path: "/heron"

--- a/integration_test/src/python/test_runner/main.py
+++ b/integration_test/src/python/test_runner/main.py
@@ -20,10 +20,10 @@ import json
 import logging
 import os
 import pkgutil
+import random
 import re
 import sys
 import time
-import uuid
 from http.client import HTTPConnection
 from threading import Lock, Thread
 
@@ -313,6 +313,7 @@ def run_tests(conf, test_args):
   ''' Run the test for each topology specified in the conf file '''
   lock = Lock()
   timestamp = time.strftime('%Y%m%d%H%M%S')
+  run_fingerprint = f"{timestamp}-{random.randint(0, 2**16):04x}"
 
   http_server_host_port = "%s:%d" % (test_args.http_server_hostname, test_args.http_server_port)
 
@@ -361,8 +362,11 @@ def run_tests(conf, test_args):
       lock.release()
 
   test_threads = []
-  for topology_conf in test_topologies:
-    topology_name = ("%s_%s_%s") % (timestamp, topology_conf["topologyName"], str(uuid.uuid4()))
+  for i, topology_conf in enumerate(test_topologies, 1):
+    # this name has to be valid for all tested schedullers, state managers, etc.
+    topology_name = f"run-{run_fingerprint}-test-{i:03}"
+    # TODO: make sure logs describe the test/topology that fails, as now topology_name is opaque
+    # topology_conf["topologyName"]
     classpath = topology_classpath_prefix + topology_conf["classPath"]
 
     # if the test includes an update we need to pass that info to the topology so it can send

--- a/scripts/release/docker-images
+++ b/scripts/release/docker-images
@@ -66,7 +66,8 @@ def build_dockerfile(
     log_run([str(BUILD_IMAGE), dist, tag, scratch], log)
     tar = Path(scratch) / f"heron-docker-{tag}-{dist}.tar.gz"
     tar_out = out_dir / tar.name
-    tar.replace(tar_out)
+    # using this rather than replace as it works if moving between devices
+    shutil.move(tar, tar_out)
     logging.info("docker image complete: %s", tar_out)
     return tar_out
 
@@ -107,7 +108,6 @@ def build_target(tag: str, target: str) -> typing.List[Path]:
         scratch = Path(tempfile.mkdtemp(prefix=f"build-{target}-"))
         log_path = scratch / "log.txt"
         log = log_path.open("w")
-        logging.debug("building %s", target)
 
         try:
             tar = build_dockerfile(scratch, target, tag, out_dir, log)

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+DIR=`dirname $0`
+UTILS=${DIR}/../shutils
+source ${UTILS}/common.sh
+
+# Autodiscover the platform
+PLATFORM=$(discover_platform)
+echo "Using $PLATFORM platform"
+
+# install heron locally
+bazel --bazelrc=tools/travis/bazel.rc run --config=$PLATFORM -- scripts/packages:heron-install.sh --user

--- a/scripts/travis/k8s.sh.kind.yaml
+++ b/scripts/travis/k8s.sh.kind.yaml
@@ -1,4 +1,6 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+# to change kubernetes version, see the tags+digests here: https://hub.docker.com/r/kindest/node/tags
 nodes:
 - role: control-plane
+#  image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -60,21 +60,9 @@ Vagrant.configure(2) do |config|
 
     master.vm.hostname = "master"
     master.vm.network :private_network, ip: NODES["master"]
+    # this port is used in ./scripts/travis/k8s.sh to expose the kubectl proxy
+    master.vm.network :forwarded_port, guest: 8001, host: 8001
 
-    master.vm.provision "shell", path: "init.sh", args: "master"
-  end
-
-  (0..SLAVES-1).each do |i|
-    config.vm.define "slave#{i}" do |slave|
-      slave.vm.provider "virtualbox" do |v|
-        v.memory = 2048
-        v.cpus = 2
-      end
-
-      slave.vm.hostname = "slave#{i}"
-      slave.vm.network :private_network, ip: NODES[slave.vm.hostname]
-
-      slave.vm.provision "shell", path: "init.sh", args: "slave"
-    end
+    master.vm.provision "shell", path: "init.sh"
   end
 end

--- a/vagrant/local-ci.sh
+++ b/vagrant/local-ci.sh
@@ -2,11 +2,12 @@
 :<<'DOC'
 This script is for running tests in a local VM, similar to the environment used in the CI pipeline. If the targent script fails, a shell will be opened up within the VM.
 
-To only run integration tests:
-  ./local-ci.sh test
+To run all of the tests:
+  ./local-ci.sh
 
-To run the full ci pipeline:
-  ./local-ci.sh ci
+To run a specific command/script:
+  ./local-ci.sh ./scripts/travis/ci.sh
+  ./local-ci.sh bash
 
 The VM does not report the platform in python as expected, so PLATFORM=Ubuntu is needed to work around that for the CI script's platform discovery.
 
@@ -23,9 +24,10 @@ if [ "$state" != "running" ]; then
 fi
 
 
-# allows you to do `$0 test` to run only integration tests
-script="${1-ci}"
-env="PLATFORM=Ubuntu JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/"
-# run the CI, if it fails drop into a shell
-vagrant ssh master --command "cd /vagrant && $env ./scripts/travis/$script.sh" \
-    || vagrant ssh master --command "cd /vagrant && $env exec bash"
+if [ -z "$1" ]; then
+    # run the CI, if it fails drop into a shell
+    vagrant ssh master --command "cd /vagrant && $env ./scripts/travis/$script.sh" \
+        || vagrant ssh master --command "cd /vagrant && exec bash"
+else
+    vagrant ssh master --command "cd /vagrant && exec $1"
+fi


### PR DESCRIPTION
I'm aiming to get the integration tests to also run for a kuberentes cluster, currently rough progress for this is in `./scripts/travis/k8s.sh`. I'm sharing this as a draft to ask for pointers.

So far the script ensures there is a test image (debian10 isn't working due to the TLS issue), then creates a kind cluster using the `./deploy/kubernetes/minikube/*.yaml` which it waits for before starting the integration tests. The cluster looks ok on the surface as the services appear healthy, and topologies can be created and their pods run (ignoring when resource requests are too high at the moment).

The problems I'm seeing at the moment are that `topology-test-runner` instance state results are not written back to the HTTP collector on the host, which is accessible from the executors from the host URL passed to the test script, and `http://127.0.0.1:8080` on the host.

The topology structure is also not updated for `topology-test-runner` and `test-runner`. Zookeeper within the cluster is accessible on `zookeeper:2181`, and `127.0.0.1:2181` from the host.

I suspect this is down to misconfiguration, maybe something like needing separate `~/.heron/conf/kubernetes/*.yaml` copies, one for within the cluster, one for the host.

Once that's worked out, I'll clean up and refactor the `./scripts/travis/*.sh` test scripts and make a proper PR