### PR TITLE
adding disclaimers to release artifacts

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,3 @@
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-
 licenses(["notice"])
 package(default_visibility = ["//visibility:public"])
 

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,13 @@
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+licenses(["notice"])
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "disclaimers",
+    srcs = [
+        "DISCLAIMER",
+        "LICENSE",
+        "NOTICE",
+    ]
+)

--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -472,6 +472,11 @@ pkg_tar(
 )
 
 pkg_tar(
+    name = "disclaimers",
+    srcs = ["//:disclaimers"],
+)
+
+pkg_tar(
     name = "heron",
     srcs = generated_release_files,
     extension = "tar.gz",
@@ -499,6 +504,7 @@ pkg_tar(
         ":heron-lib-third_party",
         ":heron-lib-uploader",
         ":heron-simulator",
+        ":disclaimers",
     ],
 )
 


### PR DESCRIPTION
This PR adds the proper  disclaimers so that we may create release binaries.  See output for verification.

Steps to reproduce
$ bazel build --config=darwin_nostyle scripts/packages:binpkgs
$ ./bazel-bin/scripts/packages/heron-install.sh --user

$ ls ~/.heron/
DISCLAIMER    NOTICE        conf/         etc/          include/      release.yaml  
LICENSE       bin/          dist/         examples/     lib/          
$ cat ~/.heron/DISCLAIMER 
Apache Heron (incubating) is an effort undergoing incubation at The Apache Software Foundation
(ASF), sponsored by the Apache Incubator PMC. Incubation is required of all newly accepted
projects until a further review indicates that the infrastructure, communications, and decision
making process have stabilized in a manner consistent with other successful ASF projects. While
incubation status is not necessarily a reflection of the completeness or stability of the code,
it does indicate that the project has yet to be fully endorsed by the ASF