### PR TITLE
Specifying explicit transitive dependency for `uvloop`

### DIFF
--- a/heron/tools/ui/src/python/BUILD
+++ b/heron/tools/ui/src/python/BUILD
@@ -13,6 +13,7 @@ pex_library(
         "jinja2==2.11.2",
         "aiofiles==0.5.0",
         "uvicorn==0.11.7",
+        "uvloop==0.14.0",
     ],
     deps = [
         "//heron/common/src/python:common-py",


### PR DESCRIPTION
Adding a temporary fix until uvicorn fix is released. Resolves #3674 

This will eventually be fixed by bumping the version of `uvicorn`, but the fix found [here](https://github.com/encode/uvicorn/pull/952) is not yet released.