### PR TITLE
Round Robin minimum RAM requirement descreasing to 16MB

### DIFF
--- a/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/org/apache/heron/packing/roundrobin/RoundRobinPacking.java
@@ -102,7 +102,7 @@ public class RoundRobinPacking implements IPacking, IRepacking {
 
   @VisibleForTesting
   static final ByteAmount DEFAULT_DAEMON_PROCESS_RAM_PADDING = ByteAmount.fromGigabytes(1);
-  private static final ByteAmount MIN_RAM_PER_INSTANCE = ByteAmount.fromMegabytes(192);
+  private static final ByteAmount MIN_RAM_PER_INSTANCE = ByteAmount.fromMegabytes(16);
 
   // Use as a stub as default number value when getting config value
   private static final ByteAmount NOT_SPECIFIED_BYTE_AMOUNT = ByteAmount.fromBytes(-1);


### PR DESCRIPTION
Decrease the minimum requirement of RAM of single instance to 16MB in Round Robin algorithm

The original minimum RAM setting is too high for micro spouts/bolts. This helps developers to split programs into much smaller than before.

16MB should fit most of the situation. Round Robin is about dividing the allocated RAM for the single container into required pieces. i.e. 800MB has 50 instances with 16MB RAM