### PR TITLE
Switch to pigz to support multi-core tar command

### DIFF
--- a/docker/scripts/build-artifacts.sh
+++ b/docker/scripts/build-artifacts.sh
@@ -95,7 +95,7 @@ trap cleanup EXIT
 
 generate_source() {
   echo "Generating source tarball"
-  tar --exclude-from=$DOCKER_DIR/.tarignore -C $PROJECT_DIR -czf $SRC_TAR .
+  tar --use-compress-program=pigz --exclude-from=$DOCKER_DIR/.tarignore -C $PROJECT_DIR -cf $SRC_TAR .
 }
 
 verify_source_exists() {

--- a/docker/scripts/build-docker.sh
+++ b/docker/scripts/build-docker.sh
@@ -83,7 +83,7 @@ run_build() {
 
   echo "Saving docker image to $DOCKER_IMAGE_FILE"
   docker save -o $DOCKER_IMAGE_FILE $DOCKER_TAG
-  gzip $DOCKER_IMAGE_FILE
+  pigz $DOCKER_IMAGE_FILE
 } 
 
 case $# in

--- a/docker/scripts/build-exec-docker.sh
+++ b/docker/scripts/build-exec-docker.sh
@@ -75,7 +75,7 @@ build_exec_image() {
   
   echo "Saving docker image to $DOCKER_IMAGE_FILE"
   docker save -o $DOCKER_IMAGE_FILE $DOCKER_TAG
-  gzip $DOCKER_IMAGE_FILE
+  pigz $DOCKER_IMAGE_FILE
 }
 
 case $# in


### PR DESCRIPTION
pigz is a multi-core version of tar, which makes the docker build process much faster.