### PR TITLE
remove explicit style ignore

### DIFF
--- a/website2/website/siteConfig.js
+++ b/website2/website/siteConfig.js
@@ -111,7 +111,6 @@ const siteConfig = {
   // Ignores CSS files found in the static folder.
   // Any CSS files not listed here will be added to the Docusaurus main.css
   separateCss: [
-      `${baseUrl}static/css/custom.css`,
       `${baseUrl}static/api/java/jquery/jquery-ui.css`,
       `${baseUrl}static/api/java/jquery/jquery-ui.min.css`,
       `${baseUrl}static/api/java/jquery/jquery-ui.structure.min.css`,


### PR DESCRIPTION
This pr fixes a broken style link in the static site.  

Before this change the drop down list items would not lay on top of each other.

<img width="576" alt="Screen Shot 2021-02-02 at 8 26 28 PM" src="https://user-images.githubusercontent.com/5785700/106689276-52494c80-6595-11eb-9ca4-0261ca9a077a.png">


After this change the drop down will properly lay on top of each other.

<img width="453" alt="Screen Shot 2021-02-02 at 8 26 00 PM" src="https://user-images.githubusercontent.com/5785700/106689344-7573fc00-6595-11eb-9221-a81673e69292.png">
