### PR TITLE
Fix log-reader for Python3

### DIFF
--- a/heron/shell/src/python/utils.py
+++ b/heron/shell/src/python/utils.py
@@ -135,7 +135,7 @@ def read_chunk(filename, offset=-1, length=-1, escape_data=False):
   if length == -1:
     length = fstat.st_size - offset
 
-  with open(filename, "r") as fp:
+  with open(filename, "rb") as fp:
     fp.seek(offset)
     try:
       data = fp.read(length)
@@ -143,13 +143,14 @@ def read_chunk(filename, offset=-1, length=-1, escape_data=False):
       return {}
 
   if data:
-    data = _escape_data(data) if escape_data else data
+    # use permissive decoding and escaping if escape_data is set, otherwise use strict decoding
+    data = _escape_data(data) if escape_data else data.decode()
     return dict(offset=offset, length=len(data), data=data)
 
   return dict(offset=offset, length=0)
 
 def _escape_data(data):
-  return escape(data.decode('utf8', 'replace'))
+  return escape(data)
 
 def pipe(prev_proc, to_cmd):
   """

--- a/heron/shell/src/python/utils.py
+++ b/heron/shell/src/python/utils.py
@@ -150,7 +150,7 @@ def read_chunk(filename, offset=-1, length=-1, escape_data=False):
   return dict(offset=offset, length=0)
 
 def _escape_data(data):
-  return escape(data)
+  return escape(data.decode())
 
 def pipe(prev_proc, to_cmd):
   """

--- a/heron/shell/src/python/utils.py
+++ b/heron/shell/src/python/utils.py
@@ -150,7 +150,7 @@ def read_chunk(filename, offset=-1, length=-1, escape_data=False):
   return dict(offset=offset, length=0)
 
 def _escape_data(data):
-  return escape(data.decode())
+  return escape(data.decode('utf8', 'replace'))
 
 def pipe(prev_proc, to_cmd):
   """


### PR DESCRIPTION
Python3

@Code0x58 
```
[I 200722 23:06:34 web:1811] 200 GET /filedata/./log-files/container_36_system-log-to-es_36.log.0?offset=-1&length=-1 (10.25.178.125) 0.64ms
[E 200722 23:06:34 web:1407] Uncaught exception GET /filedata/./log-files/container_36_system-log-to-es_36.log.0?offset=2178106&length=50000 (10.25.178.125)
    HTTPServerRequest(protocol='http', host='LNMESOSS1513:31449', method='GET', uri='/filedata/./log-files/container_36_system-log-to-es_36.log.0?offset=2178106&length=50000', version='HTTP/1.1', remote_ip='10.25.178.125', headers={'Connection': 'close', 'Host': 'LNMESOSS1513:31449', 'Accept-Encoding': 'gzip'})
    Traceback (most recent call last):
      File "/var/lib/mesos/slaves/0114e468-0f07-485c-8673-14ff74e8b46c-S593/frameworks/c663397e-a472-43bd-92dd-d97027fcf6ce-0000/executors/thermos-www-release-heron-system-access-es-others-36-60361105-ae4e-4efc-84df-b70d3c717113/runs/f8aa692a-249d-40f8-a8db-e7e4a8cbdc8f/sandbox/.pex/installed_wheels/a92bf48f8e3ffa83220bafe58403d68e2d170148/tornado-4.0.2-cp36-cp36m-linux_x86_64.whl/tornado/web.py", line 1288, in _stack_context_handle_exception
        raise_exc_info((type, value, traceback))
      File "<string>", line 3, in raise_exc_info
      File "/var/lib/mesos/slaves/0114e468-0f07-485c-8673-14ff74e8b46c-S593/frameworks/c663397e-a472-43bd-92dd-d97027fcf6ce-0000/executors/thermos-www-release-heron-system-access-es-others-36-60361105-ae4e-4efc-84df-b70d3c717113/runs/f8aa692a-249d-40f8-a8db-e7e4a8cbdc8f/sandbox/.pex/installed_wheels/a92bf48f8e3ffa83220bafe58403d68e2d170148/tornado-4.0.2-cp36-cp36m-linux_x86_64.whl/tornado/web.py", line 1475, in wrapper
        result = method(self, *args, **kwargs)
      File "/var/lib/mesos/slaves/0114e468-0f07-485c-8673-14ff74e8b46c-S593/frameworks/c663397e-a472-43bd-92dd-d97027fcf6ce-0000/executors/thermos-www-release-heron-system-access-es-others-36-60361105-ae4e-4efc-84df-b70d3c717113/runs/f8aa692a-249d-40f8-a8db-e7e4a8cbdc8f/sandbox/.pex/code/e789de3949af7faec9b2f90bd1c725ad59bc2557/heron/shell/src/python/handlers/filedatahandler.py", line 50, in get
        data = utils.read_chunk(path, offset=offset, length=length, escape_data=True)
      File "/var/lib/mesos/slaves/0114e468-0f07-485c-8673-14ff74e8b46c-S593/frameworks/c663397e-a472-43bd-92dd-d97027fcf6ce-0000/executors/thermos-www-release-heron-system-access-es-others-36-60361105-ae4e-4efc-84df-b70d3c717113/runs/f8aa692a-249d-40f8-a8db-e7e4a8cbdc8f/sandbox/.pex/code/e789de3949af7faec9b2f90bd1c725ad59bc2557/heron/shell/src/python/utils.py", line 146, in read_chunk
        data = _escape_data(data) if escape_data else data
      File "/var/lib/mesos/slaves/0114e468-0f07-485c-8673-14ff74e8b46c-S593/frameworks/c663397e-a472-43bd-92dd-d97027fcf6ce-0000/executors/thermos-www-release-heron-system-access-es-others-36-60361105-ae4e-4efc-84df-b70d3c717113/runs/f8aa692a-249d-40f8-a8db-e7e4a8cbdc8f/sandbox/.pex/code/e789de3949af7faec9b2f90bd1c725ad59bc2557/heron/shell/src/python/utils.py", line 152, in _escape_data
        return escape(data.decode('utf8', 'replace'))
    AttributeError: 'str' object has no attribute 'decode'
[E 200722 23:06:34 web:1811] 500 GET /filedata/./log-files/container_36_system-log-to-es_36.log.0?offset=2178106&length=50000 (10.25.178.125) 0.98ms
```