### PR TITLE
Improving Kubernetes scheduler logic

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,7 +54,7 @@ jetty_version = "9.4.6.v20170531"
 
 jersey_version = "2.25.1"
 
-kubernetes_client_version = "8.0.0"
+kubernetes_client_version = "11.0.0"
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@rules_jvm_external//:specs.bzl", "maven")
@@ -263,6 +263,7 @@ http_archive(
 http_archive(
     name = "org_apache_zookeeper",
     build_file = "@//:third_party/zookeeper/BUILD",
+    sha256 = "bafc0abe7da696a2020ba11b8ce7d06f6e28e9bf1e5504de09be25b8b589777d",
     strip_prefix = "apache-zookeeper-3.5.8",
     urls = ["https://archive.apache.org/dist/zookeeper/zookeeper-3.5.8/apache-zookeeper-3.5.8.tar.gz"],
 )

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -222,28 +222,23 @@ public class V1Controller extends KubernetesController {
   }
 
   boolean deleteService() {
-    try {
-      final Response response = coreClient.deleteNamespacedServiceCall(getTopologyName(),
+    try (Response response = coreClient.deleteNamespacedServiceCall(getTopologyName(),
           getNamespace(), null, null, 0, null,
-          KubernetesConstants.DELETE_OPTIONS_PROPAGATION_POLICY, null, null).execute();
+          KubernetesConstants.DELETE_OPTIONS_PROPAGATION_POLICY, null, null).execute()) {
 
-      if (response.isSuccessful()) {
-        LOG.log(Level.INFO, "Headless Service for the Job [" + getTopologyName()
-            + "] in namespace [" + getNamespace() + "] is deleted.");
-        return true;
-      } else {
+      if (!response.isSuccessful()) {
         if (response.code() == HTTP_NOT_FOUND) {
           LOG.log(Level.INFO, "Kubernetes headless service does not exist for Topology: "
                   + getTopologyName());
           return true;
         }
         LOG.log(Level.SEVERE, "Error when deleting the Service of the job ["
-            + getTopologyName() + "] in namespace [" + getNamespace() + "]");
+                + getTopologyName() + "] in namespace [" + getNamespace() + "]");
         LOG.log(Level.SEVERE, "Error killing topoogy message:" + response.message());
         KubernetesUtils.logResponseBodyIfPresent(LOG, response);
 
         throw new TopologyRuntimeManagementException(
-            KubernetesUtils.errorMessageFromResponse(response));
+                KubernetesUtils.errorMessageFromResponse(response));
       }
     } catch (ApiException e) {
       if (e.getCode() == HTTP_NOT_FOUND) {
@@ -256,31 +251,28 @@ public class V1Controller extends KubernetesController {
               + getTopologyName() + "] Kubernetes service", e);
       return false;
     }
-    return false;
+    LOG.log(Level.INFO, "Headless Service for the Job [" + getTopologyName()
+            + "] in namespace [" + getNamespace() + "] is deleted.");
+    return true;
   }
 
   boolean deleteStatefulSet() {
-    try {
-      final Response response = appsClient.deleteNamespacedStatefulSetCall(getTopologyName(),
+    try (Response response = appsClient.deleteNamespacedStatefulSetCall(getTopologyName(),
           getNamespace(), null, null, 0, null,
-          KubernetesConstants.DELETE_OPTIONS_PROPAGATION_POLICY, null, null).execute();
+          KubernetesConstants.DELETE_OPTIONS_PROPAGATION_POLICY, null, null).execute()) {
 
-      if (response.isSuccessful()) {
-        LOG.log(Level.INFO, "StatefulSet for the Job [" + getTopologyName()
-            + "] in namespace [" + getNamespace() + "] is deleted.");
-        return true;
-      } else {
+      if (!response.isSuccessful()) {
         if (response.code() == HTTP_NOT_FOUND) {
           LOG.log(Level.INFO, "Statefulset does not exist for Topology: " + getTopologyName());
           return true;
         }
         LOG.log(Level.SEVERE, "Error when deleting the StatefulSet of the job ["
-            + getTopologyName() + "] in namespace [" + getNamespace() + "]");
+                + getTopologyName() + "] in namespace [" + getNamespace() + "]");
         LOG.log(Level.SEVERE, "Error killing topology message: " + response.message());
         KubernetesUtils.logResponseBodyIfPresent(LOG, response);
 
         throw new TopologyRuntimeManagementException(
-            KubernetesUtils.errorMessageFromResponse(response));
+                KubernetesUtils.errorMessageFromResponse(response));
       }
     } catch (ApiException e) {
       if (e.getCode() == HTTP_NOT_FOUND) {
@@ -291,7 +283,9 @@ public class V1Controller extends KubernetesController {
       KubernetesUtils.logExceptionWithDetails(LOG, "Error deleting topology", e);
       return false;
     }
-    return false;
+    LOG.log(Level.INFO, "StatefulSet for the Job [" + getTopologyName()
+            + "] in namespace [" + getNamespace() + "] is deleted.");
+    return true;
   }
 
   protected List<String> getExecutorCommand(String containerId) {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -233,7 +233,8 @@ public class V1Controller extends KubernetesController {
         return true;
       } else {
         if (response.code() == HTTP_NOT_FOUND) {
-          LOG.log(Level.INFO, "Kubernetes headless service does not exist for Topology: " + getTopologyName());
+          LOG.log(Level.INFO, "Kubernetes headless service does not exist for Topology: "
+                  + getTopologyName());
           return true;
         }
         LOG.log(Level.SEVERE, "Error when deleting the Service of the job ["
@@ -246,13 +247,16 @@ public class V1Controller extends KubernetesController {
       }
     } catch (ApiException e) {
       if (e.getCode() == HTTP_NOT_FOUND) {
-        LOG.log(Level.INFO, "Kubernetes headless service does not exist for Topology: " + getTopologyName());
+        LOG.log(Level.INFO, "Kubernetes headless service does not exist for Topology: "
+                + getTopologyName());
         return true;
       }
     } catch (IOException e) {
-      KubernetesUtils.logExceptionWithDetails(LOG, "Error deleting topology [" + getTopologyName() +"] Kubernetes service", e);
+      KubernetesUtils.logExceptionWithDetails(LOG, "Error deleting topology ["
+              + getTopologyName() + "] Kubernetes service", e);
       return false;
     }
+    return false;
   }
 
   boolean deleteStatefulSet() {
@@ -287,6 +291,7 @@ public class V1Controller extends KubernetesController {
       KubernetesUtils.logExceptionWithDetails(LOG, "Error deleting topology", e);
       return false;
     }
+    return false;
   }
 
   protected List<String> getExecutorCommand(String containerId) {


### PR DESCRIPTION
This fixes #3652 . This Pull Request adds extra logic to handle Kubernetes delete requests for Topology StatefulSet and Service that do not exist in Kubernetes. This code should now gracefully handle the `HTTP_NOT_FOUND` response code.