### PR TITLE
Adding missing ENV variables for Centos 7 image

### DIFF
--- a/docker/dist/Dockerfile.dist.centos7
+++ b/docker/dist/Dockerfile.dist.centos7
@@ -17,6 +17,8 @@
 
 FROM centos:centos7
 
+ENV LC_ALL en_US.utf8
+
 RUN yum -y install epel-release \
     && yum -y update \
     && yum -y install \
@@ -29,6 +31,8 @@ RUN yum -y install epel-release \
     unzip \
     which \
     && yum clean all
+
+ENV JAVA_HOME /usr/
 
 ADD artifacts /heron
 


### PR DESCRIPTION
LC_ALL is needed by Python3. This fixes #3612 
JAVA_HOME is needed for Java topologies. This fixes #3613 