### PR TITLE
[HERON-3707] ConfigMap Pod Template Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ addons:
       - libcppunit-dev
       - pkg-config
       - python3-dev
-      - python3-venv
+      - python3-pip
+      - python3-setuptools
+      - python3-wheel
       - wget
       - zip
       - zlib1g-dev
@@ -34,10 +36,6 @@ before_install:
   - chmod +x bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
   - ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --user
 
-install:
-  - sudo apt-get install python3-pip python3-setuptools python3-wheel
-  - pip3 install travis-wait-improved
-
 script:
   - which gcc
   - gcc --version
@@ -47,4 +45,4 @@ script:
   - python -V
   - which python3
   - python3 -V
-  - travis-wait-improved --timeout=180m scripts/travis/ci.sh
+  - scripts/travis/ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --user
 
 install:
-  - sudo apt-get install python3-pip python3-setuptools
+  - sudo apt-get install python3-pip python3-setuptools python3-wheel
   - pip3 install travis-wait-improved
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
       - python3-pip
       - python3-setuptools
       - python3-wheel
+      - python3-venv
       - wget
       - zip
       - zlib1g-dev

--- a/deploy/kubernetes/general/apiserver.yaml
+++ b/deploy/kubernetes/general/apiserver.yaml
@@ -95,7 +95,7 @@ spec:
               -D heron.uploader.dlog.topologies.namespace.uri=distributedlog://zookeeper:2181/heron
               -D heron.statefulstorage.classname=org.apache.heron.statefulstorage.dlog.DlogStorage
               -D heron.statefulstorage.dlog.namespace.uri=distributedlog://zookeeper:2181/heron
-            # -D heron.kubernetes.pod.template.configmap.disabled=true
+              -D heron.kubernetes.pod.template.configmap.disabled=false
 
 ---
 apiVersion: v1

--- a/deploy/kubernetes/general/apiserver.yaml
+++ b/deploy/kubernetes/general/apiserver.yaml
@@ -27,7 +27,7 @@ metadata:
   namespace: default
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: heron-apiserver
@@ -95,6 +95,7 @@ spec:
               -D heron.uploader.dlog.topologies.namespace.uri=distributedlog://zookeeper:2181/heron
               -D heron.statefulstorage.classname=org.apache.heron.statefulstorage.dlog.DlogStorage
               -D heron.statefulstorage.dlog.namespace.uri=distributedlog://zookeeper:2181/heron
+            # -D heron.kubernetes.pod.template.configmap.disabled=true
 
 ---
 apiVersion: v1

--- a/deploy/kubernetes/general/apiserver.yaml
+++ b/deploy/kubernetes/general/apiserver.yaml
@@ -67,11 +67,7 @@ spec:
           operator: "Equal"
           effect: "NoExecute"
           tolerationSeconds: 10
-        - key: "node.alpha.kubernetes.io/notReady"
-          operator: "Equal"
-          effect: "NoExecute"
-          tolerationSeconds: 10
-        - key: "node.alpha.kubernetes.io/unreachable"
+        - key: "node.kubernetes.io/unreachable"
           operator: "Equal"
           effect: "NoExecute"
           tolerationSeconds: 10

--- a/deploy/kubernetes/general/tools.yaml
+++ b/deploy/kubernetes/general/tools.yaml
@@ -38,11 +38,7 @@ spec:
           operator: "Equal"
           effect: "NoExecute"
           tolerationSeconds: 10
-        - key: "node.alpha.kubernetes.io/notReady"
-          operator: "Equal"
-          effect: "NoExecute"
-          tolerationSeconds: 10
-        - key: "node.alpha.kubernetes.io/unreachable"
+        - key: "node.kubernetes.io/unreachable"
           operator: "Equal"
           effect: "NoExecute"
           tolerationSeconds: 10

--- a/deploy/kubernetes/gke/gcs-apiserver.yaml
+++ b/deploy/kubernetes/gke/gcs-apiserver.yaml
@@ -27,7 +27,7 @@ metadata:
   namespace: default
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: heron-apiserver

--- a/deploy/kubernetes/gke/gcs-apiserver.yaml
+++ b/deploy/kubernetes/gke/gcs-apiserver.yaml
@@ -67,11 +67,7 @@ spec:
           operator: "Equal"
           effect: "NoExecute"
           tolerationSeconds: 10
-        - key: "node.alpha.kubernetes.io/notReady"
-          operator: "Equal"
-          effect: "NoExecute"
-          tolerationSeconds: 10
-        - key: "node.alpha.kubernetes.io/unreachable"
+        - key: "node.kubernetes.io/unreachable"
           operator: "Equal"
           effect: "NoExecute"
           tolerationSeconds: 10

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -266,6 +266,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
 
 ---
 apiVersion: v1

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -56,11 +56,7 @@ spec:
           operator: "Equal"
           effect: "NoExecute"
           tolerationSeconds: 10
-        - key: "node.alpha.kubernetes.io/notReady"
-          operator: "Equal"
-          effect: "NoExecute"
-          tolerationSeconds: 10
-        - key: "node.alpha.kubernetes.io/unreachable"
+        - key: "node.kubernetes.io/unreachable"
           operator: "Equal"
           effect: "NoExecute"
           tolerationSeconds: 10

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -162,6 +162,7 @@ spec:
               -D heron.class.repacking.algorithm=org.apache.heron.packing.binpacking.FirstFitDecreasingPacking
               {{- end }}
               -D heron.kubernetes.resource.request.mode={{ .Values.topologyResourceRequestMode }}
+              -D heron.kubernetes.pod.template.configmap.disabled={{ .Values.disablePodTemplates }}
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-tools-config

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -58,6 +58,9 @@ uploader:
 # Packing algorithms
 packing: RoundRobin # ResourceCompliantRR, FirstFitDecreasing
 
+# Support for ConfigMap mounted PodTemplates
+disablePodTemplates: false
+
 # Number of replicas for storage bookies, memory and storage requirements
 bookieReplicas: 3
 bookieCpuMin: 100m

--- a/deploy/kubernetes/minikube/apiserver.yaml
+++ b/deploy/kubernetes/minikube/apiserver.yaml
@@ -28,7 +28,7 @@ metadata:
   namespace: default
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: heron-apiserver
@@ -82,6 +82,7 @@ spec:
               -D heron.uploader.dlog.topologies.namespace.uri=distributedlog://zookeeper:2181/heronbkdl
               -D heron.statefulstorage.classname=org.apache.heron.statefulstorage.dlog.DlogStorage
               -D heron.statefulstorage.dlog.namespace.uri=distributedlog://zookeeper:2181/heronbkdl
+            # -D heron.kubernetes.pod.template.configmap.disabled=true
 
 ---
 apiVersion: v1

--- a/deploy/kubernetes/minikube/apiserver.yaml
+++ b/deploy/kubernetes/minikube/apiserver.yaml
@@ -82,7 +82,7 @@ spec:
               -D heron.uploader.dlog.topologies.namespace.uri=distributedlog://zookeeper:2181/heronbkdl
               -D heron.statefulstorage.classname=org.apache.heron.statefulstorage.dlog.DlogStorage
               -D heron.statefulstorage.dlog.namespace.uri=distributedlog://zookeeper:2181/heronbkdl
-            # -D heron.kubernetes.pod.template.configmap.disabled=true
+              -D heron.kubernetes.pod.template.configmap.disabled=false
 
 ---
 apiVersion: v1

