### PR TITLE
Adding quotes around value that Helm was changing to scientific notation

### DIFF
--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -44,7 +44,7 @@ data:
   BK_autoRecoveryDaemonEnabled: "true"
   BK_journalMaxBackups: "{{ .Values.bookieJournalMaxBackups }}"
   BK_journalMaxSizeMB: "{{ .Values.bookieJournalMaxSizeMB }}"
-  BK_logSizeLimit: "{{ .Values.bookieLogSizeLimit }}"
+  BK_logSizeLimit: "{{ int64 .Values.bookieLogSizeLimit }}"
   {{- if or (eq .Values.platform "gke") (eq .Values.platform "minikube") }}
   BK_useHostNameAsBookieID: "true"
   {{- end }}

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -66,8 +66,7 @@ bookieJournalCapacity: 5G
 bookieStorageCapacity: 15G
 bookieJournalMaxBackups: 3
 bookieJournalMaxSizeMB: 300
-# This needs to be in quotes to protect from Helm scientific notation problem
-bookieLogSizeLimit: "10000000"
+bookieLogSizeLimit: 10000000
 
 # Number of replicas for zookeeper
 zkReplicas: 3

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -66,7 +66,8 @@ bookieJournalCapacity: 5G
 bookieStorageCapacity: 15G
 bookieJournalMaxBackups: 3
 bookieJournalMaxSizeMB: 300
-bookieLogSizeLimit: 10000000
+# This needs to be in quotes to protect from Helm scientific notation problem
+bookieLogSizeLimit: "10000000"
 
 # Number of replicas for zookeeper
 zkReplicas: 3


### PR DESCRIPTION
Helm was breaking a recently added Bookkeeper config item. Because it was a large integer, it was changing it to scientific notation, which Bookkeeper did not like. This should help resolve #3633 .

More information about the issue can be read here.
https://github.com/helm/helm/issues/3001