### PR TITLE
Add ability to add Kubernetes Secrets and SecretKeyRefs

### DIFF
--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -59,44 +59,49 @@ public final class KubernetesContext extends Context {
   public static final String KUBERNETES_RESOURCE_REQUEST_MODE =
           "heron.kubernetes.resource.request.mode";
 
-  public static final String HERON_KUBERNETES_VOLUME_NAME = "heron.kubernetes.volume.name";
-  public static final String HERON_KUBERNETES_VOLUME_TYPE = "heron.kubernetes.volume.type";
+  public static final String KUBERNETES_VOLUME_NAME = "heron.kubernetes.volume.name";
+  public static final String KUBERNETES_VOLUME_TYPE = "heron.kubernetes.volume.type";
 
 
   // HostPath volume keys
   // https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
-  public static final String HERON_KUBERNETES_VOLUME_HOSTPATH_PATH =
+  public static final String KUBERNETES_VOLUME_HOSTPATH_PATH =
       "heron.kubernetes.volume.hostPath.path";
 
   // nfs volume keys
   // https://kubernetes.io/docs/concepts/storage/volumes/#nfs
-  public static final String HERON_KUBERNETES_VOLUME_NFS_PATH =
+  public static final String KUBERNETES_VOLUME_NFS_PATH =
       "heron.kubernetes.volume.nfs.path";
-  public static final String HERON_KUBERNETES_VOLUME_NFS_SERVER =
+  public static final String KUBERNETES_VOLUME_NFS_SERVER =
       "heron.kubernetes.volume.nfs.server";
 
   // awsElasticBlockStore volume keys
   // https://kubernetes.io/docs/concepts/storage/volumes/#awselasticblockstore
-  public static final String HERON_KUBERNETES_VOLUME_AWS_EBS_VOLUME_ID =
+  public static final String KUBERNETES_VOLUME_AWS_EBS_VOLUME_ID =
       "heron.kubernetes.volume.awsElasticBlockStore.volumeID";
-  public static final String HERON_KUBERNETES_VOLUME_AWS_EBS_FS_TYPE =
+  public static final String KUBERNETES_VOLUME_AWS_EBS_FS_TYPE =
       "heron.kubernetes.volume.awsElasticBlockStore.fsType";
 
   // container mount volume mount keys
-  public static final String HERON_KUBERNETES_CONTAINER_VOLUME_MOUNT_NAME =
+  public static final String KUBERNETES_CONTAINER_VOLUME_MOUNT_NAME =
       "heron.kubernetes.container.volumeMount.name";
-  public static final String HERON_KUBERNETES_CONTAINER_VOLUME_MOUNT_PATH =
+  public static final String KUBERNETES_CONTAINER_VOLUME_MOUNT_PATH =
       "heron.kubernetes.container.volumeMount.path";
 
-  public static final String HERON_KUBERNETES_POD_ANNOTATION =
+  public static final String KUBERNETES_POD_ANNOTATION_PREFIX =
       "heron.kubernetes.pod.annotation.";
-  public static final String HERON_KUBERNETES_SERVICE_ANNOTATION =
+  public static final String KUBERNETES_SERVICE_ANNOTATION_PREFIX =
       "heron.kubernetes.service.annotation.";
-  public static final String HERON_KUBERNETES_POD_LABEL =
-          "heron.kubernetes.pod.label.";
-  public static final String HERON_KUBERNETES_SERVICE_LABEL =
-          "heron.kubernetes.service.label.";
-
+  public static final String KUBERNETES_POD_LABEL_PREFIX =
+      "heron.kubernetes.pod.label.";
+  public static final String KUBERNETES_SERVICE_LABEL_PREFIX =
+      "heron.kubernetes.service.label.";
+  // heron.kubernetes.pod.secret.heron-secret=/etc/secrets
+  public static final String KUBERNETES_POD_SECRET_PREFIX =
+      "heron.kubernetes.pod.secret.";
+  // heron.kubernetes.pod.secretKeyRef.ENV_NAME=name:key
+  public static final String KUBERNETES_POD_SECRET_KEY_REF_PREFIX =
+      "heron.kubernetes.pod.secretKeyRef.";
 
   private KubernetesContext() {
   }
@@ -128,31 +133,31 @@ public final class KubernetesContext extends Context {
   }
 
   static String getVolumeType(Config config) {
-    return config.getStringValue(HERON_KUBERNETES_VOLUME_TYPE);
+    return config.getStringValue(KUBERNETES_VOLUME_TYPE);
   }
 
   static String getVolumeName(Config config) {
-    return config.getStringValue(HERON_KUBERNETES_VOLUME_NAME);
+    return config.getStringValue(KUBERNETES_VOLUME_NAME);
   }
 
   static String getHostPathVolumePath(Config config) {
-    return config.getStringValue(HERON_KUBERNETES_VOLUME_HOSTPATH_PATH);
+    return config.getStringValue(KUBERNETES_VOLUME_HOSTPATH_PATH);
   }
 
   static String getNfsVolumePath(Config config) {
-    return config.getStringValue(HERON_KUBERNETES_VOLUME_NFS_PATH);
+    return config.getStringValue(KUBERNETES_VOLUME_NFS_PATH);
   }
 
   static String getNfsServer(Config config) {
-    return config.getStringValue(HERON_KUBERNETES_VOLUME_NFS_SERVER);
+    return config.getStringValue(KUBERNETES_VOLUME_NFS_SERVER);
   }
 
   static String getAwsEbsVolumeId(Config config) {
-    return config.getStringValue(HERON_KUBERNETES_VOLUME_AWS_EBS_VOLUME_ID);
+    return config.getStringValue(KUBERNETES_VOLUME_AWS_EBS_VOLUME_ID);
   }
 
   static String getAwsEbsFsType(Config config) {
-    return config.getStringValue(HERON_KUBERNETES_VOLUME_AWS_EBS_FS_TYPE);
+    return config.getStringValue(KUBERNETES_VOLUME_AWS_EBS_FS_TYPE);
   }
 
   static boolean hasVolume(Config config) {
@@ -160,27 +165,35 @@ public final class KubernetesContext extends Context {
   }
 
   static String getContainerVolumeName(Config config) {
-    return config.getStringValue(HERON_KUBERNETES_CONTAINER_VOLUME_MOUNT_NAME);
+    return config.getStringValue(KUBERNETES_CONTAINER_VOLUME_MOUNT_NAME);
   }
 
   static String getContainerVolumeMountPath(Config config) {
-    return config.getStringValue(HERON_KUBERNETES_CONTAINER_VOLUME_MOUNT_PATH);
+    return config.getStringValue(KUBERNETES_CONTAINER_VOLUME_MOUNT_PATH);
   }
 
   public static Map<String, String> getPodLabels(Config config) {
-    return getConfigItemsByPrefix(config, HERON_KUBERNETES_POD_LABEL);
+    return getConfigItemsByPrefix(config, KUBERNETES_POD_LABEL_PREFIX);
   }
 
   public static Map<String, String> getServiceLabels(Config config) {
-    return getConfigItemsByPrefix(config, HERON_KUBERNETES_SERVICE_LABEL);
+    return getConfigItemsByPrefix(config, KUBERNETES_SERVICE_LABEL_PREFIX);
   }
 
   public static Map<String, String> getPodAnnotations(Config config) {
-    return getConfigItemsByPrefix(config, HERON_KUBERNETES_POD_ANNOTATION);
+    return getConfigItemsByPrefix(config, KUBERNETES_POD_ANNOTATION_PREFIX);
   }
 
   public static Map<String, String> getServiceAnnotations(Config config) {
-    return getConfigItemsByPrefix(config, HERON_KUBERNETES_SERVICE_ANNOTATION);
+    return getConfigItemsByPrefix(config, KUBERNETES_SERVICE_ANNOTATION_PREFIX);
+  }
+
+  public static Map<String, String> getPodSecretsToMount(Config config) {
+    return getConfigItemsByPrefix(config, KUBERNETES_POD_SECRET_PREFIX);
+  }
+
+  public static Map<String, String> getPodSecretKeyRefs(Config config) {
+    return getConfigItemsByPrefix(config, KUBERNETES_POD_SECRET_KEY_REF_PREFIX);
   }
 
   static Set<String> getConfigKeys(Config config, String keyPrefix) {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -20,7 +20,14 @@
 package org.apache.heron.scheduler.kubernetes;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -53,7 +53,6 @@ import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1ContainerPort;
 import io.kubernetes.client.openapi.models.V1EnvVar;
-import io.kubernetes.client.openapi.models.V1EnvVarBuilder;
 import io.kubernetes.client.openapi.models.V1EnvVarSource;
 import io.kubernetes.client.openapi.models.V1LabelSelector;
 import io.kubernetes.client.openapi.models.V1ObjectFieldSelector;
@@ -61,6 +60,7 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
 import io.kubernetes.client.openapi.models.V1ResourceRequirements;
+import io.kubernetes.client.openapi.models.V1SecretKeySelector;
 import io.kubernetes.client.openapi.models.V1SecretVolumeSourceBuilder;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServiceSpec;
@@ -524,7 +524,8 @@ public class V1Controller extends KubernetesController {
         .valueFrom(new V1EnvVarSource()
             .fieldRef(new V1ObjectFieldSelector()
                 .fieldPath(KubernetesConstants.POD_NAME)));
-    container.setEnv(Arrays.asList(envVarHost, envVarPodName));
+    container.addEnvItem(envVarHost);
+    container.addEnvItem(envVarPodName);
 
     setSecretKeyRefs(container);
 
@@ -611,14 +612,12 @@ public class V1Controller extends KubernetesController {
       }
       String name = keyRefParts[0];
       String key = keyRefParts[1];
-      V1EnvVar envVar = new V1EnvVarBuilder()
-              .withName(secret.getKey())
-              .withNewValueFrom()
-                .withNewSecretKeyRef()
-                  .withKey(key)
-                  .withName(name)
-                .endSecretKeyRef()
-              .endValueFrom().build();
+      final V1EnvVar envVar = new V1EnvVar()
+              .name(secret.getKey())
+                .valueFrom(new V1EnvVarSource()
+                  .secretKeyRef(new V1SecretKeySelector()
+                          .key(key)
+                          .name(name)));
       container.addEnvItem(envVar);
     }
   }

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/VolumesTests.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/VolumesTests.java
@@ -39,8 +39,8 @@ public class VolumesTests {
   public void testHostPathVolume() {
     final String path = "/test/dir1";
     final Config config = Config.newBuilder()
-        .put(KubernetesContext.HERON_KUBERNETES_VOLUME_TYPE, "hostPath")
-        .put(KubernetesContext.HERON_KUBERNETES_VOLUME_HOSTPATH_PATH, path)
+        .put(KubernetesContext.KUBERNETES_VOLUME_TYPE, "hostPath")
+        .put(KubernetesContext.KUBERNETES_VOLUME_HOSTPATH_PATH, path)
         .build();
 
     final V1Volume volume = Volumes.get().create(config);
@@ -54,9 +54,9 @@ public class VolumesTests {
     final String path = "/test/dir1";
     final String server = "10.10.10.10";
     final Config config = Config.newBuilder()
-        .put(KubernetesContext.HERON_KUBERNETES_VOLUME_TYPE, "nfs")
-        .put(KubernetesContext.HERON_KUBERNETES_VOLUME_NFS_PATH, path)
-        .put(KubernetesContext.HERON_KUBERNETES_VOLUME_NFS_SERVER, server)
+        .put(KubernetesContext.KUBERNETES_VOLUME_TYPE, "nfs")
+        .put(KubernetesContext.KUBERNETES_VOLUME_NFS_PATH, path)
+        .put(KubernetesContext.KUBERNETES_VOLUME_NFS_SERVER, server)
         .build();
 
     final V1Volume volume = Volumes.get().create(config);
@@ -71,9 +71,9 @@ public class VolumesTests {
     final String volumeId = "aws-ebs-1";
     final String fsType = "ext4";
     final Config config = Config.newBuilder()
-        .put(KubernetesContext.HERON_KUBERNETES_VOLUME_TYPE, "awsElasticBlockStore")
-        .put(KubernetesContext.HERON_KUBERNETES_VOLUME_AWS_EBS_VOLUME_ID, volumeId)
-        .put(KubernetesContext.HERON_KUBERNETES_VOLUME_AWS_EBS_FS_TYPE, fsType)
+        .put(KubernetesContext.KUBERNETES_VOLUME_TYPE, "awsElasticBlockStore")
+        .put(KubernetesContext.KUBERNETES_VOLUME_AWS_EBS_VOLUME_ID, volumeId)
+        .put(KubernetesContext.KUBERNETES_VOLUME_AWS_EBS_FS_TYPE, fsType)
         .build();
 
     final V1Volume volume = Volumes.get().create(config);


### PR DESCRIPTION
Added support for dynamically adding Secrets as VolumeMounts and as ENV variables. The design mimics the design found in Apache Spark which is documented here: https://spark.apache.org/docs/latest/running-on-kubernetes.html#secret-management

This feature is important for loading TLS artifacts (i.e. certs, keys, certificate authority files)