### PR TITLE
Added ability to disable base_url in Helm chart

### DIFF
--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -116,8 +116,8 @@ spec:
             - >-
               heron-ui
               --port=8889
-              {{- if eq .Values.heron.enable_url true }}
-              --base_url={{ .Values.heron.url | default $defaultUrl }}
+              {{- if not (kindIs "invalid" .Values.heron.url) }}
+              --base_url={{ eq .Values.heron.url "-" | ternary $defaultUrl .Values.heron.url }}
               {{- end }}
         - name: heron-apiserver
           image: {{ .Values.image }}

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -116,7 +116,9 @@ spec:
             - >-
               heron-ui
               --port=8889
+              {{- if eq .Values.heron.enable_url true }}
               --base_url={{ .Values.heron.url | default $defaultUrl }}
+              {{- end }}
         - name: heron-apiserver
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -39,6 +39,7 @@ jobReplicas: 1
 # amount of memory to provide for API server
 apiServerMemory: 512M
 heron:
+  enable_url: true
   url: ~
 # Topologies uploader
 uploader:

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -39,8 +39,9 @@ jobReplicas: 1
 # amount of memory to provide for API server
 apiServerMemory: 512M
 heron:
-  enable_url: true
-  url: ~
+  # set to `-` to set base_url to the default k8s proxy URL
+  # set to `null` to remove the use of base_url
+  url: "-"
 # Topologies uploader
 uploader:
   class: dlog # s3


### PR DESCRIPTION
This PR adds a new config item to support disabling the `base_url` parameter when installing Heron using the Helm chart.