### PR TITLE
Fixes to heron-ui arg name changes

### DIFF
--- a/deploy/kubernetes/general/tools.yaml
+++ b/deploy/kubernetes/general/tools.yaml
@@ -77,7 +77,7 @@ spec:
             - >-
               heron-ui
               --port=8889
-              --base_url=/api/v1/namespaces/default/services/heron-ui:8889/proxy
+              --base-url=/api/v1/namespaces/default/services/heron-ui:8889/proxy
           resources:
             requests:
               cpu: "100m"

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -117,7 +117,7 @@ spec:
               heron-ui
               --port=8889
               {{- if not (kindIs "invalid" .Values.heron.url) }}
-              --base_url={{ eq .Values.heron.url "-" | ternary $defaultUrl .Values.heron.url }}
+              --base-url={{ eq .Values.heron.url "-" | ternary $defaultUrl .Values.heron.url }}
               {{- end }}
         - name: heron-apiserver
           image: {{ .Values.image }}

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -39,7 +39,7 @@ jobReplicas: 1
 # amount of memory to provide for API server
 apiServerMemory: 512M
 heron:
-  # set to `-` to set base_url to the default k8s proxy URL
+  # set to `-` to set base-url to the default k8s proxy URL
   # set to `null` to remove the use of base_url
   url: "-"
 # Topologies uploader

--- a/deploy/kubernetes/minikube/tools.yaml
+++ b/deploy/kubernetes/minikube/tools.yaml
@@ -63,7 +63,7 @@ spec:
             - >-
               heron-ui
               --port=8889
-              --base_url=/api/v1/namespaces/default/services/heron-ui:8889/proxy
+              --base-url=/api/v1/namespaces/default/services/heron-ui:8889/proxy
           resources:
             requests:
               cpu: "100m"

--- a/website2/docs/user-manuals-heron-ui.md
+++ b/website2/docs/user-manuals-heron-ui.md
@@ -49,13 +49,13 @@ $ ./bazel-bin/heron/tools/ui/src/python/heron-ui
 ### Heron UI Args
 
 * `--port` - Port to run the heron-ui on. Default port is `8889`.
-* `--tracker_url` - The base url for tracker. All the information about the
+* `--tracker-url` - The base url for tracker. All the information about the
   topologies is fetched from tracker. Default url is `http://localhost:8888`.
 * `--address` - Address to listen; Default address is `0.0.0.0`
-* `--base_url` - The base url path if operating behind proxy; Default is [`None`](https://github.com/apache/incubator-heron/blob/master/heron/tools/ui/src/python/main.py#L145)
+* `--base-url` - The base url path if operating behind proxy; Default is [`None`](https://github.com/apache/incubator-heron/blob/master/heron/tools/ui/src/python/main.py#L145)
 
 ```bash
 $ heron-ui
 # is equivalent to
-$ heron-ui --port=8889 --tracker_url=http://localhost:8888
+$ heron-ui --port=8889 --tracker-url=http://localhost:8888
 ```

--- a/website2/website/versioned_docs/version-0.20.0-incubating/user-manuals-heron-ui.md
+++ b/website2/website/versioned_docs/version-0.20.0-incubating/user-manuals-heron-ui.md
@@ -50,13 +50,13 @@ $ ./bazel-bin/heron/tools/ui/src/python/heron-ui
 ### Heron UI Args
 
 * `--port` - Port to run the heron-ui on. Default port is `8889`.
-* `--tracker_url` - The base url for tracker. All the information about the
+* `--tracker-url` - The base url for tracker. All the information about the
   topologies is fetched from tracker. Default url is `http://localhost:8888`.
 * `--address` - Address to listen; Default address is `0.0.0.0`
-* `--base_url` - The base url path if operating behind proxy; Default is [`None`](https://github.com/apache/incubator-heron/blob/master/heron/tools/ui/src/python/main.py#L145)
+* `--base-url` - The base url path if operating behind proxy; Default is [`None`](https://github.com/apache/incubator-heron/blob/master/heron/tools/ui/src/python/main.py#L145)
 
 ```bash
 $ heron-ui
 # is equivalent to
-$ heron-ui --port=8889 --tracker_url=http://localhost:8888
+$ heron-ui --port=8889 --tracker-url=http://localhost:8888
 ```


### PR DESCRIPTION
It appears that `heron-ui` arguments changed from `--base_url` to `--base-url`. Also `--tracker_url` changed to `--tracker-url`. This pull request should fix the places that referenced the older form.

This is one of the issues mentioned in #3633 