### PR TITLE
Improve the Kubernetes Resource handling

### DIFF
--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -161,6 +161,7 @@ spec:
               -D heron.class.packing.algorithm=org.apache.heron.packing.binpacking.FirstFitDecreasingPacking
               -D heron.class.repacking.algorithm=org.apache.heron.packing.binpacking.FirstFitDecreasingPacking
               {{- end }}
+              -D heron.kubernetes.resource.request.mode={{ .Values.topologyResourceRequestMode }}
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-tools-config

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -42,6 +42,10 @@ heron:
   # set to `-` to set base-url to the default k8s proxy URL
   # set to `null` to remove the use of base_url
   url: "-"
+
+# Can be EQUAL_TO_LIMIT or NOT_SET
+topologyResourceRequestMode: EQUAL_TO_LIMIT
+
 # Topologies uploader
 uploader:
   class: dlog # s3

--- a/heron/config/src/yaml/conf/kubernetes/scheduler.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/scheduler.yaml
@@ -34,7 +34,7 @@ heron.scheduler.is.service:                  False
 heron.executor.docker.image:                'heron/heron:latest'
 
 # logic to be used for calculating the Kubernetes resource request and limits
-# value can be "Empty", "Limit"
-# "Empty" will not set a K8s request
-# "Limit" will set the K8s request to the same values as the K8s limit
-heron.kubernetes.resource.request.mode:  Limit
+# value can be "NOT_SET", "EQUAL_TO_LIMIT"
+# "NOT_SET" will not set a K8s request
+# "EQUAL_TO_LIMIT" will set the K8s request to the same values as the K8s limit
+heron.kubernetes.resource.request.mode:  EQUAL_TO_LIMIT

--- a/heron/config/src/yaml/conf/kubernetes/scheduler.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/scheduler.yaml
@@ -32,3 +32,9 @@ heron.scheduler.is.service:                  False
 
 # docker repo for executor
 heron.executor.docker.image:                'heron/heron:latest'
