### PR TITLE
Removing defaulted HeapDumpOnOutOfMemory

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -582,7 +582,6 @@ class HeronExecutor:
         '-XX:+UseStringDeduplication',
         '-XX:MaxGCPauseMillis=100',
         '-XX:InitiatingHeapOccupancyPercent=30',
-        '-XX:+HeapDumpOnOutOfMemoryError',
         '-XX:ParallelGCThreads=4']
     if self.verbose_gc:
       gc_cmd += ['-Xlog:gc*,safepoint=info:file=' + self.log_dir + '/gc.' + gc_name +

--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -111,7 +111,7 @@ class HeronExecutorTest(unittest.TestCase):
            "-Djava.net.preferIPv4Stack=true " \
            "-XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication " \
            "-XX:MaxGCPauseMillis=100 -XX:InitiatingHeapOccupancyPercent=30 " \
-           "-XX:+HeapDumpOnOutOfMemoryError -XX:ParallelGCThreads=4 " \
+           "-XX:ParallelGCThreads=4 " \
            "-cp metricsmgr_classpath org.apache.heron.metricsmgr.MetricsManager " \
            "--id=metricsmgr-%d --port=metricsmgr_port " \
            "--topology=topname --cluster=cluster --role=role --environment=environ " \
@@ -125,7 +125,7 @@ class HeronExecutorTest(unittest.TestCase):
            "-Djava.net.preferIPv4Stack=true " \
            "-XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication " \
            "-XX:MaxGCPauseMillis=100 -XX:InitiatingHeapOccupancyPercent=30 " \
-           "-XX:+HeapDumpOnOutOfMemoryError -XX:ParallelGCThreads=4 " \
+           "-XX:ParallelGCThreads=4 " \
            "-cp metricscachemgr_classpath org.apache.heron.metricscachemgr.MetricsCacheManager " \
            "--metricscache_id metricscache-0 --server_port metricscachemgr_serverport " \
            "--stats_port metricscachemgr_statsport --topology_name topname --topology_id topid " \
@@ -139,7 +139,7 @@ class HeronExecutorTest(unittest.TestCase):
            "-Djava.net.preferIPv4Stack=true " \
            "-XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication " \
            "-XX:MaxGCPauseMillis=100 -XX:InitiatingHeapOccupancyPercent=30 " \
-           "-XX:+HeapDumpOnOutOfMemoryError -XX:ParallelGCThreads=4 " \
+           "-XX:ParallelGCThreads=4 " \
            "-cp scheduler_classpath:healthmgr_classpath " \
            "org.apache.heron.healthmgr.HealthManager --cluster cluster --role role " \
            "--environment environ --topology_name topname --metricsmgr_port metricsmgr_port"
@@ -151,7 +151,7 @@ class HeronExecutorTest(unittest.TestCase):
            "-Djava.net.preferIPv4Stack=true " \
            "-XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication " \
            "-XX:MaxGCPauseMillis=100 -XX:InitiatingHeapOccupancyPercent=30 " \
-           "-XX:+HeapDumpOnOutOfMemoryError -XX:ParallelGCThreads=4 " \
+           "-XX:ParallelGCThreads=4 " \
            "-cp instance_classpath:classpath -XX:+HeapDumpOnOutOfMemoryError " \
            "org.apache.heron.instance.HeronInstance -topology_name topname -topology_id topid " \
            "-instance_id %s -component_name %s -task_id %d -component_index 0 -stmgr_id stmgr-%d " \

--- a/heron/tools/apiserver/src/java/org/apache/heron/apiserver/resources/TopologyResource.java
+++ b/heron/tools/apiserver/src/java/org/apache/heron/apiserver/resources/TopologyResource.java
@@ -61,7 +61,6 @@ import org.apache.heron.apiserver.actions.ActionType;
 import org.apache.heron.apiserver.actions.Keys;
 import org.apache.heron.apiserver.utils.ConfigUtils;
 import org.apache.heron.apiserver.utils.FileHelper;
-import org.apache.heron.apiserver.utils.Logging;
 import org.apache.heron.apiserver.utils.Utils;
 import org.apache.heron.common.basics.DryRunFormatType;
 import org.apache.heron.common.basics.FileUtils;


### PR DESCRIPTION
This merge request removes the flag from the Heron Executor code. In most of the java examples, we show how a topology can add the optional flag. When running java components in a Kubernetes container, the heap dump file isn't as useful.

Here is an [example](https://github.com/apache/incubator-heron/blob/1a0d198ea301fd6346e0b1b6b7600c834874d8a0/examples/src/java/org/apache/heron/examples/api/AckingTopology.java#L75) of how to enable the flag.
