### PR TITLE
Joshfischer/fix rat excludes

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -20,6 +20,10 @@ m4
 META-INF
 # website and website2 are not part of the release
 website
+website2
+
+# travis toolchain config is not part of the release
+cc_toolchain_config.bzl
 
 # UI resources
 # Apache 2.0 licenses & MIT Licenses

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -18,9 +18,10 @@ heron\.iml
 bazel-.*
 m4
 META-INF
-# website and website2 are not part of the release
+# website, website2, and generated-ste are not part of the release
 website
 website2
+generated-site
 
 # travis toolchain config is not part of the release
 cc_toolchain_config.bzl


### PR DESCRIPTION
Before this PR we would get output from Apache Rat saying we had a .bzl file without a header.  This file is not included in the release and does not need one.  I also added explicit listings for the `website2` and `generate-site` folders as they were showing up in the Rat report. 
```

 Printing headers for text files without a valid license header...
 
=====================================================
== File: ./tools/travis/toolchain/cc_toolchain_config.bzl
=====================================================
def _impl(ctx):
    return cc_common.create_cc_toolchain_config_info(
        ctx = ctx,
        toolchain_identifier = "k8-toolchain",
        host_system_name = "local",
        target_system_name = "local",
        target_cpu = "k8",
        target_libc = "unknown",
        compiler = "clang",
        abi_version = "unknown",
        abi_libc_version = "unknown",
    )

cc_toolchain_config = rule(
    implementation = _impl,
    attrs = {},
    provides = [CcToolchainConfigInfo],
)
```
To reproduce my findings execute the following on master HEAD from the root folder of the project.

```
sh ./scripts/release_check/license_check.sh ~/Desktop/apache-rat-0.13/apache-rat-0.13.jar
```