### PR TITLE
fix jenkins debian10

### DIFF
--- a/docker/compile/Dockerfile.debian10
+++ b/docker/compile/Dockerfile.debian10
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-FROM debian:buster-20200607
+FROM openjdk:11.0.6-jdk-buster
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM debian
@@ -32,7 +32,6 @@ RUN apt-get update && apt-get -y install \
       libtool \
       libtool-bin \
       libssl-dev \
-      openjdk-11-jdk-headless \
       pkg-config \
       python \
       python3 \

--- a/docker/compile/Dockerfile.debian10
+++ b/docker/compile/Dockerfile.debian10
@@ -29,14 +29,14 @@ RUN apt-get update && apt-get -y install \
       curl \
       git \
       libcppunit-dev \
+      libssl-dev \
       libtool \
       libtool-bin \
-      libssl-dev \
       pkg-config \
       python \
       python3 \
-      python3-setuptools \
       python3-dev \
+      python3-setuptools \
       software-properties-common \
       tree \
       unzip \

--- a/docker/compile/Dockerfile.debian10
+++ b/docker/compile/Dockerfile.debian10
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-FROM openjdk:11.0.6-slim-buster
+FROM debian:buster-20200607
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM debian
@@ -27,21 +27,22 @@ RUN apt-get update && apt-get -y install \
       build-essential \
       cmake \
       curl \
-      libssl-dev \
       git \
+      libcppunit-dev \
       libtool \
       libtool-bin \
-      libcppunit-dev \
+      libssl-dev \
+      openjdk-11-jdk-headless \
       pkg-config \
       python \
       python3 \
+      python3-setuptools \
       python3-dev \
       software-properties-common \
-      python3-setuptools \
       tree \
-      zip \
       unzip \
-      wget
+      wget \
+      zip
 
 RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/$bazelVersion/bazel-$bazelVersion-installer-linux-x86_64.sh \
       && chmod +x /tmp/bazel.sh \

--- a/docker/compile/Dockerfile.debian9
+++ b/docker/compile/Dockerfile.debian9
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-FROM openjdk:11-jdk-slim-stretch
+FROM openjdk:11-jdk-stretch
 
 # This is passed to the heron build command via the --config flag
 ENV TARGET_PLATFORM debian
@@ -27,20 +27,20 @@ RUN apt-get update && apt-get -y install \
       build-essential \
       cmake \
       curl \
-      libssl-dev \
       git \
+      libcppunit-dev \
+      libssl-dev \
       libtool \
       libtool-bin \
-      libcppunit-dev \
       pkg-config \
-      software-properties-common \
       python \
       python3-dev \
       python3-setuptools \
+      software-properties-common \
       tree \
-      zip \
       unzip \
-      wget
+      wget \
+      zip
 
 RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/$bazelVersion/bazel-$bazelVersion-installer-linux-x86_64.sh \
       && chmod +x /tmp/bazel.sh \


### PR DESCRIPTION
The current jenkins failed due to jdk11 configure https://builds.apache.org/job/apache-heron-docker-image/59/console
Fix it with the standard debian image, test link https://builds.apache.org/job/apache-heron-docker-image/60/console