### PR TITLE
Helm: Adding option to switch the apiserver service between NodePort and ClusterIP

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -355,17 +355,17 @@ http_archive(
 http_archive(
     name = "helm_mac",
     build_file = "@//:third_party/helm/helm.BUILD",
-    sha256 = "05c7748da0ea8d5f85576491cd3c615f94063f20986fd82a0f5658ddc286cdb1",
+    sha256 = "3a9efe337c61a61b3e160da919ac7af8cded8945b75706e401f3655a89d53ef5",
     strip_prefix = "darwin-amd64",
-    urls = ["https://get.helm.sh/helm-v3.0.2-darwin-amd64.tar.gz"],
+    urls = ["https://get.helm.sh/helm-v3.7.1-darwin-amd64.tar.gz"],
 )
 
 http_archive(
     name = "helm_linux",
     build_file = "@//:third_party/helm/helm.BUILD",
-    sha256 = "c6b7aa7e4ffc66e8abb4be328f71d48c643cb8f398d95c74d075cfb348710e1d",
+    sha256 = "6cd6cad4b97e10c33c978ff3ac97bb42b68f79766f1d2284cfd62ec04cd177f4",
     strip_prefix = "linux-amd64",
-    urls = ["https://get.helm.sh/helm-v3.0.2-linux-amd64.tar.gz"],
+    urls = ["https://get.helm.sh/helm-v3.7.1-linux-amd64.tar.gz"],
 )
 # end helm
 

--- a/deploy/kubernetes/gke/medium.yaml
+++ b/deploy/kubernetes/gke/medium.yaml
@@ -30,8 +30,9 @@ platform: gke
 # Number of replicas for the job binary in bookkeeper
 jobReplicas: 2
 
-# amount of memory to provide for API server
-apiServerMemory: 512M
+apiServer:
+  # amount of memory to provide for API server
+  memory: 512M
 
 # Number of replicas for storage bookies, memory and storage requirements 
 bookieReplicas: 5

--- a/deploy/kubernetes/gke/small.yaml
+++ b/deploy/kubernetes/gke/small.yaml
@@ -30,8 +30,9 @@ platform: gke
 # Number of replicas for the job binary in bookkeeper
 jobReplicas: 2
 
-# amount of memory to provide for API server
-apiServerMemory: 512M
+apiServer:
+  # amount of memory to provide for API server
+  memory: 512M
 
 # Number of replicas for storage bookies, memory and storage requirements 
 bookieReplicas: 3

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -285,7 +285,10 @@ spec:
     - port: 9000
       targetPort: 9000
       protocol: TCP
-  {{- if eq .Values.apiserver.NodePort true }}
+      {{- if not (empty .Values.apiserver.NodePort) }}
+      nodePort: {{ .Values.apiserver.NodePort }}
+      {{- end }}
+  {{- if not (empty .Values.apiserver.NodePort) }}
   type: NodePort
   {{- else }}
   type: ClusterIP

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -18,7 +18,7 @@
 {{- $platform := .Values.platform -}}
 {{- $jobReplicas := .Values.jobReplicas -}}
 {{- $defaultUrl := (printf "/api/v1/namespaces/%s/services/%s-ui:8889/proxy" .Release.Namespace .Release.Name) -}}
-{{- $apiServerMemory := .Values.apiServerMemory }}
+{{- $apiServerMemory := .Values.apiServer.memory }}
 
 apiVersion: v1
 kind: ConfigMap
@@ -112,8 +112,8 @@ spec:
             - >-
               heron-ui
               --port=8889
-              {{- if not (kindIs "invalid" .Values.heron.url) }}
-              --base-url={{ eq .Values.heron.url "-" | ternary $defaultUrl .Values.heron.url }}
+              {{- if not (kindIs "invalid" .Values.ui.url) }}
+              --base-url={{ eq .Values.ui.url "-" | ternary $defaultUrl .Values.ui.url }}
               {{- end }}
         - name: heron-apiserver
           image: {{ .Values.image }}
@@ -181,6 +181,14 @@ spec:
     - port: 8889
       targetPort: 8889
       protocol: TCP
+      {{- if .Values.ui.nodePort.enabled }}
+      nodePort: {{ .Values.ui.nodePort.port }}
+      {{- end }}
+  {{- if .Values.ui.nodePort.enabled }}
+  type: NodePort
+  {{- else }}
+  type: ClusterIP
+  {{- end }}      
   selector:
     app: {{ .Release.Name }}-tools
     release: {{ .Release.Name }}
@@ -203,6 +211,44 @@ spec:
     - port: 8888
       targetPort: 8888
       protocol: TCP
+      {{- if .Values.tracker.nodePort.enabled }}
+      nodePort: {{ .Values.tracker.nodePort.port }}
+      {{- end }}
+  {{- if .Values.tracker.nodePort.enabled }}
+  type: NodePort
+  {{- else }}
+  type: ClusterIP
+  {{- end }}
+  selector:
+    app: {{ .Release.Name }}-tools
+    release: {{ .Release.Name }}
+
+---
+##
+## Service to expose the heron-apiserver
+##
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-apiserver
+  labels:
+    app: {{ .Release.Name }}-tools
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      {{- if .Values.apiserver.nodePort.enabled }}
+      nodePort: {{ .Values.apiserver.nodePort.port }}
+      {{- end }}
+  {{- if .Values.apiserver.nodePort.enabled }}
+  type: NodePort
+  {{- else }}
+  type: ClusterIP
+  {{- end }}
   selector:
     app: {{ .Release.Name }}-tools
     release: {{ .Release.Name }}
@@ -269,31 +315,3 @@ rules:
   verbs:
   - get
   - list
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ .Release.Name }}-apiserver
-  labels:
-    app: {{ .Release.Name }}-tools
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-spec:
-  ports:
-    - port: 9000
-      targetPort: 9000
-      protocol: TCP
-      {{- if .Values.apiserver.NodePort.enabled }}
-      nodePort: {{ .Values.apiserver.NodePort.port }}
-      {{- end }}
-  {{- if .Values.apiserver.NodePort.enabled }}
-  type: NodePort
-  {{- else }}
-  type: ClusterIP
-  {{- end }}
-
-  selector:
-    app: {{ .Release.Name }}-tools
-    release: {{ .Release.Name }}

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -285,10 +285,10 @@ spec:
     - port: 9000
       targetPort: 9000
       protocol: TCP
