### PR TITLE
adding py3 venv

### DIFF
--- a/docker/compile/Dockerfile.debian10
+++ b/docker/compile/Dockerfile.debian10
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get -y install \
       python3 \
       python3-dev \
       python3-setuptools \
+      python3-venv \
       software-properties-common \
       tree \
       unzip \


### PR DESCRIPTION
previously the debian10 build was broken.  This PR fixes it.