### PR TITLE
Restoring glog back to 0.3.5

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -279,8 +279,9 @@ http_archive(
 http_archive(
     name = "com_github_google_glog",
     build_file = "@//:third_party/glog/glog.BUILD",
-    strip_prefix = "glog-0.4.0",
-    urls = ["https://github.com/google/glog/archive/v0.4.0.tar.gz"],
+    sha256 = "7580e408a2c0b5a89ca214739978ce6ff480b5e7d8d7698a2aa92fadc484d1e0",
+    strip_prefix = "glog-0.3.5",
+    urls = ["https://github.com/google/glog/archive/v0.3.5.tar.gz"],
 )
 
 http_archive(

--- a/third_party/glog/glog.BUILD
+++ b/third_party/glog/glog.BUILD
@@ -41,7 +41,6 @@ common_script = [
 ]
 
 mac_script = "\n".join(common_script + [
-    './autogen.sh',
     './configure --prefix=$$INSTALL_DIR --enable-shared=no',
     'make install',
     'rm -rf $$TMP_DIR',
@@ -51,7 +50,6 @@ linux_script = "\n".join(common_script + [
      'export VAR_LIBS="-Wl,--rpath -Wl,$$UNWIND_DIR/lib -L$$UNWIND_DIR/lib"',
      'export VAR_INCL="-I$$UNWIND_DIR/include"',
      'export VAR_LD="-L$$UNWIND_DIR/lib"',
-     './autogen.sh',
      'autoreconf -f -i',
      './configure --prefix=$$INSTALL_DIR --enable-shared=no LIBS="$$VAR_LIBS" CPPFLAGS="$$VAR_INCL" LDFLAGS="$$VAR_LD"',
      'make install LIBS="$$VAR_LIBS" CPPFLAGS="$$VAR_INCL" LDFLAGS="$$VAR_LD"',


### PR DESCRIPTION
In #3655 the version of GLOG was updated from 0.3.5 to 0.4.0. While this works on Ubuntu and Darwin, I discovered that the build does not work on Centos 7. This pull request reverts the version so that Centos builds work again. Will need to investigate why there was link errors.