### PR TITLE
Fix heron-downloader cannot load the jar package correctly

### DIFF
--- a/heron/downloaders/src/shell/heron-downloader.sh
+++ b/heron/downloaders/src/shell/heron-downloader.sh
@@ -16,7 +16,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-BINDIR=$(dirname "$0")
+LINK=$(readlink ${0})
+if [ -z "$LINK" ]; then
+   LINK=$0
+fi
+BINDIR=$(dirname ${LINK})
 HERON_CORE=$(dirname ${BINDIR})
 HERON_DOWNLOADER_JAR=${HERON_CORE}/lib/downloaders/heron-downloader.jar
 


### PR DESCRIPTION
1. Install heron in the linux system to the /usr/lib/heron directory
2. Create symbolic links of several executable files in heron/bin to the /usr/bin directory
3. Try to call the heron* program separately, and the heron-downloader program fails to load the jar package correctly, and other programs are normal