### PR TITLE
Adding missing logic to Kubernetes Scheduler to properly set the Remote Debug ports

### DIFF
--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -68,7 +68,7 @@ public final class KubernetesConstants {
   public static final int CHECKPOINT_MGR_PORT = 6009;
   // port number the start with when more than one port needed for remote debugging
   public static final int JVM_REMOTE_DEBUGGER_PORT = 6010;
-  public static final String JVM_REMOTE_DEBUGGER_PORT_NAME = "remote-debugger";
+  public static final String JVM_REMOTE_DEBUGGER_PORT_NAME = "rmt-debug";
 
   public static final Map<ExecutorPort, Integer> EXECUTOR_PORTS = new HashMap<>();
   static {


### PR DESCRIPTION
The remote debug ports were being added to the Pod Spec, but the logic was never added to provide the port information to the Heron Executor which launches the Java processes.

Also there was an issue with the Kubernetes port name being larger than 15 characters. So I renamed it to fit the K8s spec.