### PR TITLE
correct reference to values

### DIFF
--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -42,9 +42,9 @@ data:
   BK_indexDirectories: "/bookkeeper/data/ledgers" 
   BK_zkServers: {{ .Release.Name }}-zookeeper:{{ .Values.zookeeper.clientPort }}
   BK_autoRecoveryDaemonEnabled: "true"
-  BK_journalMaxBackups: {{ .Values.bookieJournalMaxBackups }}
-  BK_journalMaxSizeMB: {{ .Values.bookieJournalMaxSizeMB }}
-  BK_logSizeLimit: {{ .Values.bookieLogSizeLimit }}
+  BK_journalMaxBackups: "{{ .Values.bookieJournalMaxBackups }}"
+  BK_journalMaxSizeMB: "{{ .Values.bookieJournalMaxSizeMB }}"
+  BK_logSizeLimit: "{{ .Values.bookieLogSizeLimit }}"
   {{- if or (eq .Values.platform "gke") (eq .Values.platform "minikube") }}
   BK_useHostNameAsBookieID: "true"
   {{- end }}


### PR DESCRIPTION
Previous to this PR `helm install` would fail because helm was trying to substitute a number instead of  string.  The error would look something like below.

```
$ helm install ./heron -g -n heron
Error: ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadString: expects " or n, but found 3, error found in #10 byte of ...|xSizeMB":300,"BK_led|..., bigger context ...|"BK_journalMaxBackups":"3","BK_journalMaxSizeMB":300,"BK_ledgerDirectories":"/bookkeeper/data/ledger|...
```

There is still some work to do on the helm chart  and bookkeeper.  This is a start of that work.  I'll follow up with details of what else needs to be done via github issues and the mailing list.