### PR TITLE
Adding missing environment variable

### DIFF
--- a/deploy/kubernetes/helm/templates/zookeeper.yaml
+++ b/deploy/kubernetes/helm/templates/zookeeper.yaml
@@ -118,6 +118,10 @@ spec:
           value: "{{ .Values.zookeeper.serverPort }}"
         - name: ZK_ELECTION_PORT
           value: "{{ .Values.zookeeper.leaderElectionPort }}"
+        - name: ZOOKEEPER_SERVERS
+          {{- $replicaCount := int .Values.zkReplicas }}
+          {{- $fullName := printf "%s-%s" .Release.Name "zookeeper" }}
+          value: "{{ range $i, $e := until $replicaCount }}{{ fullName }}-{{ $e }},{{ end }}"
         command:
         - sh
         - -c


### PR DESCRIPTION
Fixes #3610 . This solution resolves the list of Zookeeper servers at Helm install time and passes in the list of servers by setting ZOOKEEPER_SERVERS environment variable. In the future, we should consider updating the Zookeeper startup script to dynamically discover the other pods using the headless service discovery mechanism provided by Kubernetes (i.e. nslookup)