### PR TITLE
Added some helpful Bookkeeper config items

### DIFF
--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -42,6 +42,9 @@ data:
   BK_indexDirectories: "/bookkeeper/data/ledgers" 
   BK_zkServers: {{ .Release.Name }}-zookeeper:{{ .Values.zookeeper.clientPort }}
   BK_autoRecoveryDaemonEnabled: "true"
+  BK_journalMaxBackups: {{ .Values.bookieJournalMaxBackups }}
+  BK_journalMaxSizeMB: {{ .Values.bookieJournalMaxSizeMB }}
+  BK_logSizeLimit: {{ .Values.bookieLogSizeLimit }}
   {{- if or (eq .Values.platform "gke") (eq .Values.platform "minikube") }}
   BK_useHostNameAsBookieID: "true"
   {{- end }}

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -64,6 +64,9 @@ bookieReadCacheSize: 32
 bookieWriteCacheSize: 32
 bookieJournalCapacity: 5G
 bookieStorageCapacity: 15G
+bookieJournalMaxBackups: 3
+bookieJournalMaxSizeMB: 300
+bookieLogSizeLimit: 10000000
 
 # Number of replicas for zookeeper
 zkReplicas: 3


### PR DESCRIPTION
When working with Heron in a Kubernetes environment, we sometimes run out of space in Bookkeeper due to multiple Heron analytic packages being stored. This pull request adds a few more Bookkeeper config items which can now be configured with the Helm package set of configurations. The default values are based on values we found to be helpful.

The testing was done with Bookkeeper used only for the Upload/Download aspect of Heron scheduling an analytic. These default config parameters might not be sufficient if someone is running a stateful analytic. But the Helm package provides the ability for the user to set the values to whatever they need.