### PR TITLE
Support javadoc of jdk11

### DIFF
--- a/tools/rules/javadoc.bzl
+++ b/tools/rules/javadoc.bzl
@@ -20,7 +20,7 @@ def _impl(ctx):
     transitive_jar_paths = [j.path for j in transitive_jar_set.to_list()]
     dir = ctx.outputs.zip.path + ".dir"
     source = ctx.outputs.zip.path + ".source"
-    external_docs = ["http://docs.oracle.com/javase/8/docs/api"] + ctx.attr.external_docs
+    external_docs = ["https://docs.oracle.com/en/java/javase/11/docs/api"] + ctx.attr.external_docs
     cmd = [
         "rm -rf %s" % source,
         "mkdir %s" % source,
@@ -36,7 +36,8 @@ def _impl(ctx):
             "-notimestamp",
             "-quiet",
             "-windowtitle '%s'" % ctx.attr.title,
-            " ".join(["-link %s" % url for url in external_docs]),
+            "-source 11",
+            " ".join(["-link '%s'" % url for url in external_docs]),
             "-sourcepath %s" % source,
             "-subpackages ",
             ":".join(ctx.attr.pkgs),


### PR DESCRIPTION
#3512 

# AS-IS
```
sh ./scripts/ci/build_maven_artifacts.sh 0.20.3-incubating-rc8-SNAPSHOT ./artifacts
Starting Heron Maven Jars Process
HERON_BUILD_VERSION master
HERON_BUILD_SCM_REVISION dd3b67b212ec5a5bdce8706e3e3dba11e20b4b30
HERON_BUILD_HOST house3s-iMac.local
HERON_BUILD_TIME Sat Dec 12 13:01:21 KST 2020
HERON_BUILD_TIMESTAMP 1607745681000
HERON_BUILD_USER thinker0
HERON_BUILD_RELEASE_STATUS Modified
Make jar components
INFO: Analyzed 8 targets (1 packages loaded, 226 targets configured).
INFO: Found 8 targets...
ERROR: /Users/thinker0/opensource/heron/heron/api/src/java/BUILD:9:9: error executing shell command: '/bin/bash -c rm -rf bazel-out/darwin-fastbuild/bin/heron/api/src/java/heron-api-javadoc.zip.source && mkdir bazel-out/darwin-fastbuild/bin/heron/api/src/java/heron-api-javadoc.zip.source && unzip -...' failed (Exit 1): bash failed: error executing command /bin/bash -c ... (remaining 1 argument(s) skipped)
javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
1 error
INFO: Elapsed time: 5.810s, Critical Path: 5.62s
INFO: 2 processes: 2 internal.
FAILED: Build did NOT complete successfully
```

# Fixed
```
./scripts/ci/build_maven_artifacts.sh 0.20.3-incubating-rc8-SNAPSHOT ./artifacts
Starting Heron Maven Jars Process
HERON_BUILD_VERSION master
HERON_BUILD_SCM_REVISION dd3b67b212ec5a5bdce8706e3e3dba11e20b4b30
HERON_BUILD_HOST house3s-iMac.local
HERON_BUILD_TIME Sat Dec 12 13:02:05 KST 2020
HERON_BUILD_TIMESTAMP 1607745725000
HERON_BUILD_USER thinker0
HERON_BUILD_RELEASE_STATUS Modified
Make jar components
INFO: Analyzed 8 targets (1 packages loaded, 226 targets configured).
INFO: Found 8 targets...
INFO: Elapsed time: 5.424s, Critical Path: 5.14s
INFO: 2 processes: 1 internal, 1 local.
INFO: Build completed successfully, 2 total actions
INFO: Analyzed 15 targets (1 packages loaded, 59 targets configured).
INFO: Found 15 targets...
INFO: Elapsed time: 2.826s, Critical Path: 2.63s
INFO: 2 processes: 1 internal, 1 local.
INFO: Build completed successfully, 2 total actions
INFO: Analyzed 5 targets (1 packages loaded, 26 targets configured).
INFO: Found 5 targets...
INFO: Elapsed time: 2.610s, Critical Path: 2.46s
INFO: 2 processes: 1 internal, 1 local.
INFO: Build completed successfully, 2 total actions
INFO: Analyzed 5 targets (1 packages loaded, 233 targets configured).
INFO: Found 5 targets...
INFO: Elapsed time: 4.321s, Critical Path: 4.07s
INFO: 2 processes: 1 internal, 1 local.
INFO: Build completed successfully, 2 total actions
INFO: Analyzed 2 targets (1 packages loaded, 10 targets configured).
INFO: Found 2 targets...
INFO: Elapsed time: 2.088s, Critical Path: 1.93s
INFO: 2 processes: 1 internal, 1 local.
INFO: Build completed successfully, 2 total actions
INFO: Analyzed 2 targets (1 packages loaded, 6 targets configured).
INFO: Found 2 targets...
INFO: Elapsed time: 1.878s, Critical Path: 1.72s
INFO: 2 processes: 1 internal, 1 local.
INFO: Build completed successfully, 2 total actions
Found Version Tag 0.20.3-incubating-rc8-SNAPSHOT
Run Maven template for poms ...
Removing heron-api-0.20.3-incubating-rc8-SNAPSHOT.pom
Removing heron-kafka-bolt-0.20.3-incubating-rc8-SNAPSHOT.pom
Removing heron-kafka-spout-0.20.3-incubating-rc8-SNAPSHOT.pom
Removing heron-simulator-0.20.3-incubating-rc8-SNAPSHOT.pom
Removing heron-spi-0.20.3-incubating-rc8-SNAPSHOT.pom
Removing heron-storm-0.20.3-incubating-rc8-SNAPSHOT.pom
```