### PR TITLE
Update pip-2020-resolver of PexBuilder

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -183,7 +183,7 @@ py_repositories()
 # pip_repositories()
 
 # for pex repos
-PEX_WHEEL = "https://pypi.python.org/packages/18/92/99270775cfc5ddb60c19588de1c475f9ff2837a6e0bbd5eaa5286a6a472b/pex-2.1.9-py2.py3-none-any.whl"
+PEX_WHEEL = "https://pypi.python.org/packages/fa/c4/5dbdce75117b60b6ffec65bc92ac25ee873b84158a55cfbffa1d49db6eb1/pex-2.1.54-py2.py3-none-any.whl"
 
 PY_WHEEL = "https://pypi.python.org/packages/53/67/9620edf7803ab867b175e4fd23c7b8bd8eba11cb761514dcd2e726ef07da/py-1.4.34-py2.py3-none-any.whl"
 
@@ -218,8 +218,8 @@ http_file(
 
 http_file(
     name = "pex_src",
-    downloaded_file_path = "pex-2.1.9-py2.py3-none-any.whl",
-    sha256 = "5cad8d960c187541f71682fc938a843ef9092aab46f27b33ace7e570325e2626",
+    downloaded_file_path = "pex-2.1.54-py2.py3-none-any.whl",
+    sha256 = "e60b006abe8abfd3c3377128e22c33f30cc6dea89e2beb463cf8360e3626db62",
     urls = [PEX_WHEEL],
 )
 

--- a/tools/rules/pex/pex_rules.bzl
+++ b/tools/rules/pex/pex_rules.bzl
@@ -179,7 +179,7 @@ def _pex_binary_impl(ctx):
     pexbuilder = ctx.executable._pexbuilder
 
     # form the arguments to pex builder
-    arguments = [] if ctx.attr.zip_safe else ["--not-zip-safe"]
+    arguments = []
     arguments += [] if ctx.attr.pex_use_wheels else ["--no-use-wheel"]
     if ctx.attr.interpreter:
         arguments += ["--python", ctx.attr.interpreter]
@@ -197,7 +197,8 @@ def _pex_binary_impl(ctx):
         "--disable-cache",
         "--python-shebang", "#!/usr/bin/env python3",
         "--no-compile",
-        manifest_file.path,
+        "--resolver-version", "pip-2020-resolver",
+        "--manifest-file", manifest_file.path,
     ]
     #EXTRA_PEX_ARGS#
 

--- a/tools/rules/pex/wrapper/pex_wrapper.py
+++ b/tools/rules/pex/wrapper/pex_wrapper.py
@@ -15,7 +15,9 @@
 """ Pex builder wrapper """
 
 import pex.bin.pex as pexbin
-from pex.common import safe_delete
+from pex.resolve import requirement_options, resolver_options, target_options
+from pex.resolve.requirement_configuration import RequirementConfiguration
+from pex.common import die, safe_delete
 from pex.tracer import TRACER
 from pex.variables import ENV
 
@@ -51,20 +53,53 @@ def parse_manifest(manifest_text):
     return json.loads(manifest_text)
 
 
-def main():
+def main(args=None):
+    args = args[:] if args else sys.argv[1:]
+    args = [pexbin.transform_legacy_arg(arg) for arg in args]
     pparser = pexbin.configure_clp()
-    poptions, args = pparser.parse_args(sys.argv)
 
-    manifest_file = args[1]
+    try:
+        separator = args.index("--")
+        args, cmdline = args[:separator], args[separator + 1:]
+    except ValueError:
+        args, cmdline = args, []
+
+    pparser.add_argument(
+            "--manifest-file",
+            dest="manifest_file",
+            default=None,
+            metavar="FILE",
+            type=str,
+            help="pex_wrapper manifest file.",
+        )
+    poptions = pparser.parse_args(args=args)
+
+    manifest_file = poptions.manifest_file
     manifest_text = open(manifest_file, 'r').read()
     manifest = parse_manifest(manifest_text)
 
     reqs = manifest.get('requirements', [])
+    requirement_configuration = RequirementConfiguration(requirements=reqs)
+    try:
+        resolver_configuration = resolver_options.configure(poptions)
+    except resolver_options.InvalidConfigurationError as e:
+        die(str(e))
+
+    try:
+        target_configuration = target_options.configure(poptions)
+    except target_options.InterpreterNotFound as e:
+        die(str(e))
+    except target_options.InterpreterConstraintsNotSatisfied as e:
+        die(str(e), exit_code=pexbin.CANNOT_SETUP_INTERPRETER)
 
     with ENV.patch(PEX_VERBOSE=str(poptions.verbosity),
                    PEX_ROOT=poptions.pex_root or ENV.PEX_ROOT):
         with TRACER.timed('Building pex'):
-            pex_builder = pexbin.build_pex(reqs, poptions)
+            pex_builder = pexbin.build_pex(
+                requirement_configuration=requirement_configuration,
+                resolver_configuration=resolver_configuration,
+                target_configuration=target_configuration,
+                options=poptions)
 
         # Add source files from the manifest
         for modmap in manifest.get('modules', []):
@@ -90,7 +125,7 @@ def main():
         for reqmap in manifest.get('resources', []):
             src = reqmap.get('src')
             dst = reqmap.get('dest')
-            pex_builder.add_resource(dereference_symlinks(src), dst)
+            pex_builder.add_source(dereference_symlinks(src), dst)
 
         # Add eggs/wheels from the manifest
         for egg in manifest.get('prebuiltLibraries', []):


### PR DESCRIPTION
Fix pip-2020-resolver of PexBuilder
- Fix failed to resolve a requirement

```
export CC=/usr/bin/clang
export CXX=/usr/bin/clang++

echo $CC $CXX
./bazel_configure.py

/usr/bin/clang /usr/bin/clang++
Platform Darwin
Using C compiler          :	/usr/bin/clang (12.0.5)
Using C++ compiler        :	/usr/bin/clang++ (12.0.5)
Using C preprocessor      :	/usr/bin/cpp (12.0.5)
Using C++ preprocessor    :	/usr/bin/cpp (12.0.5)
Using linker              :	/usr/bin/ld
Using JDK                 :	/Users/thinker0/.sdkman/candidates/java/current
Using Automake            :	/usr/local/Cellar/automake/1.16.5/bin/automake (1.16.5)
Using Autoconf            :	/usr/local/Cellar/autoconf/2.71/bin/autoconf (2.71)
Using Make                :	/usr/bin/make (3.81)
Using Python3             :	/usr/local/Cellar/python@3.8/3.8.12_1/Frameworks/Python.framework/Versions/3.8/bin/python3.8 (3.8.12)
Using Libtool             :	/usr/local/Cellar/libtool/2.4.6_4/bin/glibtool (2.4.6)
Using archiver            :	/usr/bin/ar
Using coverage tool       :	/usr/bin/gcov
Using ant                 :	/usr/local/Cellar/ant/1.10.12/bin/ant
dwp                       :	not found, but ok
Using nm                  :	/usr/bin/nm
objcopy                   :	not found, but ok
Using objdump             :	/usr/bin/objdump
Using strip               :	/usr/bin/strip
```

![image](https://user-images.githubusercontent.com/357785/140841139-7ed2dd9a-7616-40f9-b047-83156450ba5b.png)
![image](https://user-images.githubusercontent.com/357785/140841158-a8584b3f-f393-461c-bebb-4ffb43ff8463.png)