+
+# logic to be used for calculating the Kubernetes resource request and limits
+# value can be "Empty", "Limit"
+# "Empty" will not set a K8s request
+# "Limit" will set the K8s request to the same values as the K8s limit
+heron.kubernetes.resource.request.mode:  Limit

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -33,6 +33,25 @@ public final class KubernetesContext extends Context {
   public static final String HERON_KUBERNETES_SCHEDULER_IMAGE_PULL_POLICY =
       "heron.kubernetes.scheduler.imagePullPolicy";
 
+  public enum KubernetesResourceRequestMode {
+    /**
+     * The Kubernetes Request will not be set by the Heron Kubernetes Scheduler.
+     * The generated pods will use the Kubernetes default values.
+     */
+    NOT_SET,
+    /**
+     * The Kubernetes Pod Resource Request will be set to the same values as
+     * provided in the Resource Limit. This mode effectively guarantees the
+     * cpu and memory will be reserved.
+     */
+    EQUAL_TO_LIMIT;
+  }
+  /**
+   * This config item is used to determine how to configure the K8s Resource Request.
+   * The format of this flag is the string encoded values of the
+   * underlying KubernetesRequestMode value.
+   */
+  public static final String KUBERNETES_RESOURCE_REQUEST_MODE = "heron.kubernetes.resource.request.mode";
 
   public static final String HERON_KUBERNETES_VOLUME_NAME = "heron.kubernetes.volume.name";
   public static final String HERON_KUBERNETES_VOLUME_TYPE = "heron.kubernetes.volume.type";
@@ -85,6 +104,10 @@ public final class KubernetesContext extends Context {
   public static boolean hasImagePullPolicy(Config config) {
     final String imagePullPolicy = getKubernetesImagePullPolicy(config);
     return isNotEmpty(imagePullPolicy);
+  }
+
+  public static KubernetesResourceRequestMode getKubernetesRequestMode(Config config) {
+    return KubernetesResourceRequestMode.valueOf(config.getStringValue(KUBERNETES_RESOURCE_REQUEST_MODE));
   }
 
   static String getVolumeType(Config config) {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -51,7 +51,8 @@ public final class KubernetesContext extends Context {
    * The format of this flag is the string encoded values of the
    * underlying KubernetesRequestMode value.
    */
-  public static final String KUBERNETES_RESOURCE_REQUEST_MODE = "heron.kubernetes.resource.request.mode";
+  public static final String KUBERNETES_RESOURCE_REQUEST_MODE =
+          "heron.kubernetes.resource.request.mode";
 
   public static final String HERON_KUBERNETES_VOLUME_NAME = "heron.kubernetes.volume.name";
   public static final String HERON_KUBERNETES_VOLUME_TYPE = "heron.kubernetes.volume.type";
@@ -107,7 +108,8 @@ public final class KubernetesContext extends Context {
   }
 
   public static KubernetesResourceRequestMode getKubernetesRequestMode(Config config) {
-    return KubernetesResourceRequestMode.valueOf(config.getStringValue(KUBERNETES_RESOURCE_REQUEST_MODE));
+    return KubernetesResourceRequestMode.valueOf(
+            config.getStringValue(KUBERNETES_RESOURCE_REQUEST_MODE));
   }
 
   static String getVolumeType(Config config) {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesController.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesController.java
@@ -62,16 +62,13 @@ public abstract class KubernetesController implements IScalable {
     return KubernetesContext.getSchedulerURI(configuration);
   }
 
-  ContainerResourcePair getContainerResourcePair(PackingPlan packingPlan) {
+  Resource getContainerResource(PackingPlan packingPlan) {
     // Align resources to maximal requested resource
     PackingPlan updatedPackingPlan = packingPlan.cloneWithHomogeneousScheduledResource();
     SchedulerUtils.persistUpdatedPackingPlan(Runtime.topologyName(runtimeConfiguration),
         updatedPackingPlan, Runtime.schedulerStateManagerAdaptor(runtimeConfiguration));
 
-    return new ContainerResourcePair(
-            updatedPackingPlan.getContainers().iterator().next().getRequiredResource(),
-            updatedPackingPlan.getContainers().iterator().next().getScheduledResource().get()
-    );
+    return updatedPackingPlan.getContainers().iterator().next().getScheduledResource().get();
   }
 
   abstract boolean submit(PackingPlan packingPlan);
@@ -80,23 +77,4 @@ public abstract class KubernetesController implements IScalable {
 
   abstract boolean restart(int shardId);
 
-  public static class ContainerResourcePair {
-    private final Resource requiredResource;
-    private final Resource scheduledResource;
-
-    public ContainerResourcePair(
-                         Resource requiredResource,
-                         Resource scheduledResource) {
-      this.requiredResource = requiredResource;
-      this.scheduledResource = scheduledResource;
-    }
-
-    public Resource getRequiredResource() {
-      return requiredResource;
-    }
-
-    public Resource getScheduledResource() {
-      return scheduledResource;
-    }
-  }
 }

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -100,7 +100,7 @@ public class V1Controller extends KubernetesController {
       throw new TopologySubmissionException("K8S scheduler does not allow upper case topologies.");
     }
 
-    final Resource resource = getContainerResource(packingPlan);
+    final Resource containerResource = getContainerResource(packingPlan);
 
     final V1Service topologyService = createTopologyyService();
     try {
@@ -118,7 +118,7 @@ public class V1Controller extends KubernetesController {
     for (PackingPlan.ContainerPlan containerPlan : packingPlan.getContainers()) {
       numberOfInstances = Math.max(numberOfInstances, containerPlan.getInstances().size());
     }
-    final V1StatefulSet statefulSet = createStatefulSet(resource, numberOfInstances);
+    final V1StatefulSet statefulSet = createStatefulSet(containerResource, numberOfInstances);
 
     try {
       final V1StatefulSet response =
@@ -316,8 +316,7 @@ public class V1Controller extends KubernetesController {
     return service;
   }
 
-  private V1StatefulSet createStatefulSet(Resource containerResource,
-                                          int numberOfInstances) {
+  private V1StatefulSet createStatefulSet(Resource containerResource, int numberOfInstances) {
     final String topologyName = getTopologyName();
     final Config runtimeConfiguration = getRuntimeConfiguration();
 
@@ -471,10 +470,10 @@ public class V1Controller extends KubernetesController {
             Quantity.fromString(Double.toString(roundDecimal(
                     resource.getCpu(), 3))));
     resourceRequirements.setLimits(limits);
-    KubernetesContext.KubernetesRequestMode requestMode =
+    KubernetesContext.KubernetesResourceRequestMode requestMode =
             KubernetesContext.getKubernetesRequestMode(configuration);
     // Set the Kubernetes container resource request
-    if (requestMode == KubernetesContext.KubernetesRequestMode.EQUAL_TO_LIMIT) {
+    if (requestMode == KubernetesContext.KubernetesResourceRequestMode.EQUAL_TO_LIMIT) {
       LOG.log(Level.CONFIG, "Setting K8s Request equal to Limit");
       resourceRequirements.setRequests(limits);
     } else {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -315,7 +315,8 @@ public class V1Controller extends KubernetesController {
     return service;
   }
 
-  private V1StatefulSet createStatefulSet(ContainerResourcePair containerResource, int numberOfInstances) {
+  private V1StatefulSet createStatefulSet(ContainerResourcePair containerResource,
+                                          int numberOfInstances) {
     final String topologyName = getTopologyName();
     final Config runtimeConfiguration = getRuntimeConfiguration();
 
@@ -464,13 +465,16 @@ public class V1Controller extends KubernetesController {
     requests.put(KubernetesConstants.MEMORY,
         Quantity.fromString(KubernetesUtils.Megabytes(resource.getRequiredResource().getRam())));
     requests.put(KubernetesConstants.CPU,
-         Quantity.fromString(Double.toString(roundDecimal(resource.getRequiredResource().getCpu(), 3))));
+         Quantity.fromString(Double.toString(roundDecimal(resource.getRequiredResource().getCpu(),
+                 3))));
     resourceRequirements.setRequests(requests);
     final Map<String, Quantity> limits = new HashMap<>();
     limits.put(KubernetesConstants.MEMORY,
-            Quantity.fromString(KubernetesUtils.Megabytes(resource.getScheduledResource().getRam())));
+            Quantity.fromString(KubernetesUtils.Megabytes(
+                    resource.getScheduledResource().getRam())));
     limits.put(KubernetesConstants.CPU,
-            Quantity.fromString(Double.toString(roundDecimal(resource.getScheduledResource().getCpu(), 3))));
+            Quantity.fromString(Double.toString(roundDecimal(
+                    resource.getScheduledResource().getCpu(), 3))));
     resourceRequirements.setLimits(limits);
     container.setResources(resourceRequirements);
 


### PR DESCRIPTION
The previous Heron Kubernetes Scheduler calculated a homogenous PackingPlan and used the resulting `ScheduledResource` which had the "max" cpu and memory. The `RequiredResource` was never used. This Pull Request updates the logic in the Heron Kubernetes Scheduler to use both sets of `Resource` objects. The `RequiredResource` will be used as the `V1ResourceRequirements` `Request` and the `ScheduledResource` will continue to be set as the `V1ResourceRequirements` `Limit`.