-      {{- if not (empty .Values.apiserver.NodePort) }}
-      nodePort: {{ .Values.apiserver.NodePort }}
+      {{- if .Values.apiserver.NodePort.enabled }}
+      nodePort: {{ .Values.apiserver.NodePort.port }}
       {{- end }}
-  {{- if not (empty .Values.apiserver.NodePort) }}
+  {{- if .Values.apiserver.NodePort.enabled }}
   type: NodePort
   {{- else }}
   type: ClusterIP

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -285,7 +285,12 @@ spec:
     - port: 9000
       targetPort: 9000
       protocol: TCP
+  {{- if eq .Values.apiserver.NodePort true }}
   type: NodePort
+  {{- else }}
+  type: ClusterIP
+  {{- end }}
+
   selector:
     app: {{ .Release.Name }}-tools
     release: {{ .Release.Name }}

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -241,10 +241,10 @@ spec:
     - port: 9000
       targetPort: 9000
       protocol: TCP
-      {{- if .Values.apiserver.nodePort.enabled }}
-      nodePort: {{ .Values.apiserver.nodePort.port }}
+      {{- if .Values.apiServer.nodePort.enabled }}
+      nodePort: {{ .Values.apiServer.nodePort.port }}
       {{- end }}
-  {{- if .Values.apiserver.nodePort.enabled }}
+  {{- if .Values.apiServer.nodePort.enabled }}
   type: NodePort
   {{- else }}
   type: ClusterIP

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -44,7 +44,9 @@ heron:
   url: "-"
 
 apiserver:
-  NodePort: 32090
+  NodePort:
+    enabled: false
+    port: 32090
 
 # Can be EQUAL_TO_LIMIT or NOT_SET
 topologyResourceRequestMode: EQUAL_TO_LIMIT

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -44,7 +44,7 @@ heron:
   url: "-"
 
 apiserver:
-  NodePort: true
+  NodePort: 32090
 
 # Can be EQUAL_TO_LIMIT or NOT_SET
 topologyResourceRequestMode: EQUAL_TO_LIMIT

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -36,17 +36,28 @@ imagePullPolicy: IfNotPresent
 # Number of replicas for the job binary in bookkeeper
 jobReplicas: 1
 
-# amount of memory to provide for API server
-apiServerMemory: 512M
-heron:
+apiServer:
+  # amount of memory to provide for API server
+  memory: 512M
+  nodePort:
+    enabled: false
+    # port can be left empty and Kubernetes will assign a random NodePort
+    port:
+
+tracker:
+  nodePort:
+    enabled: false
+    # port can be left empty and Kubernetes will assign a random NodePort
+    port:
+
+ui:
+  nodePort:
+    enabled: false
+    # port can be left empty and Kubernetes will assign a random NodePort
+    port:
   # set to `-` to set base-url to the default k8s proxy URL
   # set to `null` to remove the use of base_url
   url: "-"
-
-apiserver:
-  NodePort:
-    enabled: false
-    port: 32090
 
 # Can be EQUAL_TO_LIMIT or NOT_SET
 topologyResourceRequestMode: EQUAL_TO_LIMIT

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -43,6 +43,9 @@ heron:
   # set to `null` to remove the use of base_url
   url: "-"
 
+apiserver:
+  NodePort: true
+
 # Can be EQUAL_TO_LIMIT or NOT_SET
 topologyResourceRequestMode: EQUAL_TO_LIMIT
 


### PR DESCRIPTION
It gives an option for users to pick whether the apiserver service should be NodePort or ClusterIP.