### PR TITLE
Add ant to vagrant machine

### DIFF
--- a/vagrant/init.sh
+++ b/vagrant/init.sh
@@ -102,7 +102,7 @@ REMOVED
 apt-get -qy update
 
 # install deps
-apt-get install -qy vim zip mc curl wget openjdk-11-jdk scala git python3-setuptools python3-dev libtool-bin libcppunit-dev python-is-python3
+apt-get install -qy ant vim zip mc curl wget openjdk-11-jdk scala git python3-setuptools python3-dev libtool-bin libcppunit-dev python-is-python3
 
 # install_mesos $mode
 if [ $mode == "master" ]; then 


### PR DESCRIPTION
Ant was a recently added requirement, CI in vagrant will abort at `./bazel_configure.py`