--- a/heron/scheduler-core/src/java/org/apache/heron/scheduler/LaunchRunner.java
+++ b/heron/scheduler-core/src/java/org/apache/heron/scheduler/LaunchRunner.java
@@ -184,7 +184,7 @@ public class LaunchRunner {
       final StringBuilder errorMessage = new StringBuilder(
           String.format("Failed to launch topology '%s'", topologyName));
       if (e.getMessage() != null) {
-        errorMessage.append(String.format("%n%s", e.getMessage()));
+        errorMessage.append("\n").append(e.getMessage());
       }
 
       try {
@@ -199,12 +199,15 @@ public class LaunchRunner {
           final String logMessage =
               String.format("Failed to remove topology '%s' from scheduler after failed submit. "
                   + "Please re-try the kill command.", topologyName);
-          errorMessage.append(String.format("%n%s", logMessage));
+          errorMessage.append("\n").append(logMessage);
           LOG.log(Level.SEVERE, logMessage);
         }
       // SUPPRESS CHECKSTYLE IllegalCatch
       } catch (Exception ignored){
         // The above call to clear the Scheduler may fail. This situation can be ignored.
+        LOG.log(Level.FINE,
+            String.format("Failure clearing failed topology `%s` from Scheduler during `submit`",
+                topologyName));
       }
 
       // Clear state from the State Manager.

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -104,8 +104,7 @@ public final class KubernetesConstants {
   static final List<String> TOLERATIONS = Collections.unmodifiableList(
       Arrays.asList(
           "node.kubernetes.io/not-ready",
-          "node.alpha.kubernetes.io/notReady",
-          "node.alpha.kubernetes.io/unreachable"
+          "node.kubernetes.io/unreachable"
       )
   );
 }

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -34,8 +34,6 @@ public final class KubernetesConstants {
 
   public static final String MEMORY = "memory";
   public static final String CPU = "cpu";
-  public static final int REQUEST_RESPONSE_WINDOW_SIZE = 10;
-  public static final int REQUEST_RESPONSE_TIMEOUT = 5;
 
   // container env constants
   public static final String ENV_HOST = "HOST";

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -34,7 +34,8 @@ public final class KubernetesConstants {
 
   public static final String MEMORY = "memory";
   public static final String CPU = "cpu";
-  public static final String KUBERNETES_ROLE_NAME = "heron-configmap-access";
+
+  public static final String EXECUTOR_NAME = "executor";
 
   // container env constants
   public static final String ENV_HOST = "HOST";

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -34,6 +34,7 @@ public final class KubernetesConstants {
 
   public static final String MEMORY = "memory";
   public static final String CPU = "cpu";
+  public static final String KUBERNETES_ROLE_NAME = "heron-kubernetes-role";
 
   // container env constants
   public static final String ENV_HOST = "HOST";

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -34,7 +34,7 @@ public final class KubernetesConstants {
 
   public static final String MEMORY = "memory";
   public static final String CPU = "cpu";
-  public static final String KUBERNETES_ROLE_NAME = "heron-kubernetes-role";
+  public static final String KUBERNETES_ROLE_NAME = "heron-configmap-access";
 
   // container env constants
   public static final String ENV_HOST = "HOST";

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -21,7 +21,6 @@ package org.apache.heron.scheduler.kubernetes;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -185,7 +184,7 @@ public final class KubernetesContext extends Context {
 
   public static boolean getPodTemplateConfigMapDisabled(Config config) {
     final String disabled = config.getStringValue(KUBERNETES_POD_TEMPLATE_CONFIGMAP_DISABLED);
-    return disabled != null && disabled.toLowerCase(Locale.ROOT).equals("true");
+    return "true".equalsIgnoreCase(disabled);
   }
 
   public static Map<String, String> getPodLabels(Config config) {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -21,6 +21,7 @@ package org.apache.heron.scheduler.kubernetes;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -82,9 +83,11 @@ public final class KubernetesContext extends Context {
   public static final String KUBERNETES_VOLUME_AWS_EBS_FS_TYPE =
       "heron.kubernetes.volume.awsElasticBlockStore.fsType";
 
-  // pod template configmap name keys (<--config-property> on cli)
+  // pod template configmap
   public static final String KUBERNETES_POD_TEMPLATE_CONFIGMAP_NAME =
       "heron.kubernetes.pod.template.configmap.name";
+  public static final String KUBERNETES_POD_TEMPLATE_CONFIGMAP_DISABLED =
+      "heron.kubernetes.pod.template.configmap.disabled";
 
   // container mount volume mount keys
   public static final String KUBERNETES_CONTAINER_VOLUME_MOUNT_NAME =
@@ -178,6 +181,11 @@ public final class KubernetesContext extends Context {
 
   public static String getPodTemplateConfigMapName(Config config) {
     return config.getStringValue(KUBERNETES_POD_TEMPLATE_CONFIGMAP_NAME);
+  }
+
+  public static boolean getPodTemplateConfigMapDisabled(Config config) {
+    final String disabled = config.getStringValue(KUBERNETES_POD_TEMPLATE_CONFIGMAP_DISABLED);
+    return disabled != null && disabled.toLowerCase(Locale.ROOT).equals("true");
   }
 
   public static Map<String, String> getPodLabels(Config config) {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesUtils.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesUtils.java
@@ -94,13 +94,13 @@ final class KubernetesUtils {
     private static final Logger LOG = Logger.getLogger(V1Controller.class.getName());
 
     /**
-     * Merge two lists by keeping all values in the "primaryList" and de-duplicating values in
-     * "secondaryList" using the "comparator".
+     * Merge two lists by keeping all values in the <code>primaryList</code> and de-duplicating values in
+     * <code>secondaryList</code> using the <code>comparator</code>.
      * @param primaryList All the values in this will be retained.
-     * @param secondaryList The values in this list will be deduplicated against "primaryList".
-     * @param comparator Used to compare keys in the TreeSet to find their insertion position.
-     * @param description Description of the list merge operation and used for error messages.
-     * @return A de-duplicated list of all the values in both input lists using the comparator.
+     * @param secondaryList The values in this list will be deduplicated against <code>primaryList</code>.
+     * @param comparator Used to compare keys in the <code>TreeSet</code> to find their insertion position.
+     * @param description Description of the list merge operation which is used for error messages.
+     * @return A de-duplicated list of all the values in both input lists using the <code>comparator</code>.
      */
     protected List<T> mergeListsDedupe(List<T> primaryList, List<T> secondaryList,
                                        Comparator<T> comparator, String description) {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesUtils.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesUtils.java
@@ -20,17 +20,22 @@
 package org.apache.heron.scheduler.kubernetes;
 
 import java.io.IOException;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.heron.common.basics.ByteAmount;
 import org.apache.heron.common.basics.SysUtils;
+import org.apache.heron.scheduler.TopologySubmissionException;
 import org.apache.heron.scheduler.utils.Runtime;
 import org.apache.heron.spi.common.Config;
 import org.apache.heron.spi.common.Context;
 
 import io.kubernetes.client.openapi.ApiException;
-
 import okhttp3.Response;
 
 final class KubernetesUtils {
@@ -83,5 +88,38 @@ final class KubernetesUtils {
   // #meaning-of-memory
   static String Megabytes(ByteAmount amount) {
     return String.format("%sMi", Long.toString(amount.asMegabytes()));
+  }
+
+  static class V1ControllerUtils<T> {
+    private static final Logger LOG = Logger.getLogger(V1Controller.class.getName());
+
+    /**
+     * Merge two lists by keeping all values in the "primaryList" and de-duplicating values in
+     * "secondaryList" using the "comparator".
+     * @param primaryList All the values in this will be retained.
+     * @param secondaryList The values in this list will be deduplicated against "primaryList".
+     * @param comparator Used to compare keys in the TreeSet to find their insertion position.
+     * @param description Description of the list merge operation and used for error messages.
+     * @return A de-duplicated list of all the values in both input lists using the comparator.
+     */
+    protected List<T> mergeListsDedupe(List<T> primaryList, List<T> secondaryList,
+                                       Comparator<T> comparator, String description) {
+      if (primaryList == null || primaryList.isEmpty()) {
+        return secondaryList;
+      }
+      if (secondaryList == null || secondaryList.isEmpty()) {
+        return primaryList;
+      }
+      try {
+        Set<T> treeSet = new TreeSet<>(comparator);
+        treeSet.addAll(primaryList);
+        treeSet.addAll(secondaryList);
+        return new LinkedList<>(treeSet);
+      } catch (NullPointerException e) {
+        final String message = String.format("Failed to merge lists for %s", description);
+        LOG.log(Level.FINE, message);
+        throw new TopologySubmissionException(message);
+      }
+    }
   }
 }

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -599,7 +599,6 @@ public class V1Controller extends KubernetesController {
     limits.put(KubernetesConstants.CPU,
             Quantity.fromString(Double.toString(roundDecimal(
                     resource.getCpu(), 3))));
-    resourceRequirements.setLimits(limits);
 
     // Set the Kubernetes container resource request.
     KubernetesContext.KubernetesResourceRequestMode requestMode =

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -92,6 +92,10 @@ public class V1Controller extends KubernetesController {
 
   V1Controller(Config configuration, Config runtimeConfiguration) {
     super(configuration, runtimeConfiguration);
+
+    LOG.log(Level.WARNING, String.format("Custom Pod Templates are %s",
+        KubernetesContext.getPodTemplateConfigMapDisabled(configuration) ? "DISABLED" : "ENABLED"));
+
     try {
       final ApiClient apiClient = io.kubernetes.client.util.Config.defaultClient();
       Configuration.setDefaultApiClient(apiClient);
@@ -669,8 +673,9 @@ public class V1Controller extends KubernetesController {
   protected V1PodTemplateSpec loadPodFromTemplate() {
     final Pair<String, String> podTemplateConfigMapName = getPodTemplateLocation();
 
-    // Default Pod Template.
-    if (podTemplateConfigMapName == null) {
+    // Default Pod Template. Check if Pod Templates are disabled.
+    if (podTemplateConfigMapName == null
+        || KubernetesContext.getPodTemplateConfigMapDisabled(super.getConfiguration())) {
       LOG.log(Level.INFO, "Configuring cluster with the Default Pod Template");
       return new V1PodTemplateSpec();
     }

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -61,6 +61,7 @@ import io.kubernetes.client.openapi.models.V1LabelSelector;
 import io.kubernetes.client.openapi.models.V1ObjectFieldSelector;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1PodTemplate;
 import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
 import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1SecretKeySelector;
@@ -659,7 +660,8 @@ public class V1Controller extends KubernetesController {
           final Map<String, String> configMapData = configMap.getData();
 
           if (configMapData != null && configMapData.containsKey(podTemplateConfigMapName)) {
-            return (V1PodTemplateSpec) Yaml.load(configMapData.get(podTemplateConfigMapName));
+            return ((V1PodTemplate) Yaml.load(configMapData.get(podTemplateConfigMapName)))
+                .getTemplate();
           }
         }
 

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -782,7 +782,10 @@ public class V1Controller extends KubernetesController {
           "Apache Heron");
       LOG.log(Level.INFO, "Configured Role-Based Access Control for K8s cluster");
     } catch (ApiException e) {
-      KubernetesUtils.logExceptionWithDetails(LOG, "Error configuring RBAC", e);
+      KubernetesUtils.logExceptionWithDetails(LOG,
+          String.format("Error configuring RBAC%nStatus code: %s%n Reason: %s%nResponse: %s%n",
+              e.getCode(), e.getResponseBody(), e.getResponseHeaders()),
+          e);
       throw new TopologySubmissionException(e.getMessage());
     }
   }

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -87,14 +87,17 @@ public class V1Controller extends KubernetesController {
 
   private static final String ENV_SHARD_ID = "SHARD_ID";
 
+  private final boolean isPodTemplateDisabled;
+
   private final AppsV1Api appsClient;
   private final CoreV1Api coreClient;
 
   V1Controller(Config configuration, Config runtimeConfiguration) {
     super(configuration, runtimeConfiguration);
 
+    isPodTemplateDisabled = KubernetesContext.getPodTemplateConfigMapDisabled(configuration);
     LOG.log(Level.WARNING, String.format("Custom Pod Templates are %s",
-        KubernetesContext.getPodTemplateConfigMapDisabled(configuration) ? "DISABLED" : "ENABLED"));
+        isPodTemplateDisabled ? "DISABLED" : "ENABLED"));
 
     try {
       final ApiClient apiClient = io.kubernetes.client.util.Config.defaultClient();
@@ -674,8 +677,7 @@ public class V1Controller extends KubernetesController {
     final Pair<String, String> podTemplateConfigMapName = getPodTemplateLocation();
 
     // Default Pod Template. Check if Pod Templates are disabled.
-    if (podTemplateConfigMapName == null
-        || KubernetesContext.getPodTemplateConfigMapDisabled(super.getConfiguration())) {
+    if (podTemplateConfigMapName == null || isPodTemplateDisabled) {
       LOG.log(Level.INFO, "Configuring cluster with the Default Pod Template");
       return new V1PodTemplateSpec();
     }

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -23,13 +23,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -569,14 +570,12 @@ public class V1Controller extends KubernetesController {
                 .fieldPath(KubernetesConstants.POD_NAME)));
 
     if (container.getEnv() != null) {
-      Set<V1EnvVar> envVars = new HashSet<>();
-      envVars.add(envVarHost);
-      envVars.add(envVarPodName);
+      Set<V1EnvVar> envVars = new TreeSet<>(Comparator.comparing(V1EnvVar::getName));
+      envVars.addAll(Arrays.asList(envVarHost, envVarPodName));
       envVars.addAll(container.getEnv());
       container.setEnv(new LinkedList<>(envVars));
     } else {
-      container.addEnvItem(envVarHost);
-      container.addEnvItem(envVarPodName);
+      container.setEnv(Arrays.asList(envVarHost, envVarPodName));
     }
 
     setSecretKeyRefs(container);

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -658,8 +658,13 @@ public class V1Controller extends KubernetesController {
           }
 
           final Map<String, String> configMapData = configMap.getData();
-
           if (configMapData != null && configMapData.containsKey(podTemplateConfigMapName)) {
+
+            final String podTemplateStr = configMapData.get(podTemplateConfigMapName);
+            if (podTemplateStr == null || podTemplateStr.isEmpty()) {
+              throw new IllegalArgumentException("Pod Template is empty");
+            }
+
             return ((V1PodTemplate) Yaml.load(configMapData.get(podTemplateConfigMapName)))
                 .getTemplate();
           }
@@ -672,7 +677,7 @@ public class V1Controller extends KubernetesController {
         KubernetesUtils.logExceptionWithDetails(LOG, "Error retrieving Pod Template "
             + podTemplateConfigMapName, e);
         throw new TopologySubmissionException(e.getMessage());
-      } catch (IOException | ClassCastException e) {
+      } catch (IOException | ClassCastException | IllegalArgumentException e) {
         final String message = "Error parsing Pod Template " + podTemplateConfigMapName;
         KubernetesUtils.logExceptionWithDetails(LOG, message, e);
         throw new TopologySubmissionException(message);

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -551,7 +551,7 @@ public class V1Controller extends KubernetesController {
       container.setImagePullPolicy(KubernetesContext.getKubernetesImagePullPolicy(configuration));
     }
 
-    // Setup the environment variables for the container. Heron overwrites provided values.
+    // Setup the environment variables for the container. Heron defaults take precedence.
     final V1EnvVar envVarHost = new V1EnvVar();
     envVarHost.name(KubernetesConstants.ENV_HOST)
         .valueFrom(new V1EnvVarSource()
@@ -583,8 +583,11 @@ public class V1Controller extends KubernetesController {
     }
     final V1ResourceRequirements resourceRequirements = container.getResources();
 
-    // Set the Kubernetes container resource limit
-    final Map<String, Quantity> limits = new HashMap<>();
+    // Set the Kubernetes container resource limit. Heron defaults take precedence.
+    if (resourceRequirements.getLimits() == null) {
+      resourceRequirements.setLimits(new HashMap<>());
+    }
+    final Map<String, Quantity> limits = resourceRequirements.getLimits();
     limits.put(KubernetesConstants.MEMORY,
             Quantity.fromString(KubernetesUtils.Megabytes(
                     resource.getRam())));

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -710,10 +710,14 @@ public class V1Controller extends KubernetesController {
   protected V1PodTemplateSpec loadPodFromTemplate() {
     final Pair<String, String> podTemplateConfigMapName = getPodTemplateLocation();
 
-    // Default Pod Template. Check if Pod Templates are disabled.
-    if (podTemplateConfigMapName == null || isPodTemplateDisabled) {
+    // Default Pod Template.
+    if (podTemplateConfigMapName == null) {
       LOG.log(Level.INFO, "Configuring cluster with the Default Pod Template");
       return new V1PodTemplateSpec();
+    }
+
+    if (isPodTemplateDisabled) {
+      throw new TopologySubmissionException("Custom executor Pod Templates are disabled");
     }
 
     final String configMapName = podTemplateConfigMapName.first;

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -659,8 +659,9 @@ public class V1Controller extends KubernetesController {
 
       return new Pair<>(configMapName, podTemplateName);
     } catch (IndexOutOfBoundsException | IllegalArgumentException e) {
-      KubernetesUtils.logExceptionWithDetails(LOG, "Invalid ConfigMap and/or Pod Template name", e);
-      throw new TopologySubmissionException(e.getMessage());
+      final String message = "Invalid ConfigMap and/or Pod Template name";
+      KubernetesUtils.logExceptionWithDetails(LOG, message, e);
+      throw new TopologySubmissionException(message);
     }
   }
 

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -652,6 +652,10 @@ public class V1Controller extends KubernetesController {
 
         // Probe ConfigMaps for the specified Pod Template name.
         for (V1ConfigMap configMap : configMapLists) {
+          if (configMap == null) {
+            continue;
+          }
+
           final Map<String, String> configMapData = configMap.getData();
 
           if (configMapData != null && configMapData.containsKey(podTemplateConfigMapName)) {
@@ -666,10 +670,10 @@ public class V1Controller extends KubernetesController {
         KubernetesUtils.logExceptionWithDetails(LOG, "Error retrieving Pod Template "
             + podTemplateConfigMapName, e);
         throw new TopologySubmissionException(e.getMessage());
-      } catch (IOException e) {
-        KubernetesUtils.logExceptionWithDetails(LOG, "Error parsing Pod Template "
-            + podTemplateConfigMapName, e);
-        throw new TopologySubmissionException(e.getMessage());
+      } catch (IOException | ClassCastException e) {
+        final String message = "Error parsing Pod Template " + podTemplateConfigMapName;
+        KubernetesUtils.logExceptionWithDetails(LOG, message, e);
+        throw new TopologySubmissionException(message);
       }
     }
 
@@ -677,7 +681,7 @@ public class V1Controller extends KubernetesController {
     return new V1PodTemplateSpec();
   }
 
-  private List<V1ConfigMap> getConfigMaps() {
+  protected List<V1ConfigMap> getConfigMaps() {
     try {
       V1ConfigMapList configMapList = coreClient
           .listNamespacedConfigMap(

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -761,8 +761,12 @@ public class V1Controller extends KubernetesController {
     bearerToken.setApiKey(apiKey);
 
     // Generate role.
-    V1Role body = new V1Role();
-    body.setMetadata(new V1ObjectMeta().name(KubernetesConstants.KUBERNETES_ROLE_NAME));
+    V1Role body = new V1Role()
+        .apiVersion("rbac.authorization.k8s.io/v1")
+        .kind("Role");
+    body.setMetadata(new V1ObjectMeta()
+        .name(KubernetesConstants.KUBERNETES_ROLE_NAME)
+        .namespace(getNamespace()));
 
     V1PolicyRule policyRule = new V1PolicyRule();
     policyRule.setApiGroups(Collections.singletonList(""));
@@ -777,13 +781,13 @@ public class V1Controller extends KubernetesController {
       apiInstance.createNamespacedRole(
           getNamespace(),
           body,
-          null,
+          "pretty",
           null,
           "Apache Heron");
       LOG.log(Level.INFO, "Configured Role-Based Access Control for K8s cluster");
     } catch (ApiException e) {
       KubernetesUtils.logExceptionWithDetails(LOG,
-          String.format("Error configuring RBAC%nStatus code: %s%n Reason: %s%nResponse: %s%n",
+          String.format("Error configuring RBAC%nStatus code: %s%nReason: %s%nResponse: %s",
               e.getCode(), e.getResponseBody(), e.getResponseHeaders()),
           e);
       throw new TopologySubmissionException(e.getMessage());

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -668,7 +668,7 @@ public class V1Controller extends KubernetesController {
     }
   }
 
-  private V1PodTemplateSpec loadPodFromTemplate() {
+  protected V1PodTemplateSpec loadPodFromTemplate() {
     final Pair<String, String> podTemplateConfigMapName = getPodTemplateLocation();
 
     // Default Pod Template.

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -697,25 +697,21 @@ public class V1Controller extends KubernetesController {
 
         final Map<String, String> configMapData = configMap.getData();
         if (configMapData != null && configMapData.containsKey(podTemplateName)) {
-
-          final String podTemplateStr = configMapData.get(podTemplateName);
-          if (podTemplateStr == null || podTemplateStr.isEmpty()) {
-            throw new IllegalArgumentException("Pod Template is empty");
-          }
-          V1PodTemplateSpec podTemplate = ((V1PodTemplate) Yaml.load(podTemplateStr)).getTemplate();
+          // NullPointerException when Pod Template is empty.
+          V1PodTemplateSpec podTemplate = ((V1PodTemplate)
+              Yaml.load(configMapData.get(podTemplateName))).getTemplate();
           LOG.log(Level.INFO, String.format("Configuring cluster with the %s.%s Pod Template",
               configMapName, podTemplateName));
           return podTemplate;
         }
       }
-
       // Failure to locate Pod Template with provided name.
       throw new ApiException(String.format("Failed to locate Pod Template %s in ConfigMap %s",
           podTemplateName, configMapName));
     } catch (ApiException e) {
       KubernetesUtils.logExceptionWithDetails(LOG, e.getMessage(), e);
       throw new TopologySubmissionException(e.getMessage());
-    } catch (IOException | ClassCastException | IllegalArgumentException e) {
+    } catch (IOException | ClassCastException | NullPointerException e) {
       final String message = String.format("Error parsing Pod Template %s in ConfigMap %s",
           podTemplateName, configMapName);
       KubernetesUtils.logExceptionWithDetails(LOG, message, e);

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -574,28 +574,10 @@ public class V1Controller extends KubernetesController {
       container.setImagePullPolicy(KubernetesContext.getKubernetesImagePullPolicy(configuration));
     }
 
-    // Configure environment vars. Deduplicate on var name with Heron defaults take precedence.
-    final V1EnvVar envVarHost = new V1EnvVar();
-    envVarHost.name(KubernetesConstants.ENV_HOST)
-        .valueFrom(new V1EnvVarSource()
-            .fieldRef(new V1ObjectFieldSelector()
-                .fieldPath(KubernetesConstants.POD_IP)));
+    // Configure environment variables.
+    configureContainerEnvVars(container);
 
-    final V1EnvVar envVarPodName = new V1EnvVar();
-    envVarPodName.name(KubernetesConstants.ENV_POD_NAME)
-        .valueFrom(new V1EnvVarSource()
-            .fieldRef(new V1ObjectFieldSelector()
-                .fieldPath(KubernetesConstants.POD_NAME)));
-
-    if (container.getEnv() != null) {
-      Set<V1EnvVar> envVars = new TreeSet<>(Comparator.comparing(V1EnvVar::getName));
-      envVars.addAll(Arrays.asList(envVarHost, envVarPodName));
-      envVars.addAll(container.getEnv());
-      container.setEnv(new LinkedList<>(envVars));
-    } else {
-      container.setEnv(Arrays.asList(envVarHost, envVarPodName));
-    }
-
+    // Set secret keys.
     setSecretKeyRefs(container);
 
     // Set container resources
@@ -639,6 +621,31 @@ public class V1Controller extends KubernetesController {
 
     // setup volume mounts
     mountVolumeIfPresent(container);
+  }
+
+  @VisibleForTesting
+  protected void configureContainerEnvVars(final V1Container container) {
+    final V1EnvVar envVarHost = new V1EnvVar();
+    envVarHost.name(KubernetesConstants.ENV_HOST)
+        .valueFrom(new V1EnvVarSource()
+            .fieldRef(new V1ObjectFieldSelector()
+                .fieldPath(KubernetesConstants.POD_IP)));
+
+    final V1EnvVar envVarPodName = new V1EnvVar();
+    envVarPodName.name(KubernetesConstants.ENV_POD_NAME)
+        .valueFrom(new V1EnvVarSource()
+            .fieldRef(new V1ObjectFieldSelector()
+                .fieldPath(KubernetesConstants.POD_NAME)));
+
+    // Deduplicate on var name with Heron defaults take precedence.
+    if (container.getEnv() != null) {
+      Set<V1EnvVar> envVars = new TreeSet<>(Comparator.comparing(V1EnvVar::getName));
+      envVars.addAll(Arrays.asList(envVarHost, envVarPodName));
+      envVars.addAll(container.getEnv());
+      container.setEnv(new LinkedList<>(envVars));
+    } else {
+      container.setEnv(Arrays.asList(envVarHost, envVarPodName));
+    }
   }
 
   @VisibleForTesting

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.heron.api.utils.TopologyUtils;
+import org.apache.heron.common.basics.Pair;
 import org.apache.heron.scheduler.TopologyRuntimeManagementException;
 import org.apache.heron.scheduler.TopologySubmissionException;
 import org.apache.heron.scheduler.utils.Runtime;
@@ -639,9 +640,33 @@ public class V1Controller extends KubernetesController {
     return Math.round(value * scale) / scale;
   }
 
-  private V1PodTemplateSpec loadPodFromTemplate() {
+  protected Pair<String, String> getPodTemplateLocation() {
     final String podTemplateConfigMapName = KubernetesContext
         .getPodTemplateConfigMapName(super.getConfiguration());
+
+    if (podTemplateConfigMapName == null) {
+      return null;
+    }
+
+    try {
+      final int splitPoint = podTemplateConfigMapName.indexOf(".");
+      final String configMapName = podTemplateConfigMapName.substring(0, splitPoint);
+      final String podTemplateName = podTemplateConfigMapName.substring(splitPoint + 1);
+
+      if (configMapName.isEmpty() || podTemplateName.isEmpty()) {
+        throw new IllegalArgumentException("Empty ConfigMap or Pod Template name");
+      }
+
+      return new Pair<>(configMapName, podTemplateName);
+    } catch (NullPointerException | IllegalArgumentException e) {
+      KubernetesUtils.logExceptionWithDetails(LOG, "Invalid ConfigMap/Pod Template "
+          + "name", e);
+      throw new TopologySubmissionException(e.getMessage());
+    }
+  }
+
+  private V1PodTemplateSpec loadPodFromTemplate() {
+    final Pair<String, String> podTemplateConfigMapName = getPodTemplateLocation();
 
     // Default Pod Template.
     if (podTemplateConfigMapName == null) {
@@ -655,22 +680,26 @@ public class V1Controller extends KubernetesController {
         throw new ApiException("No ConfigMaps returned by K8s client");
       }
 
+      final String configMapName = podTemplateConfigMapName.first;
+      final String podTemplateName = podTemplateConfigMapName.second;
+
       // Probe ConfigMaps for the specified Pod Template name.
       for (V1ConfigMap configMap : configMapLists) {
-        if (configMap == null) {
+        // kubectl will set the name filed in metadata automatically for ConfigMaps using the
+        // parameters on the command line. Hence, name field in the metadata cannot be null.
+        if (configMap == null || !configMap.getMetadata().getName().equals(configMapName)) {
           continue;
         }
 
         final Map<String, String> configMapData = configMap.getData();
-        if (configMapData != null && configMapData.containsKey(podTemplateConfigMapName)) {
+        if (configMapData != null && configMapData.containsKey(podTemplateName)) {
 
-          final String podTemplateStr = configMapData.get(podTemplateConfigMapName);
+          final String podTemplateStr = configMapData.get(podTemplateName);
           if (podTemplateStr == null || podTemplateStr.isEmpty()) {
             throw new IllegalArgumentException("Pod Template is empty");
           }
 
-          return ((V1PodTemplate) Yaml.load(configMapData.get(podTemplateConfigMapName)))
-              .getTemplate();
+          return ((V1PodTemplate) Yaml.load(podTemplateStr)).getTemplate();
         }
       }
 

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -602,17 +602,21 @@ public class V1Controller extends KubernetesController {
     }
     final V1ResourceRequirements resourceRequirements = container.getResources();
 
-    // Configure resource limits. Deduplicate on limit name with Heron defaults taking precedence.
+    // Configure resource limits. Deduplicate on limit name with user values taking precedence.
     if (resourceRequirements.getLimits() == null) {
       resourceRequirements.setLimits(new HashMap<>());
     }
     final Map<String, Quantity> limits = resourceRequirements.getLimits();
-    limits.put(KubernetesConstants.MEMORY,
-            Quantity.fromString(KubernetesUtils.Megabytes(
-                    resource.getRam())));
-    limits.put(KubernetesConstants.CPU,
-            Quantity.fromString(Double.toString(roundDecimal(
-                    resource.getCpu(), 3))));
+    if (!limits.containsKey(KubernetesConstants.MEMORY)) {
+      limits.put(KubernetesConstants.MEMORY,
+          Quantity.fromString(KubernetesUtils.Megabytes(
+              resource.getRam())));
+    }
+    if (!limits.containsKey(KubernetesConstants.CPU)) {
+      limits.put(KubernetesConstants.CPU,
+          Quantity.fromString(Double.toString(roundDecimal(
+              resource.getCpu(), 3))));
+    }
 
     // Set the Kubernetes container resource request.
     KubernetesContext.KubernetesResourceRequestMode requestMode =

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -664,11 +664,17 @@ public class V1Controller extends KubernetesController {
 
       // Merge volume mounts. Deduplicate using mount's name with Heron defaults taking precedence.
       if (container.getVolumeMounts() != null) {
-        Set<V1VolumeMount> volumeMountSet = new TreeSet<>(
-            Comparator.comparing(V1VolumeMount::getName));
-        volumeMountSet.add(mount);
-        volumeMountSet.addAll(container.getVolumeMounts());
-        container.volumeMounts(new LinkedList<>(volumeMountSet));
+        try {
+          Set<V1VolumeMount> volumeMountSet = new TreeSet<>(
+              Comparator.comparing(V1VolumeMount::getName));
+          volumeMountSet.add(mount);
+          volumeMountSet.addAll(container.getVolumeMounts());
+          container.volumeMounts(new LinkedList<>(volumeMountSet));
+        } catch (NullPointerException e) {
+          final String message = "Executor Pod Template is missing a <Volume Mount> name";
+          LOG.log(Level.INFO, message);
+          throw new TopologySubmissionException(message);
+        }
       } else {
         container.setVolumeMounts(Collections.singletonList(mount));
       }

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -612,16 +612,12 @@ public class V1Controller extends KubernetesController {
       resourceRequirements.setLimits(new HashMap<>());
     }
     final Map<String, Quantity> limits = resourceRequirements.getLimits();
-    if (!limits.containsKey(KubernetesConstants.MEMORY)) {
-      limits.put(KubernetesConstants.MEMORY,
-          Quantity.fromString(KubernetesUtils.Megabytes(
-              resource.getRam())));
-    }
-    if (!limits.containsKey(KubernetesConstants.CPU)) {
-      limits.put(KubernetesConstants.CPU,
-          Quantity.fromString(Double.toString(roundDecimal(
-              resource.getCpu(), 3))));
-    }
+    limits.put(KubernetesConstants.MEMORY,
+        Quantity.fromString(KubernetesUtils.Megabytes(
+            resource.getRam())));
+    limits.put(KubernetesConstants.CPU,
+        Quantity.fromString(Double.toString(roundDecimal(
+            resource.getCpu(), 3))));
 
     // Set the Kubernetes container resource request.
     KubernetesContext.KubernetesResourceRequestMode requestMode =

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -398,7 +398,7 @@ public class V1Controller extends KubernetesController {
     podTemplateSpec.setMetadata(templateMetaData);
 
     final List<String> command = getExecutorCommand("$" + ENV_SHARD_ID, numberOfInstances);
-    podTemplateSpec.spec(getPodSpec(command, containerResource, numberOfInstances));
+    finalizePodSpec(podTemplateSpec, command, containerResource, numberOfInstances);
 
     statefulSetSpec.setTemplate(podTemplateSpec);
 
@@ -445,9 +445,12 @@ public class V1Controller extends KubernetesController {
     return KubernetesContext.getServiceLabels(getConfiguration());
   }
 
-  private V1PodSpec getPodSpec(List<String> executorCommand, Resource resource,
-      int numberOfInstances) {
-    final V1PodSpec podSpec = new V1PodSpec();
+  private void finalizePodSpec(V1PodTemplateSpec podTemplateSpec, List<String> executorCommand,
+                               Resource resource, int numberOfInstances) {
+    if (podTemplateSpec.getSpec() == null) {
+      podTemplateSpec.spec(new V1PodSpec());
+    }
+    final V1PodSpec podSpec = podTemplateSpec.getSpec();
 
     // set the termination period to 0 so pods can be deleted quickly
     podSpec.setTerminationGracePeriodSeconds(0L);
@@ -456,14 +459,12 @@ public class V1Controller extends KubernetesController {
     // https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#taint-based-evictions
     podSpec.setTolerations(getTolerations());
 
-    podSpec.containers(Collections.singletonList(
+    podSpec.setContainers(Collections.singletonList(
         getContainer(executorCommand, resource, numberOfInstances)));
 
     addVolumesIfPresent(podSpec);
 
     mountSecretsAsVolumes(podSpec);
-
-    return podSpec;
   }
 
   private List<V1Toleration> getTolerations() {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -693,16 +693,16 @@ public class V1Controller extends KubernetesController {
       V1ConfigMapList configMapList = coreClient
           .listNamespacedConfigMap(
               KubernetesConstants.DEFAULT_NAMESPACE,
-              "false",
-              false,
               null,
               null,
               null,
-              KubernetesConstants.REQUEST_RESPONSE_WINDOW_SIZE,
               null,
               null,
-              KubernetesConstants.REQUEST_RESPONSE_TIMEOUT,
-              false);
+              null,
+              null,
+              null,
+              null,
+              null);
 
       if (configMapList == null) {
         throw new ApiException("No ConfigMaps returned by K8s client");

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -454,8 +454,10 @@ public class V1Controller extends KubernetesController {
     return KubernetesContext.getServiceLabels(getConfiguration());
   }
 
-  private void finalizePodSpec(V1PodTemplateSpec podTemplateSpec, List<String> executorCommand,
-                               Resource resource, int numberOfInstances) {
+  private void finalizePodSpec(final V1PodTemplateSpec podTemplateSpec,
+                               List<String> executorCommand,
+                               Resource resource,
+                               int numberOfInstances) {
     if (podTemplateSpec.getSpec() == null) {
       podTemplateSpec.spec(new V1PodSpec());
     }
@@ -556,7 +558,7 @@ public class V1Controller extends KubernetesController {
       container.setImagePullPolicy(KubernetesContext.getKubernetesImagePullPolicy(configuration));
     }
 
-    // Setup the environment variables for the container. Heron defaults take precedence.
+    // Configure environment vars. Deduplicate on var name with Heron defaults take precedence.
     final V1EnvVar envVarHost = new V1EnvVar();
     envVarHost.name(KubernetesConstants.ENV_HOST)
         .valueFrom(new V1EnvVarSource()
@@ -586,7 +588,7 @@ public class V1Controller extends KubernetesController {
     }
     final V1ResourceRequirements resourceRequirements = container.getResources();
 
-    // Set the Kubernetes container resource limit. Heron defaults take precedence.
+    // Configure resource limits. Deduplicate on limit name with Heron defaults taking precedence.
     if (resourceRequirements.getLimits() == null) {
       resourceRequirements.setLimits(new HashMap<>());
     }
@@ -610,7 +612,7 @@ public class V1Controller extends KubernetesController {
     }
     container.setResources(resourceRequirements);
 
-    // Set container ports. Deduplicate ports with Heron defaults take precedence.
+    // Set container ports. Deduplicate using port number with Heron defaults taking precedence.
     final boolean debuggingEnabled =
         TopologyUtils.getTopologyRemoteDebuggingEnabled(
             Runtime.topology(getRuntimeConfiguration()));
@@ -660,7 +662,7 @@ public class V1Controller extends KubernetesController {
               .name(KubernetesContext.getContainerVolumeName(config))
               .mountPath(KubernetesContext.getContainerVolumeMountPath(config));
 
-      // Merge volume mounts. Deduplicate using mount's name with Heron defaults take precedence.
+      // Merge volume mounts. Deduplicate using mount's name with Heron defaults taking precedence.
       if (container.getVolumeMounts() != null) {
         Set<V1VolumeMount> volumeMountSet = new TreeSet<>(
             Comparator.comparing(V1VolumeMount::getName));
@@ -703,7 +705,7 @@ public class V1Controller extends KubernetesController {
 
   protected Pair<String, String> getPodTemplateLocation() {
     final String podTemplateConfigMapName = KubernetesContext
-        .getPodTemplateConfigMapName(super.getConfiguration());
+        .getPodTemplateConfigMapName(getConfiguration());
 
     if (podTemplateConfigMapName == null) {
       return null;

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -660,7 +660,7 @@ public class V1Controller extends KubernetesController {
             .getItems();
 
         if (configMapList == null) {
-          throw new ApiException("No ConfigMaps set");
+          throw new ApiException("No ConfigMaps set but Pod Template name supplied");
         }
 
         // Probe ConfigMaps for the specified Pod Template name.

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -641,8 +641,9 @@ public class V1Controller extends KubernetesController {
     mountVolumeIfPresent(container);
   }
 
-  private void configureContainerPorts(boolean remoteDebugEnabled, int numberOfInstances,
-                                       final V1Container container) {
+  @VisibleForTesting
+  protected void configureContainerPorts(boolean remoteDebugEnabled, int numberOfInstances,
+                                         final V1Container container) {
     List<V1ContainerPort> ports = new ArrayList<>();
     KubernetesConstants.EXECUTOR_PORTS.forEach((p, v) -> {
       final V1ContainerPort port = new V1ContainerPort();

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -66,9 +66,9 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodTemplate;
 import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
-import io.kubernetes.client.openapi.models.V1PolicyRule;
 import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1Role;
+import io.kubernetes.client.openapi.models.V1RoleBuilder;
 import io.kubernetes.client.openapi.models.V1SecretKeySelector;
 import io.kubernetes.client.openapi.models.V1SecretVolumeSourceBuilder;
 import io.kubernetes.client.openapi.models.V1Service;
@@ -757,19 +757,19 @@ public class V1Controller extends KubernetesController {
     bearerToken.setApiKey(apiKey);
 
     // Generate role.
-    V1Role body = new V1Role()
-        .apiVersion("rbac.authorization.k8s.io/v1")
-        .kind("Role");
-    body.setMetadata(new V1ObjectMeta()
-        .name(KubernetesConstants.KUBERNETES_ROLE_NAME)
-        .namespace(getNamespace()));
-
-    V1PolicyRule policyRule = new V1PolicyRule();
-    policyRule.setApiGroups(Collections.singletonList(""));
-    policyRule.setResources(Collections.singletonList("configmaps"));
-    policyRule.setVerbs(Arrays.asList("get", "watch", "list"));
-
-    body.setRules(Collections.singletonList(policyRule));
+    V1Role body = new V1RoleBuilder()
+        .withApiVersion("rbac.authorization.k8s.io/v1")
+        .withKind("Role")
+        .withNewMetadata()
+          .withName(KubernetesConstants.KUBERNETES_ROLE_NAME)
+          .withNamespace(getNamespace())
+        .endMetadata()
+        .addNewRule()
+          .addAllToApiGroups(Collections.singletonList(""))
+          .addAllToResources(Collections.singletonList("configmaps"))
+          .addAllToVerbs(Arrays.asList("get", "watch", "list"))
+        .endRule()
+        .build();
 
     // Submit role to K8s cluster.
     RbacAuthorizationV1Api apiInstance = new RbacAuthorizationV1Api(defaultAPIClient);

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -36,6 +36,8 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.heron.api.utils.TopologyUtils;
 import org.apache.heron.common.basics.Pair;
 import org.apache.heron.scheduler.TopologyRuntimeManagementException;
@@ -407,7 +409,7 @@ public class V1Controller extends KubernetesController {
     podTemplateSpec.setMetadata(templateMetaData);
 
     final List<String> command = getExecutorCommand("$" + ENV_SHARD_ID, numberOfInstances);
-    finalizePodSpec(podTemplateSpec, command, containerResource, numberOfInstances);
+    configurePodSpec(podTemplateSpec, command, containerResource, numberOfInstances);
 
     statefulSetSpec.setTemplate(podTemplateSpec);
 
@@ -454,10 +456,10 @@ public class V1Controller extends KubernetesController {
     return KubernetesContext.getServiceLabels(getConfiguration());
   }
 
-  private void finalizePodSpec(final V1PodTemplateSpec podTemplateSpec,
-                               List<String> executorCommand,
-                               Resource resource,
-                               int numberOfInstances) {
+  private void configurePodSpec(final V1PodTemplateSpec podTemplateSpec,
+                                List<String> executorCommand,
+                                Resource resource,
+                                int numberOfInstances) {
     if (podTemplateSpec.getSpec() == null) {
       podTemplateSpec.spec(new V1PodSpec());
     }
@@ -559,7 +561,7 @@ public class V1Controller extends KubernetesController {
   }
 
   private void configureExecutorContainer(List<String> executorCommand, Resource resource,
-      int numberOfInstances, final V1Container container) {
+                                          int numberOfInstances, final V1Container container) {
     final Config configuration = getConfiguration();
 
     // Set up the container images.
@@ -733,6 +735,7 @@ public class V1Controller extends KubernetesController {
     return Math.round(value * scale) / scale;
   }
 
+  @VisibleForTesting
   protected Pair<String, String> getPodTemplateLocation() {
     final String podTemplateConfigMapName = KubernetesContext
         .getPodTemplateConfigMapName(getConfiguration());
@@ -758,6 +761,7 @@ public class V1Controller extends KubernetesController {
     }
   }
 
+  @VisibleForTesting
   protected V1PodTemplateSpec loadPodFromTemplate() {
     final Pair<String, String> podTemplateConfigMapName = getPodTemplateLocation();
 
@@ -813,6 +817,7 @@ public class V1Controller extends KubernetesController {
     }
   }
 
+  @VisibleForTesting
   protected List<V1ConfigMap> getConfigMaps() {
     try {
       V1ConfigMapList configMapList = coreClient

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -472,14 +472,18 @@ public class V1Controller extends KubernetesController {
     configureTolerations(podSpec);
 
     // Get <executor> container and discard all others.
+    final String executorName = KubernetesConstants.EXECUTOR_NAME;
     V1Container executorContainer = null;
     List<V1Container> containers = podSpec.getContainers();
     if (containers != null) {
       for (V1Container container : containers) {
         final String name = container.getName();
-        if (name != null && name.equals(KubernetesConstants.EXECUTOR_NAME)) {
+        if (name != null && name.equals(executorName)) {
+          if (executorContainer != null) {
+            throw new TopologySubmissionException(
+                String.format("Multiple configurations found for %s container", executorName));
+          }
           executorContainer = container;
-          break;
         }
       }
     } else {
@@ -487,7 +491,7 @@ public class V1Controller extends KubernetesController {
     }
 
     if (executorContainer == null) {
-      executorContainer = new V1Container().name(KubernetesConstants.EXECUTOR_NAME);
+      executorContainer = new V1Container().name(executorName);
       containers.add(executorContainer);
     }
 

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -840,7 +840,7 @@ public class V1Controller extends KubernetesController {
     } catch (ApiException e) {
       final String message = "Error retrieving ConfigMaps";
       KubernetesUtils.logExceptionWithDetails(LOG, message, e);
-      throw new TopologySubmissionException(String.format("%s:%n%s", message, e.getMessage()));
+      throw new TopologySubmissionException(String.format("%s: %s", message, e.getMessage()));
     }
   }
 }

--- a/heron/schedulers/tests/java/BUILD
+++ b/heron/schedulers/tests/java/BUILD
@@ -206,6 +206,7 @@ java_tests(
         "org.apache.heron.scheduler.kubernetes.VolumesTests",
         "org.apache.heron.scheduler.kubernetes.KubernetesContextTest",
         "org.apache.heron.scheduler.kubernetes.V1ControllerTest",
+        "org.apache.heron.scheduler.kubernetes.KubernetesUtilsTest",
     ],
     runtime_deps = [":kubernetes-tests"],
 )

--- a/heron/schedulers/tests/java/BUILD
+++ b/heron/schedulers/tests/java/BUILD
@@ -192,7 +192,9 @@ java_tests(
 java_library(
     name = "kubernetes-tests",
     srcs = glob(["**/kubernetes/*.java"]),
-    deps = scheduler_deps_files + kubernetes_deps_files,
+    deps = scheduler_deps_files + kubernetes_deps_files + [
+        "@maven//:org_apache_commons_commons_collections4",
+    ],
 )
 
 java_tests(

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
@@ -36,12 +36,27 @@ public class KubernetesContextTest {
       .build();
 
   @Test
-  public void testPodTemplateConfigMapContext() {
+  public void testPodTemplateConfigMapName() {
     Assert.assertEquals(KubernetesContext.KUBERNETES_POD_TEMPLATE_CONFIGMAP_NAME,
         KUBERNETES_POD_TEMPLATE_CONFIGMAP_NAME);
     Assert.assertEquals(
         KubernetesContext.getPodTemplateConfigMapName(configWithPodTemplateConfigMap),
         POD_TEMPLATE_CONFIGMAP_NAME);
     Assert.assertNull(KubernetesContext.getPodTemplateConfigMapName(config));
+  }
+
+  @Test
+  public void testPodTemplateConfigMapDisabled() {
+    Assert.assertFalse(KubernetesContext.getPodTemplateConfigMapDisabled(config));
+    Assert.assertFalse(KubernetesContext
+        .getPodTemplateConfigMapDisabled(configWithPodTemplateConfigMap));
+
+    final Config configWithPodTemplateConfigMapOff = Config.newBuilder()
+        .put(KubernetesContext.KUBERNETES_POD_TEMPLATE_CONFIGMAP_NAME,
+            POD_TEMPLATE_CONFIGMAP_NAME)
+        .put(KubernetesContext.KUBERNETES_POD_TEMPLATE_CONFIGMAP_DISABLED, "TRUE")
+        .build();
+    Assert.assertTrue(KubernetesContext
+        .getPodTemplateConfigMapDisabled(configWithPodTemplateConfigMapOff));
   }
 }

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesUtilsTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesUtilsTest.java
@@ -103,9 +103,7 @@ public class KubernetesUtilsTest {
     Assert.assertTrue("<primaryList> and <secondaryList> merged and deduplicated",
         expectedEnvVars.containsAll(
             v1ControllerUtils.mergeListsDedupe(heronEnvVars, inputEnvVars,
-                Comparator.comparing(V1EnvVar::getName), description)
-        )
-    );
+                Comparator.comparing(V1EnvVar::getName), description)));
 
     // Expect thrown error.
     String errorMessage = "";

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesUtilsTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesUtilsTest.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.heron.scheduler.kubernetes;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.apache.heron.scheduler.TopologySubmissionException;
+
+import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1EnvVarSource;
+import io.kubernetes.client.openapi.models.V1ObjectFieldSelector;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KubernetesUtilsTest {
+
+  @Test
+  public void testMergeListsDedupe() {
+    final String description = "Pod Template Environment Variables";
+    final List<V1EnvVar> heronEnvVars =
+        Collections.unmodifiableList(V1Controller.getExecutorEnvVars());
+    final V1EnvVar additionEnvVar = new V1EnvVar()
+        .name("env-variable-to-be-kept")
+        .valueFrom(new V1EnvVarSource()
+            .fieldRef(new V1ObjectFieldSelector()
+                .fieldPath("env-variable-was-kept")));
+    final List<V1EnvVar> expectedEnvVars = Collections.unmodifiableList(
+        new LinkedList<V1EnvVar>(V1Controller.getExecutorEnvVars()) {{
+          add(additionEnvVar);
+        }});
+    final List<V1EnvVar> inputEnvVars = Arrays.asList(
+        new V1EnvVar()
+            .name(KubernetesConstants.ENV_HOST)
+            .valueFrom(new V1EnvVarSource()
+                .fieldRef(new V1ObjectFieldSelector()
+                    .fieldPath("env-host-to-be-replaced"))),
+        new V1EnvVar()
+            .name(KubernetesConstants.ENV_POD_NAME)
+            .valueFrom(new V1EnvVarSource()
+                .fieldRef(new V1ObjectFieldSelector()
+                    .fieldPath("pod-name-to-be-replaced"))),
+        additionEnvVar
+    );
+
+    KubernetesUtils.V1ControllerUtils<V1EnvVar> v1ControllerUtils =
+        new KubernetesUtils.V1ControllerUtils<>();
+
+    // Both input lists are null.
+    Assert.assertNull("Both input lists are <null>",
+         v1ControllerUtils.mergeListsDedupe(null, null,
+             Comparator.comparing(V1EnvVar::getName), description));
+
+    // <primaryList> is <null>.
+    Assert.assertEquals("<primaryList> is null and <secondaryList> should have been returned",
+        inputEnvVars,
+        v1ControllerUtils.mergeListsDedupe(null, inputEnvVars,
+            Comparator.comparing(V1EnvVar::getName), description));
+
+    // <primaryList> is empty.
+    Assert.assertEquals("<primaryList> is empty and <secondaryList> should have been returned",
+        inputEnvVars,
+        v1ControllerUtils.mergeListsDedupe(new LinkedList<>(), inputEnvVars,
+            Comparator.comparing(V1EnvVar::getName), description));
+
+    // <secondaryList> is <null>.
+    Assert.assertEquals("<secondaryList> is null and <primaryList> should have been returned",
+        heronEnvVars,
+        v1ControllerUtils.mergeListsDedupe(heronEnvVars, null,
+            Comparator.comparing(V1EnvVar::getName), description));
+
+    // <secondaryList> is empty.
+    Assert.assertEquals("<secondaryList> is empty and <primaryList> should have been returned",
+        heronEnvVars,
+        v1ControllerUtils.mergeListsDedupe(heronEnvVars, new LinkedList<>(),
+            Comparator.comparing(V1EnvVar::getName), description));
+
+    // Merge both lists.
+    Assert.assertTrue("<primaryList> and <secondaryList> merged and deduplicated",
+        expectedEnvVars.containsAll(
+            v1ControllerUtils.mergeListsDedupe(heronEnvVars, inputEnvVars,
+                Comparator.comparing(V1EnvVar::getName), description)
+        )
+    );
+
+    // Expect thrown error.
+    String errorMessage = "";
+    try {
+      v1ControllerUtils.mergeListsDedupe(heronEnvVars, Collections.singletonList(new V1EnvVar()),
+          Comparator.comparing(V1EnvVar::getName), description);
+    } catch (TopologySubmissionException e) {
+      errorMessage = e.getMessage();
+    }
+    Assert.assertTrue("Expecting error to be thrown for null deduplication key",
+        errorMessage.contains(description));
+
+  }
+}

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesUtilsTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesUtilsTest.java
@@ -76,25 +76,25 @@ public class KubernetesUtilsTest {
              Comparator.comparing(V1EnvVar::getName), description));
 
     // <primaryList> is <null>.
-    Assert.assertEquals("<primaryList> is null and <secondaryList> should have been returned",
+    Assert.assertEquals("<primaryList> is null and <secondaryList> should be returned",
         inputEnvVars,
         v1ControllerUtils.mergeListsDedupe(null, inputEnvVars,
             Comparator.comparing(V1EnvVar::getName), description));
 
     // <primaryList> is empty.
-    Assert.assertEquals("<primaryList> is empty and <secondaryList> should have been returned",
+    Assert.assertEquals("<primaryList> is empty and <secondaryList> should be returned",
         inputEnvVars,
         v1ControllerUtils.mergeListsDedupe(new LinkedList<>(), inputEnvVars,
             Comparator.comparing(V1EnvVar::getName), description));
 
     // <secondaryList> is <null>.
-    Assert.assertEquals("<secondaryList> is null and <primaryList> should have been returned",
+    Assert.assertEquals("<secondaryList> is null and <primaryList> should be returned",
         heronEnvVars,
         v1ControllerUtils.mergeListsDedupe(heronEnvVars, null,
             Comparator.comparing(V1EnvVar::getName), description));
 
     // <secondaryList> is empty.
-    Assert.assertEquals("<secondaryList> is empty and <primaryList> should have been returned",
+    Assert.assertEquals("<secondaryList> is empty and <primaryList> should be returned",
         heronEnvVars,
         v1ControllerUtils.mergeListsDedupe(heronEnvVars, new LinkedList<>(),
             Comparator.comparing(V1EnvVar::getName), description));
@@ -115,6 +115,5 @@ public class KubernetesUtilsTest {
     }
     Assert.assertTrue("Expecting error to be thrown for null deduplication key",
         errorMessage.contains(description));
-
   }
 }

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -40,6 +40,7 @@ import org.apache.heron.spi.common.Config;
 import org.apache.heron.spi.common.Key;
 
 import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1ConfigMapBuilder;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
 
@@ -65,7 +66,6 @@ public class V1ControllerTest {
   private final LinkedList<V1ConfigMap> nonTargetConfigMapList;
   private final V1ConfigMap configMapWithNonTargetData;
 
-  private final V1Controller v1ControllerNoPodTemplate = new V1Controller(config, runtime);
   @Spy
   private final V1Controller v1ControllerWithPodTemplate =
       new V1Controller(configWithPodTemplate, runtime);
@@ -103,6 +103,7 @@ public class V1ControllerTest {
   @Test
   public void testLoadPodFromTemplateDefault()
       throws InvocationTargetException, IllegalAccessException {
+    final V1Controller v1ControllerNoPodTemplate = new V1Controller(config, runtime);
     final V1PodTemplateSpec podSpec = (V1PodTemplateSpec) loadPodFromTemplate
         .invoke(v1ControllerNoPodTemplate);
 
@@ -165,11 +166,13 @@ public class V1ControllerTest {
     String message = "";
 
     // ConfigMap List without target ConfigMaps and an invalid Pod Template.
-    final LinkedList<V1ConfigMap> invalidPodConfigMapList;
-    V1ConfigMap configMapInvalidPod = new V1ConfigMap();
-    configMapInvalidPod.setMetadata(new V1ObjectMeta().name(CONFIGMAP_NAME));
-    configMapInvalidPod.putDataItem(POD_TEMPLATE_NAME, "Dummy Value");
-    invalidPodConfigMapList = new LinkedList<>(
+    V1ConfigMap configMapInvalidPod = new V1ConfigMapBuilder()
+        .withNewMetadata()
+          .withName(CONFIGMAP_NAME)
+        .endMetadata()
+        .addToData(POD_TEMPLATE_NAME, "Dummy Value")
+        .build();
+    final LinkedList<V1ConfigMap> invalidPodConfigMapList = new LinkedList<>(
         Arrays.asList(configMapWithNonTargetData, configMapInvalidPod));
 
     doReturn(invalidPodConfigMapList).when(v1ControllerWithPodTemplate).getConfigMaps();
@@ -181,11 +184,13 @@ public class V1ControllerTest {
     Assert.assertTrue(message.contains(expected));
 
     // ConfigMap List without target ConfigMaps and an empty Pod Template.
-    final LinkedList<V1ConfigMap> emptyPodConfigMapList;
-    V1ConfigMap configMapEmptyPod = new V1ConfigMap();
-    configMapEmptyPod.setMetadata(new V1ObjectMeta().name(CONFIGMAP_NAME));
-    configMapEmptyPod.putDataItem(POD_TEMPLATE_NAME, "");
-    emptyPodConfigMapList = new LinkedList<>(
+    V1ConfigMap configMapEmptyPod = new V1ConfigMapBuilder()
+        .withNewMetadata()
+          .withName(CONFIGMAP_NAME)
+        .endMetadata()
+        .addToData(POD_TEMPLATE_NAME, "")
+        .build();
+    final LinkedList<V1ConfigMap> emptyPodConfigMapList = new LinkedList<>(
         Arrays.asList(configMapWithNonTargetData, configMapEmptyPod));
 
     doReturn(emptyPodConfigMapList).when(v1ControllerWithPodTemplate).getConfigMaps();
@@ -263,11 +268,13 @@ public class V1ControllerTest {
             + "          limits:\n"
             + "            cpu: \"400m\"\n"
             + "            memory: \"512M\"";
-    final LinkedList<V1ConfigMap> validPodConfigMapList;
-    V1ConfigMap configMapValidPod = new V1ConfigMap();
-    configMapValidPod.setMetadata(new V1ObjectMeta().name(CONFIGMAP_NAME));
-    configMapValidPod.putDataItem(POD_TEMPLATE_NAME, validPodTemplate);
-    validPodConfigMapList = new LinkedList<>(
+    V1ConfigMap configMapValidPod = new V1ConfigMapBuilder()
+        .withNewMetadata()
+          .withName(CONFIGMAP_NAME)
+        .endMetadata()
+        .addToData(POD_TEMPLATE_NAME, validPodTemplate)
+        .build();
+    final LinkedList<V1ConfigMap> validPodConfigMapList = new LinkedList<>(
         Arrays.asList(configMapWithNonTargetData, configMapValidPod));
 
     doReturn(validPodConfigMapList).when(v1ControllerWithPodTemplate).getConfigMaps();
@@ -291,10 +298,13 @@ public class V1ControllerTest {
             + "    labels:\n"
             + "      app: heron-tracker\n"
             + "  spec:\n";
-    V1ConfigMap configMap = new V1ConfigMap();
-    configMap.setMetadata(new V1ObjectMeta().name(CONFIGMAP_NAME));
-    configMap.putDataItem(POD_TEMPLATE_NAME, invalidPodTemplate);
-    LinkedList<V1ConfigMap> configMapList =
+    V1ConfigMap configMap = new V1ConfigMapBuilder()
+        .withNewMetadata()
+          .withName(CONFIGMAP_NAME)
+        .endMetadata()
+        .addToData(POD_TEMPLATE_NAME, invalidPodTemplate)
+        .build();
+    final LinkedList<V1ConfigMap> configMapList =
         new LinkedList<>(Collections.singletonList(configMap));
 
     final String expected = "Error parsing";

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -50,7 +50,6 @@ public class V1ControllerTest {
   private static final String CONFIGMAP_POD_TEMPLATE_NAME = "CONFIG-MAP-NAME.POD-TEMPLATE-NAME";
   private static final String CONFIGMAP_NAME = "CONFIG-MAP-NAME";
   private static final String POD_TEMPLATE_NAME = "POD-TEMPLATE-NAME";
-  private static final String POD_TEMPLATE_DEFAULT = new V1PodTemplateSpec().toString();
   private static final String POD_TEMPLATE_VALID =
       "apiVersion: apps/v1\n"
           + "kind: PodTemplate\n"
@@ -130,7 +129,7 @@ public class V1ControllerTest {
     final V1Controller v1ControllerNoPodTemplate = new V1Controller(config, runtime);
     final V1PodTemplateSpec podSpec = v1ControllerNoPodTemplate.loadPodFromTemplate();
 
-    Assert.assertEquals(podSpec.toString(), POD_TEMPLATE_DEFAULT);
+    Assert.assertEquals(podSpec.toString(), new V1PodTemplateSpec().toString());
   }
 
   @Test
@@ -327,11 +326,14 @@ public class V1ControllerTest {
         .build();
     final LinkedList<V1ConfigMap> validPodConfigMapList = new LinkedList<>(
         Arrays.asList(configMapWithNonTargetData, configMapValidPod));
-
+    final String expected = "Pod Templates are disabled";
     doReturn(validPodConfigMapList).when(v1ControllerPodTemplate).getConfigMaps();
-    V1PodTemplateSpec podTemplateSpec = v1ControllerPodTemplate.loadPodFromTemplate();
 
-    Assert.assertEquals(podTemplateSpec.toString(), POD_TEMPLATE_DEFAULT);
+    try {
+      v1ControllerPodTemplate.loadPodFromTemplate();
+    } catch (TopologySubmissionException e) {
+      Assert.assertTrue(e.getMessage().contains(expected));
+    }
   }
 
   @Test

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -57,9 +57,7 @@ public class V1ControllerTest {
 
   private final LinkedList<V1ConfigMap> emptyConfigMapList;
   private final LinkedList<V1ConfigMap> dummyConfigMapList;
-  private final LinkedList<V1ConfigMap> invalidPodConfigMapList;
-  private final LinkedList<V1ConfigMap> emptyPodConfigMapList;
-  private final LinkedList<V1ConfigMap> validPodConfigMapList;
+  private final V1ConfigMap configMapWithNonTargetData;
 
   private final V1Controller v1ControllerNoPodTemplate = new V1Controller(config, runtime);
   @Spy
@@ -79,52 +77,10 @@ public class V1ControllerTest {
         Arrays.asList(emptyConfigMap, emptyConfigMap, null, emptyConfigMap, emptyConfigMap));
 
     // ConfigMap List with empty and non-target maps.
-    V1ConfigMap configMapWithNonTargetData = new V1ConfigMap();
+    configMapWithNonTargetData = new V1ConfigMap();
     configMapWithNonTargetData.putDataItem("Dummy Key", "Dummy Value");
     dummyConfigMapList = new LinkedList<>(emptyConfigMapList);
     dummyConfigMapList.add(configMapWithNonTargetData);
-
-    // ConfigMap List with empty and invalid target maps.
-    V1ConfigMap configMapInvalidPod = new V1ConfigMap();
-    configMapInvalidPod.putDataItem(CONFIGMAP_NAME, "Dummy Value");
-    invalidPodConfigMapList = new LinkedList<>(
-        Arrays.asList(configMapWithNonTargetData, configMapInvalidPod));
-
-    // ConfigMap List with empty and empty target maps.
-    V1ConfigMap configMapEmptyPod = new V1ConfigMap();
-    configMapEmptyPod.putDataItem(CONFIGMAP_NAME, "");
-    emptyPodConfigMapList = new LinkedList<>(
-        Arrays.asList(configMapWithNonTargetData, configMapEmptyPod));
-
-    // ConfigMap List with valid Pod Template.
-    final String validPodTemplate =
-        "apiVersion: apps/v1\n"
-        + "kind: PodTemplate\n"
-        + "metadata:\n"
-        + "  name: heron-tracker\n"
-        + "  namespace: default\n"
-        + "template:\n"
-        + "  metadata:\n"
-        + "    labels:\n"
-        + "      app: heron-tracker\n"
-        + "  spec:\n"
-        + "    containers:\n"
-        + "      - name: heron-tracker\n"
-        + "        image: apache/heron:latest\n"
-        + "        ports:\n"
-        + "          - containerPort: 8888\n"
-        + "            name: api-port\n"
-        + "        resources:\n"
-        + "          requests:\n"
-        + "            cpu: \"100m\"\n"
-        + "            memory: \"200M\"\n"
-        + "          limits:\n"
-        + "            cpu: \"400m\"\n"
-        + "            memory: \"512M\"";
-    V1ConfigMap configMapValidPod = new V1ConfigMap();
-    configMapValidPod.putDataItem(CONFIGMAP_NAME, validPodTemplate);
-    validPodConfigMapList = new LinkedList<>(
-        Arrays.asList(configMapWithNonTargetData, configMapValidPod));
   }
 
   @Test
@@ -191,6 +147,13 @@ public class V1ControllerTest {
     final String expected = "Error parsing";
     String message = "";
 
+    // ConfigMap List with empty and invalid target maps.
+    final LinkedList<V1ConfigMap> invalidPodConfigMapList;
+    V1ConfigMap configMapInvalidPod = new V1ConfigMap();
+    configMapInvalidPod.putDataItem(CONFIGMAP_NAME, "Dummy Value");
+    invalidPodConfigMapList = new LinkedList<>(
+        Arrays.asList(configMapWithNonTargetData, configMapInvalidPod));
+
     doReturn(invalidPodConfigMapList).when(v1ControllerWithPodTemplate).getConfigMaps();
     try {
       loadPodFromTemplate.invoke(v1ControllerWithPodTemplate);
@@ -198,6 +161,13 @@ public class V1ControllerTest {
       message = e.getCause().getMessage();
     }
     Assert.assertTrue(message.contains(expected));
+
+    // ConfigMap List with empty and empty target maps.
+    final LinkedList<V1ConfigMap> emptyPodConfigMapList;
+    V1ConfigMap configMapEmptyPod = new V1ConfigMap();
+    configMapEmptyPod.putDataItem(CONFIGMAP_NAME, "");
+    emptyPodConfigMapList = new LinkedList<>(
+        Arrays.asList(configMapWithNonTargetData, configMapEmptyPod));
 
     doReturn(emptyPodConfigMapList).when(v1ControllerWithPodTemplate).getConfigMaps();
     try {
@@ -247,6 +217,38 @@ public class V1ControllerTest {
         + "            volumeMounts: null\n"
         + "            workingDir: null\n"
         + "        }]";
+
+
+    // ConfigMap List with valid Pod Template.
+    final String validPodTemplate =
+        "apiVersion: apps/v1\n"
+            + "kind: PodTemplate\n"
+            + "metadata:\n"
+            + "  name: heron-tracker\n"
+            + "  namespace: default\n"
+            + "template:\n"
+            + "  metadata:\n"
+            + "    labels:\n"
+            + "      app: heron-tracker\n"
+            + "  spec:\n"
+            + "    containers:\n"
+            + "      - name: heron-tracker\n"
+            + "        image: apache/heron:latest\n"
+            + "        ports:\n"
+            + "          - containerPort: 8888\n"
+            + "            name: api-port\n"
+            + "        resources:\n"
+            + "          requests:\n"
+            + "            cpu: \"100m\"\n"
+            + "            memory: \"200M\"\n"
+            + "          limits:\n"
+            + "            cpu: \"400m\"\n"
+            + "            memory: \"512M\"";
+    final LinkedList<V1ConfigMap> validPodConfigMapList;
+    V1ConfigMap configMapValidPod = new V1ConfigMap();
+    configMapValidPod.putDataItem(CONFIGMAP_NAME, validPodTemplate);
+    validPodConfigMapList = new LinkedList<>(
+        Arrays.asList(configMapWithNonTargetData, configMapValidPod));
 
     doReturn(validPodConfigMapList).when(v1ControllerWithPodTemplate).getConfigMaps();
     V1PodTemplateSpec podTemplateSpec =

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -89,14 +89,12 @@ public class V1ControllerTest {
       if (configMap == null) {
         continue;
       }
-      configMap.setMetadata(new V1ObjectMeta());
-      configMap.getMetadata().setName("some-config-map-name" + (++index));
+      configMap.setMetadata(new V1ObjectMeta().name("some-config-map-name" + (++index)));
     }
 
     // ConfigMap List with empty and non-target maps.
     configMapWithNonTargetData = new V1ConfigMap();
-    configMapWithNonTargetData.setMetadata(new V1ObjectMeta());
-    configMapWithNonTargetData.getMetadata().setName(CONFIGMAP_NAME);
+    configMapWithNonTargetData.setMetadata(new V1ObjectMeta().name(CONFIGMAP_NAME));
     configMapWithNonTargetData.putDataItem("Dummy Key", "Dummy Value");
     nonTargetConfigMapList = new LinkedList<>(emptyConfigMapList);
     nonTargetConfigMapList.add(configMapWithNonTargetData);
@@ -169,8 +167,7 @@ public class V1ControllerTest {
     // ConfigMap List without target ConfigMaps and an invalid Pod Template.
     final LinkedList<V1ConfigMap> invalidPodConfigMapList;
     V1ConfigMap configMapInvalidPod = new V1ConfigMap();
-    configMapInvalidPod.setMetadata(new V1ObjectMeta());
-    configMapInvalidPod.getMetadata().setName(CONFIGMAP_NAME);
+    configMapInvalidPod.setMetadata(new V1ObjectMeta().name(CONFIGMAP_NAME));
     configMapInvalidPod.putDataItem(POD_TEMPLATE_NAME, "Dummy Value");
     invalidPodConfigMapList = new LinkedList<>(
         Arrays.asList(configMapWithNonTargetData, configMapInvalidPod));
@@ -186,8 +183,7 @@ public class V1ControllerTest {
     // ConfigMap List without target ConfigMaps and an empty Pod Template.
     final LinkedList<V1ConfigMap> emptyPodConfigMapList;
     V1ConfigMap configMapEmptyPod = new V1ConfigMap();
-    configMapEmptyPod.setMetadata(new V1ObjectMeta());
-    configMapEmptyPod.getMetadata().setName(CONFIGMAP_NAME);
+    configMapEmptyPod.setMetadata(new V1ObjectMeta().name(CONFIGMAP_NAME));
     configMapEmptyPod.putDataItem(POD_TEMPLATE_NAME, "");
     emptyPodConfigMapList = new LinkedList<>(
         Arrays.asList(configMapWithNonTargetData, configMapEmptyPod));
@@ -269,8 +265,7 @@ public class V1ControllerTest {
             + "            memory: \"512M\"";
     final LinkedList<V1ConfigMap> validPodConfigMapList;
     V1ConfigMap configMapValidPod = new V1ConfigMap();
-    configMapValidPod.setMetadata(new V1ObjectMeta());
-    configMapValidPod.getMetadata().setName(CONFIGMAP_NAME);
+    configMapValidPod.setMetadata(new V1ObjectMeta().name(CONFIGMAP_NAME));
     configMapValidPod.putDataItem(POD_TEMPLATE_NAME, validPodTemplate);
     validPodConfigMapList = new LinkedList<>(
         Arrays.asList(configMapWithNonTargetData, configMapValidPod));
@@ -297,8 +292,7 @@ public class V1ControllerTest {
             + "      app: heron-tracker\n"
             + "  spec:\n";
     V1ConfigMap configMap = new V1ConfigMap();
-    configMap.setMetadata(new V1ObjectMeta());
-    configMap.getMetadata().setName(CONFIGMAP_NAME);
+    configMap.setMetadata(new V1ObjectMeta().name(CONFIGMAP_NAME));
     configMap.putDataItem(POD_TEMPLATE_NAME, invalidPodTemplate);
     LinkedList<V1ConfigMap> configMapList =
         new LinkedList<>(Collections.singletonList(configMap));

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -32,6 +32,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import org.apache.heron.api.exception.TopologySubmissionException;
 import org.apache.heron.spi.common.Config;
 import org.apache.heron.spi.common.Key;
 
@@ -63,15 +64,15 @@ public class V1ControllerTest {
   private V1ConfigMapList mockConfigMapList;
 
   @InjectMocks
-  private final Method loadPodFromTemplateNoPodTemplate = V1Controller.class
-      .getDeclaredMethod("loadPodFromTemplate");
-  private final Method loadPodFromTemplateWithPodTemplate = V1Controller.class
+  private final Method loadPodFromTemplate = V1Controller.class
       .getDeclaredMethod("loadPodFromTemplate");
 
   public V1ControllerTest() throws NoSuchMethodException {
-    loadPodFromTemplateNoPodTemplate.setAccessible(true);
-    loadPodFromTemplateWithPodTemplate.setAccessible(true);
+    loadPodFromTemplate.setAccessible(true);
   }
+
+  @Rule
+  public final ExpectedException exceptionRule = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -81,22 +82,19 @@ public class V1ControllerTest {
   @Test
   public void testLoadPodFromTemplateDefault()
       throws InvocationTargetException, IllegalAccessException {
-    final V1PodTemplateSpec podSpec = (V1PodTemplateSpec) loadPodFromTemplateNoPodTemplate
+    final V1PodTemplateSpec podSpec = (V1PodTemplateSpec) loadPodFromTemplate
         .invoke(v1ControllerNoPodTemplate);
 
     Assert.assertEquals(podSpec.toString(), POD_TEMPLATE_DEFAULT);
   }
 
-  @Rule
-  public ExpectedException noConfigMapsExceptionRule = ExpectedException.none();
-
   @Test
   public void testLoadPodFromTemplateNoConfigMaps()
       throws InvocationTargetException, IllegalAccessException {
-//    noConfigMapsExceptionRule.expect(TopologySubmissionException.class);
-//    noConfigMapsExceptionRule.expectMessage("No ConfigMaps set");
-//
-//    final V1PodTemplateSpec podSpec = (V1PodTemplateSpec) loadPodFromTemplateWithPodTemplate
-//        .invoke(v1ControllerWithPodTemplate);
+    exceptionRule.expect(TopologySubmissionException.class);
+    exceptionRule.expectMessage("No ConfigMaps set");
+
+    final V1PodTemplateSpec podSpec = (V1PodTemplateSpec) loadPodFromTemplate
+        .invoke(v1ControllerWithPodTemplate);
   }
 }

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -66,9 +66,10 @@ import static org.mockito.Mockito.doReturn;
 public class V1ControllerTest {
 
   private static final String TOPOLOGY_NAME = "topology-name";
-  private static final String CONFIGMAP_POD_TEMPLATE_NAME = "CONFIG-MAP-NAME.POD-TEMPLATE-NAME";
   private static final String CONFIGMAP_NAME = "CONFIG-MAP-NAME";
   private static final String POD_TEMPLATE_NAME = "POD-TEMPLATE-NAME";
+  private static final String CONFIGMAP_POD_TEMPLATE_NAME =
+      String.format("%s.%s", CONFIGMAP_NAME, POD_TEMPLATE_NAME);
   private static final String POD_TEMPLATE_VALID =
       "apiVersion: apps/v1\n"
           + "kind: PodTemplate\n"

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -129,7 +129,7 @@ public class V1ControllerTest {
     final V1Controller v1ControllerNoPodTemplate = new V1Controller(config, runtime);
     final V1PodTemplateSpec podSpec = v1ControllerNoPodTemplate.loadPodFromTemplate();
 
-    Assert.assertEquals(podSpec.toString(), new V1PodTemplateSpec().toString());
+    Assert.assertEquals(podSpec, new V1PodTemplateSpec());
   }
 
   @Test

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -348,4 +348,14 @@ public class V1ControllerTest {
     V1Controller v1Controller = new V1Controller(testConfig, runtime);
     v1Controller.getPodTemplateLocation();
   }
+
+  @Test
+  public void testGetPodTemplateLocationNoDelimiter() {
+    expectedException.expect(TopologySubmissionException.class);
+    final Config testConfig = Config.newBuilder()
+        .put(KubernetesContext.KUBERNETES_POD_TEMPLATE_CONFIGMAP_NAME,
+        "CONFIGMAP-NAMEPOD-TEMPLATE-NAME").build();
+    V1Controller v1Controller = new V1Controller(testConfig, runtime);
+    v1Controller.getPodTemplateLocation();
+  }
 }

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -400,7 +400,7 @@ public class V1ControllerTest {
     // Null ports. This is the default case.
     final V1Container inputContainerWithNullPorts = new V1ContainerBuilder().build();
     v1ControllerWithPodTemplate.configureContainerPorts(false, 0, inputContainerWithNullPorts);
-    Assert.assertTrue("Server and/or shell ports for container null ports did not match",
+    Assert.assertTrue("Server and/or shell PORTS for container with null ports list",
         CollectionUtils.containsAll(inputContainerWithNullPorts.getPorts(), expectedPortsBase));
 
     // Empty ports.
@@ -408,7 +408,7 @@ public class V1ControllerTest {
         .withPorts(new LinkedList<>())
         .build();
     v1ControllerWithPodTemplate.configureContainerPorts(false, 0, inputContainerWithEmptyPorts);
-    Assert.assertTrue("Server and/or shell ports for container empty ports did not match",
+    Assert.assertTrue("Server and/or shell PORTS for container with empty ports list",
         CollectionUtils.containsAll(inputContainerWithEmptyPorts.getPorts(), expectedPortsBase));
 
     // Port overriding.
@@ -421,7 +421,7 @@ public class V1ControllerTest {
         .add(new V1ContainerPort().name(portNamekept).containerPort(portNumberkept));
 
     v1ControllerWithPodTemplate.configureContainerPorts(false, 0, inputContainerWithPorts);
-    Assert.assertTrue("Server and/or shell ports for container were not overwritten.",
+    Assert.assertTrue("Server and/or shell PORTS for container should be overwritten.",
         CollectionUtils.containsAll(inputContainerWithPorts.getPorts(), expectedPortsOverriding));
 
     // Port overriding with debug ports.
@@ -436,7 +436,7 @@ public class V1ControllerTest {
 
     v1ControllerWithPodTemplate.configureContainerPorts(
         true, numInstances, inputContainerWithDebug);
-    Assert.assertTrue("Server and/or shell ports for container were not overwritten.",
+    Assert.assertTrue("Server and/or shell with debug PORTS for container should be overwritten.",
         CollectionUtils.containsAll(inputContainerWithDebug.getPorts(), expectedPortsDebug));
   }
 
@@ -466,7 +466,7 @@ public class V1ControllerTest {
     // Null env vars. This is the default case.
     V1Container containerWithNullEnvVars = new V1ContainerBuilder().build();
     v1ControllerWithPodTemplate.configureContainerEnvVars(containerWithNullEnvVars);
-    Assert.assertTrue("ENV_HOST & ENV_POD_NAME in container with null Env Vars did not match",
+    Assert.assertTrue("ENV_HOST & ENV_POD_NAME in container with null Env Vars should match",
         CollectionUtils.containsAll(containerWithNullEnvVars.getEnv(), heronEnvVars));
 
     // Empty env vars.
@@ -474,7 +474,7 @@ public class V1ControllerTest {
         .withEnv(new LinkedList<>())
         .build();
     v1ControllerWithPodTemplate.configureContainerEnvVars(containerWithEmptyEnvVars);
-    Assert.assertTrue("ENV_HOST & ENV_POD_NAME in container with empty Env Vars did not match",
+    Assert.assertTrue("ENV_HOST & ENV_POD_NAME in container with empty Env Vars should match",
         CollectionUtils.containsAll(containerWithEmptyEnvVars.getEnv(), heronEnvVars));
 
     // Env Var overriding.
@@ -484,7 +484,7 @@ public class V1ControllerTest {
         .withEnv(inputEnvVars)
         .build();
     v1ControllerWithPodTemplate.configureContainerEnvVars(containerWithEnvVars);
-    Assert.assertTrue("ENV_HOST & ENV_POD_NAME in container with Env Vars did not match",
+    Assert.assertTrue("ENV_HOST & ENV_POD_NAME in container with Env Vars should be overridden",
         CollectionUtils.containsAll(containerWithEnvVars.getEnv(), expectedOverriding));
   }
 
@@ -524,7 +524,7 @@ public class V1ControllerTest {
     V1Container containerNull = new V1ContainerBuilder().build();
     v1ControllerWithPodTemplate.configureContainerResources(
         containerNull, configNoLimit, resourceDefault);
-    Assert.assertTrue("Default LIMITS not set in container with null LIMITS",
+    Assert.assertTrue("Default LIMITS should be set in container with null LIMITS",
         containerNull.getResources().getLimits().entrySet()
             .containsAll(expectDefaultRequirements.getLimits().entrySet()));
 
@@ -532,7 +532,7 @@ public class V1ControllerTest {
     V1Container containerEmpty = new V1ContainerBuilder().withNewResources().endResources().build();
     v1ControllerWithPodTemplate.configureContainerResources(
         containerEmpty, configNoLimit, resourceDefault);
-    Assert.assertTrue("Default LIMITS not set in container with empty LIMITS",
+    Assert.assertTrue("Default LIMITS should be set in container with empty LIMITS",
         containerNull.getResources().getLimits().entrySet()
             .containsAll(expectDefaultRequirements.getLimits().entrySet()));
 
@@ -542,7 +542,7 @@ public class V1ControllerTest {
         .build();
     v1ControllerWithPodTemplate.configureContainerResources(
         containerCustom, configNoLimit, resourceDefault);
-    Assert.assertTrue("Custom LIMITS not set in container with custom LIMITS",
+    Assert.assertTrue("Custom LIMITS should be set in container with custom LIMITS",
         containerCustom.getResources().getLimits().entrySet()
             .containsAll(expectCustomRequirements.getLimits().entrySet()));
 
@@ -552,10 +552,10 @@ public class V1ControllerTest {
         .build();
     v1ControllerWithPodTemplate.configureContainerResources(
         containerRequests, configWithLimit, resourceDefault);
-    Assert.assertTrue("Custom LIMITS not set in container with custom LIMITS and REQUEST",
+    Assert.assertTrue("Custom LIMITS should be set in container with custom LIMITS and REQUEST",
         containerRequests.getResources().getLimits().entrySet()
             .containsAll(expectCustomRequirements.getLimits().entrySet()));
-    Assert.assertTrue("Custom REQUEST not set in container with custom LIMITS and REQUEST",
+    Assert.assertTrue("Custom REQUEST should be set in container with custom LIMITS and REQUEST",
         containerRequests.getResources().getRequests().entrySet()
             .containsAll(expectCustomRequirements.getLimits().entrySet()));
   }
@@ -605,7 +605,7 @@ public class V1ControllerTest {
     // Default. Null Volumes.
     V1PodSpec podSpecNull = new V1PodSpecBuilder().build();
     controllerWithVol.addVolumesIfPresent(podSpecNull);
-    Assert.assertTrue("Default VOLUMES not set in container with null VOLUMES",
+    Assert.assertTrue("Default VOLUMES should be set in container with null VOLUMES",
         CollectionUtils.containsAll(expectedDefault, podSpecNull.getVolumes()));
 
     // Empty Volumes list
@@ -613,7 +613,7 @@ public class V1ControllerTest {
         .withVolumes(new LinkedList<>())
         .build();
     controllerWithVol.addVolumesIfPresent(podSpecEmpty);
-    Assert.assertTrue("Default VOLUMES not set in container with empty VOLUMES",
+    Assert.assertTrue("Default VOLUMES should be set in container with empty VOLUMES",
         CollectionUtils.containsAll(expectedDefault, podSpecEmpty.getVolumes()));
 
     // Custom Volumes list
@@ -621,7 +621,7 @@ public class V1ControllerTest {
         .withVolumes(customVolumeList)
         .build();
     controllerWithVol.addVolumesIfPresent(podSpecCustom);
-    Assert.assertTrue("Default VOLUMES not set in container with custom VOLUMES",
+    Assert.assertTrue("Default VOLUMES should be set in container with custom VOLUMES",
         CollectionUtils.containsAll(expectedCustom, podSpecCustom.getVolumes()));
   }
 
@@ -662,7 +662,7 @@ public class V1ControllerTest {
     // Default. Null Volume Mounts.
     V1Container containerNull = new V1ContainerBuilder().build();
     controllerWithMounts.mountVolumeIfPresent(containerNull);
-    Assert.assertTrue("Default VOLUME MOUNTS not set in container with null VOLUMES MOUNTS",
+    Assert.assertTrue("Default VOLUME MOUNTS should be set in container with null VOLUME MOUNTS",
         CollectionUtils.containsAll(expectedMountsDefault, containerNull.getVolumeMounts()));
 
     // Empty Volume Mounts.
@@ -670,7 +670,7 @@ public class V1ControllerTest {
         .withVolumeMounts(new LinkedList<>())
         .build();
     controllerWithMounts.mountVolumeIfPresent(containerEmpty);
-    Assert.assertTrue("Default VOLUME MOUNTS not set in container with empty VOLUMES MOUNTS",
+    Assert.assertTrue("Default VOLUME MOUNTS should be set in container with empty VOLUME MOUNTS",
         CollectionUtils.containsAll(expectedMountsDefault, containerEmpty.getVolumeMounts()));
 
     // Custom Volume Mounts.
@@ -678,7 +678,7 @@ public class V1ControllerTest {
         .withVolumeMounts(volumeMountsCustomList)
         .build();
     controllerWithMounts.mountVolumeIfPresent(containerCustom);
-    Assert.assertTrue("Default VOLUME MOUNTS not set in container with custom VOLUMES MOUNTS",
+    Assert.assertTrue("Default VOLUME MOUNTS should be set in container with custom VOLUME MOUNTS",
         CollectionUtils.containsAll(expectedMountsCustom, containerCustom.getVolumeMounts()));
   }
 
@@ -704,7 +704,7 @@ public class V1ControllerTest {
     // Null Tolerations. This is the default case.
     final V1PodSpec podSpecNullTolerations = new V1PodSpecBuilder().build();
     v1ControllerWithPodTemplate.configureTolerations(podSpecNullTolerations);
-    Assert.assertTrue("Pod Spec has <null> Tolerations and should be set to Heron's defaults",
+    Assert.assertTrue("Pod Spec has null TOLERATIONS and should be set to Heron's defaults",
         CollectionUtils.containsAll(podSpecNullTolerations.getTolerations(),
             expectedTolerationBase));
 
@@ -713,7 +713,7 @@ public class V1ControllerTest {
         .withTolerations(new LinkedList<>())
         .build();
     v1ControllerWithPodTemplate.configureTolerations(podSpecWithEmptyTolerations);
-    Assert.assertTrue("Pod Spec has empty Tolerations and should be set to Heron's defaults",
+    Assert.assertTrue("Pod Spec has empty TOLERATIONS and should be set to Heron's defaults",
         CollectionUtils.containsAll(podSpecWithEmptyTolerations.getTolerations(),
             expectedTolerationBase));
 
@@ -726,7 +726,7 @@ public class V1ControllerTest {
     expectedTolerationsOverriding.add(keptToleration);
 
     v1ControllerWithPodTemplate.configureTolerations(podSpecWithTolerations);
-    Assert.assertTrue("Pod Spec has Tolerations and should be overriden with Heron's defaults",
+    Assert.assertTrue("Pod Spec has TOLERATIONS and should be overridden with Heron's defaults",
         CollectionUtils.containsAll(podSpecWithTolerations.getTolerations(),
             expectedTolerationsOverriding));
   }

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -32,7 +32,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import org.apache.heron.api.exception.TopologySubmissionException;
 import org.apache.heron.spi.common.Config;
 import org.apache.heron.spi.common.Key;
 
@@ -91,10 +90,10 @@ public class V1ControllerTest {
   @Test
   public void testLoadPodFromTemplateNoConfigMaps()
       throws InvocationTargetException, IllegalAccessException {
-    exceptionRule.expect(TopologySubmissionException.class);
-    exceptionRule.expectMessage("No ConfigMaps set");
-
-    final V1PodTemplateSpec podSpec = (V1PodTemplateSpec) loadPodFromTemplate
-        .invoke(v1ControllerWithPodTemplate);
+//    exceptionRule.expect(TopologySubmissionException.class);
+//    exceptionRule.expectMessage("No ConfigMaps set");
+//
+//    final V1PodTemplateSpec podSpec = (V1PodTemplateSpec) loadPodFromTemplate
+//        .invoke(v1ControllerWithPodTemplate);
   }
 }


### PR DESCRIPTION
**_Issue #3707:_**

This PR adds support for custom Pod Templates via the `--config-property` CLI flag. Please view the documentation for this PR in issue #3717 by going to the _**Files changed**_ tab and then navigating to the _**View file**_ option under the `...` for the MD file.

<details><summary><b><i>Old Post</i></b></summary>

A preliminary WIP PR to add Pod Template support in Heron similar to how it is handled in [Spark](https://spark.apache.org/docs/latest/running-on-kubernetes.html#pod-template). The `ConfigMap` name should be passed in from the cli flag `config-property`.

The solution is following what has been done by [Spark](https://github.com/apache/spark/blob/de59e01aa4853ef951da080c0d1908d53d133ebe/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStep.scala#L39-L54) to produce the following YAML nodes:
```YAML
  volumes:
    - name: pod-template-name  # from <POD_TEMPLATE_VOLUME>.
      configMap:
        name: configmap-name  # from <configmapName>.
        items:
        - key: pod-template-key  # from <POD_TEMPLATE_KEY>.
          path: executor-pod-spec-template-file-name # from <EXECUTOR_POD_SPEC_TEMPLATE_FILE_NAME>.
```

The first phase of this PR is generating the above basic YAML nodes in a `V1PodSpec`. The objective is to call the `createConfigMapVolumeMount` method from within `createStatefulSet` to add the `V1PodTemplateSpec` somewhere here:
https://github.com/apache/incubator-heron/blob/b2a4e828569c0445a758ca9f3780600a0855e665/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java#L386-L394

I have added what I believe (build/test issues on my end) will extract the `configmapName` from a provided parameter to `--config-property`. The option requires a key-value pair as outlined [here](https://heron.apache.org/docs/0.20.2-incubating/user-manuals-heron-cli):
```
--config-property (key=value; a config key and its value; default: [])
```

I have selected a key of `heron.kubernetes.pod.template.configmap.name` for now pending approval from the dev group.

I have not located the testing suite base for the methods in the `V1Controller`. If there is no test suite it would be prudent to invest some time in creating one.

</details>