### PR TITLE
Fix for misisng JDK tools

### DIFF
--- a/docker/dist/Dockerfile.dist.debian10
+++ b/docker/dist/Dockerfile.dist.debian10
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-FROM openjdk:11.0.6-jre-slim-buster
+FROM openjdk:11-jdk-slim-buster
 
 RUN apt-get update \
     && apt-get -y install \

--- a/docker/dist/Dockerfile.dist.debian9
+++ b/docker/dist/Dockerfile.dist.debian9
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-FROM openjdk:11-jre-slim-stretch
+FROM openjdk:11-jdk-slim-stretch
 
 RUN apt-get -y update \
     && apt-get -y install \

--- a/docker/dist/Dockerfile.dist.ubuntu14.04
+++ b/docker/dist/Dockerfile.dist.ubuntu14.04
@@ -30,7 +30,7 @@ RUN apt-get -y update \
 
 RUN add-apt-repository ppa:openjdk-r/ppa \
     && apt-get -y update \
-    && apt-get -y install openjdk-11-jre-headless \
+    && apt-get -y install openjdk-11-jdk-headless \
     && apt-get clean
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64

--- a/docker/dist/Dockerfile.dist.ubuntu16.04
+++ b/docker/dist/Dockerfile.dist.ubuntu16.04
@@ -32,7 +32,7 @@ RUN add-apt-repository ppa:openjdk-r/ppa
 
 RUN apt-get update \
     && apt-get -y install \
-    openjdk-11-jre-headless \
+    openjdk-11-jdk-headless \
     && apt-get clean
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64

--- a/docker/dist/Dockerfile.dist.ubuntu18.04
+++ b/docker/dist/Dockerfile.dist.ubuntu18.04
@@ -21,7 +21,7 @@ RUN apt-get -y update \
     && apt-get -y install \
     curl \
     netcat-openbsd \
-    openjdk-11-jre-headless \
+    openjdk-11-jdk-headless \
     python3 \
     python3-distutils \
     supervisor \

--- a/docker/dist/Dockerfile.dist.ubuntu20.04
+++ b/docker/dist/Dockerfile.dist.ubuntu20.04
@@ -22,7 +22,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update \
     && apt-get -y install \
     curl \
-    openjdk-11-jre-headless \
+    openjdk-11-jdk-headless \
     netcat-openbsd \
     python3 \
     python3-distutils \


### PR DESCRIPTION
When we updated the Distribution images to use JRE instead of JDK, we lost the ability to run commands like `jmap` and `jstack`. This Pull Request updates the images to use JDK as they did before.