### PR TITLE
Bump Netty to 4.1.70

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -96,7 +96,7 @@ maven_install(
         "org.glassfish.jersey.media:jersey-media-multipart:" + jersey_version,
         "org.glassfish.jersey.containers:jersey-container-servlet:" + jersey_version,
         "org.apache.distributedlog:distributedlog-core:" + distributedlog_version,
-        "io.netty:netty-all:4.1.50.Final",
+        "io.netty:netty-all:4.1.70.Final",
         "aopalliance:aopalliance:1.0",
         "org.roaringbitmap:RoaringBitmap:0.6.51",
         "com.google.guava:guava:23.6-jre",

--- a/maven_install.json
+++ b/maven_install.json
@@ -2395,218 +2395,931 @@
                 "sha256": "ebcaae3db51658c592e601079f97a3425a511092c2b5443d0af43389e9e55e7d"
             },
             {
-                "coord": "io.netty:netty-all:4.1.50.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar",
+                "coord": "io.netty:netty-all:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-all/4.1.70.Final/netty-all-4.1.70.Final.jar",
+                "directDependencies": [
+                    "io.netty:netty-codec-socks:4.1.70.Final",
+                    "io.netty:netty-handler:4.1.70.Final",
+                    "io.netty:netty-codec-http:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-codec-http2:4.1.70.Final",
+                    "io.netty:netty-codec-mqtt:4.1.70.Final",
+                    "io.netty:netty-handler-proxy:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
+                    "io.netty:netty-codec-memcache:4.1.70.Final",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-transport-sctp:4.1.70.Final",
+                    "io.netty:netty-codec-redis:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.70.Final",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
+                    "io.netty:netty-codec-xml:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:4.1.70.Final",
+                    "io.netty:netty-codec-smtp:4.1.70.Final",
+                    "io.netty:netty-codec-haproxy:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-transport-udt:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-codec-socks:4.1.70.Final",
+                    "io.netty:netty-handler:4.1.70.Final",
+                    "io.netty:netty-codec-http:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-codec-http2:4.1.70.Final",
+                    "io.netty:netty-codec-mqtt:4.1.70.Final",
+                    "io.netty:netty-handler-proxy:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
+                    "io.netty:netty-codec-memcache:4.1.70.Final",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-transport-sctp:4.1.70.Final",
+                    "io.netty:netty-codec-redis:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.70.Final",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
+                    "io.netty:netty-codec-xml:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:4.1.70.Final",
+                    "io.netty:netty-codec-smtp:4.1.70.Final",
+                    "io.netty:netty-codec-haproxy:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-transport-udt:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-all/4.1.70.Final/netty-all-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-all/4.1.70.Final/netty-all-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-all/4.1.70.Final/netty-all-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-all/4.1.70.Final/netty-all-4.1.70.Final.jar"
+                ],
+                "sha256": "0bb4af1cd0294bfcf5df2c80a63f252f3f75e6b24127bf6f077cca41fe4ecce5"
+            },
+            {
+                "coord": "io.netty:netty-buffer:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-buffer/4.1.70.Final/netty-buffer-4.1.70.Final.jar",
+                "directDependencies": [
+                    "io.netty:netty-common:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-common:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-buffer/4.1.70.Final/netty-buffer-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-buffer/4.1.70.Final/netty-buffer-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-buffer/4.1.70.Final/netty-buffer-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.70.Final/netty-buffer-4.1.70.Final.jar"
+                ],
+                "sha256": "30108c7bfc1dfec9ff050affa2815eb3883f1f1d24898c6b1959b36a2828339a"
+            },
+            {
+                "coord": "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-buffer/4.1.70.Final/netty-buffer-4.1.70.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-common:jar:sources:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-common:jar:sources:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-buffer/4.1.70.Final/netty-buffer-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-buffer/4.1.70.Final/netty-buffer-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-buffer/4.1.70.Final/netty-buffer-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.70.Final/netty-buffer-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "010d93eaa03d9adde77503f5a3fea65324575bce810e897bee4e44886e0de864"
+            },
+            {
+                "coord": "io.netty:netty-codec-dns:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-dns/4.1.70.Final/netty-codec-dns-4.1.70.Final.jar",
+                "directDependencies": [
+                    "io.netty:netty-buffer:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-codec:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-dns/4.1.70.Final/netty-codec-dns-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-dns/4.1.70.Final/netty-codec-dns-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-codec-dns/4.1.70.Final/netty-codec-dns-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-dns/4.1.70.Final/netty-codec-dns-4.1.70.Final.jar"
+                ],
+                "sha256": "7d34ff811c1864bc9ec996ee19a1d313d5c47913e0ecbe1357def59cb490fd6c"
+            },
+            {
+                "coord": "io.netty:netty-codec-dns:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-dns/4.1.70.Final/netty-codec-dns-4.1.70.Final-sources.jar",
                 "directDependencies": [],
                 "dependencies": [],
-                "url": "https://jcenter.bintray.com/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar",
-                "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar",
-                    "https://maven.google.com/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar"
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
                 ],
-                "sha256": "c9c4bf40599b706301289cf5f8ae0b3700007bfb85c0858f1bb0252737033e20"
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-dns/4.1.70.Final/netty-codec-dns-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-dns/4.1.70.Final/netty-codec-dns-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-codec-dns/4.1.70.Final/netty-codec-dns-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-dns/4.1.70.Final/netty-codec-dns-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "b7680d6734ec9a44347c071362799046075849ad5bd6f990e084b31446191ba4"
             },
             {
-                "coord": "io.netty:netty-all:jar:sources:4.1.50.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final-sources.jar",
+                "coord": "io.netty:netty-codec-haproxy:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-haproxy/4.1.70.Final/netty-codec-haproxy-4.1.70.Final.jar",
                 "directDependencies": [],
                 "dependencies": [],
-                "url": "https://jcenter.bintray.com/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final-sources.jar",
-                "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final-sources.jar",
-                    "https://maven.google.com/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final-sources.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final-sources.jar"
+                "exclusions": [
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
                 ],
-                "sha256": "7eef605e699aad5480350fd111ecca3dd1fc847f8cd575c2b0882fef35c9cdf5"
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-haproxy/4.1.70.Final/netty-codec-haproxy-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-haproxy/4.1.70.Final/netty-codec-haproxy-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-codec-haproxy/4.1.70.Final/netty-codec-haproxy-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-haproxy/4.1.70.Final/netty-codec-haproxy-4.1.70.Final.jar"
+                ],
+                "sha256": "4e01b3247e890b6e7483c8e0280051576991b8a26b3dad172cce3a3625d8774b"
             },
             {
-                "coord": "io.netty:netty-buffer:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-buffer/4.1.63.Final/netty-buffer-4.1.63.Final.jar",
-                "directDependencies": [
-                    "io.netty:netty-common:4.1.63.Final"
-                ],
-                "dependencies": [
-                    "io.netty:netty-common:4.1.63.Final"
-                ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-buffer/4.1.63.Final/netty-buffer-4.1.63.Final.jar",
-                "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-buffer/4.1.63.Final/netty-buffer-4.1.63.Final.jar",
-                    "https://maven.google.com/io/netty/netty-buffer/4.1.63.Final/netty-buffer-4.1.63.Final.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.63.Final/netty-buffer-4.1.63.Final.jar"
-                ],
-                "sha256": "f7fb235fdf125bddb0b65cc3473a7cfef120a42ca07f3faf7cb381016cbd7d81"
-            },
-            {
-                "coord": "io.netty:netty-buffer:jar:sources:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-buffer/4.1.63.Final/netty-buffer-4.1.63.Final-sources.jar",
-                "directDependencies": [
-                    "io.netty:netty-common:jar:sources:4.1.63.Final"
-                ],
-                "dependencies": [
-                    "io.netty:netty-common:jar:sources:4.1.63.Final"
-                ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-buffer/4.1.63.Final/netty-buffer-4.1.63.Final-sources.jar",
-                "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-buffer/4.1.63.Final/netty-buffer-4.1.63.Final-sources.jar",
-                    "https://maven.google.com/io/netty/netty-buffer/4.1.63.Final/netty-buffer-4.1.63.Final-sources.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.63.Final/netty-buffer-4.1.63.Final-sources.jar"
-                ],
-                "sha256": "d341f80b7c5eaa95fcb25cbb27321610c09695157f90cf06e679c258b9920b82"
-            },
-            {
-                "coord": "io.netty:netty-codec:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec/4.1.63.Final/netty-codec-4.1.63.Final.jar",
-                "directDependencies": [
-                    "io.netty:netty-buffer:4.1.63.Final",
-                    "io.netty:netty-common:4.1.63.Final",
-                    "io.netty:netty-transport:4.1.63.Final"
-                ],
-                "dependencies": [
-                    "io.netty:netty-common:4.1.63.Final",
-                    "io.netty:netty-resolver:4.1.63.Final",
-                    "io.netty:netty-buffer:4.1.63.Final",
-                    "io.netty:netty-transport:4.1.63.Final"
-                ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-codec/4.1.63.Final/netty-codec-4.1.63.Final.jar",
-                "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-codec/4.1.63.Final/netty-codec-4.1.63.Final.jar",
-                    "https://maven.google.com/io/netty/netty-codec/4.1.63.Final/netty-codec-4.1.63.Final.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.63.Final/netty-codec-4.1.63.Final.jar"
-                ],
-                "sha256": "642f48374272a19d8e323f9b775f468918e3965b212f1611c5ea1d8649979640"
-            },
-            {
-                "coord": "io.netty:netty-codec:jar:sources:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec/4.1.63.Final/netty-codec-4.1.63.Final-sources.jar",
-                "directDependencies": [
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final"
-                ],
-                "dependencies": [
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final"
-                ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-codec/4.1.63.Final/netty-codec-4.1.63.Final-sources.jar",
-                "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-codec/4.1.63.Final/netty-codec-4.1.63.Final-sources.jar",
-                    "https://maven.google.com/io/netty/netty-codec/4.1.63.Final/netty-codec-4.1.63.Final-sources.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.63.Final/netty-codec-4.1.63.Final-sources.jar"
-                ],
-                "sha256": "af23b88c6f1e9a3b8e31a026d8e3100ad3b222030df4ffd0ca0a32b54f76c0bd"
-            },
-            {
-                "coord": "io.netty:netty-common:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-common/4.1.63.Final/netty-common-4.1.63.Final.jar",
+                "coord": "io.netty:netty-codec-haproxy:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-haproxy/4.1.70.Final/netty-codec-haproxy-4.1.70.Final-sources.jar",
                 "directDependencies": [],
                 "dependencies": [],
-                "url": "https://jcenter.bintray.com/io/netty/netty-common/4.1.63.Final/netty-common-4.1.63.Final.jar",
-                "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-common/4.1.63.Final/netty-common-4.1.63.Final.jar",
-                    "https://maven.google.com/io/netty/netty-common/4.1.63.Final/netty-common-4.1.63.Final.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-common/4.1.63.Final/netty-common-4.1.63.Final.jar"
+                "exclusions": [
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
                 ],
-                "sha256": "c9fbf7c5e777f08475e8564a83d6b3cb1e855b6899a1d498684ba4849802e96c"
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-haproxy/4.1.70.Final/netty-codec-haproxy-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-haproxy/4.1.70.Final/netty-codec-haproxy-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-codec-haproxy/4.1.70.Final/netty-codec-haproxy-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-haproxy/4.1.70.Final/netty-codec-haproxy-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "e0c0bfadfaa89508f98d154328a4b27a1d6eaeed18509661e656a139086db978"
             },
             {
-                "coord": "io.netty:netty-common:jar:sources:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-common/4.1.63.Final/netty-common-4.1.63.Final-sources.jar",
+                "coord": "io.netty:netty-codec-http2:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-http2/4.1.70.Final/netty-codec-http2-4.1.70.Final.jar",
                 "directDependencies": [],
                 "dependencies": [],
-                "url": "https://jcenter.bintray.com/io/netty/netty-common/4.1.63.Final/netty-common-4.1.63.Final-sources.jar",
-                "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-common/4.1.63.Final/netty-common-4.1.63.Final-sources.jar",
-                    "https://maven.google.com/io/netty/netty-common/4.1.63.Final/netty-common-4.1.63.Final-sources.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-common/4.1.63.Final/netty-common-4.1.63.Final-sources.jar"
+                "exclusions": [
+                    "io.netty:netty-codec-http",
+                    "com.github.luben:zstd-jni",
+                    "com.aayushatharva.brotli4j:brotli4j",
+                    "io.netty:netty-common",
+                    "io.netty:netty-handler",
+                    "com.jcraft:jzlib",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-codec",
+                    "io.netty:netty-transport"
                 ],
-                "sha256": "18e830e2290ec07c3a710aa816569fc488fc32948fa071bce9504c522a67d2b9"
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-http2/4.1.70.Final/netty-codec-http2-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-http2/4.1.70.Final/netty-codec-http2-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-codec-http2/4.1.70.Final/netty-codec-http2-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.70.Final/netty-codec-http2-4.1.70.Final.jar"
+                ],
+                "sha256": "f837d7960166ade34d836f0920542e85ebfbcfcc9c2170706bdd1e1bdeb46dad"
             },
             {
-                "coord": "io.netty:netty-handler:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-handler/4.1.63.Final/netty-handler-4.1.63.Final.jar",
-                "directDependencies": [
-                    "io.netty:netty-codec:4.1.63.Final",
-                    "io.netty:netty-resolver:4.1.63.Final",
-                    "io.netty:netty-buffer:4.1.63.Final",
-                    "io.netty:netty-common:4.1.63.Final",
-                    "io.netty:netty-transport:4.1.63.Final"
+                "coord": "io.netty:netty-codec-http2:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-http2/4.1.70.Final/netty-codec-http2-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-codec-http",
+                    "com.github.luben:zstd-jni",
+                    "com.aayushatharva.brotli4j:brotli4j",
+                    "io.netty:netty-common",
+                    "io.netty:netty-handler",
+                    "com.jcraft:jzlib",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-codec",
+                    "io.netty:netty-transport"
                 ],
-                "dependencies": [
-                    "io.netty:netty-codec:4.1.63.Final",
-                    "io.netty:netty-resolver:4.1.63.Final",
-                    "io.netty:netty-buffer:4.1.63.Final",
-                    "io.netty:netty-common:4.1.63.Final",
-                    "io.netty:netty-transport:4.1.63.Final"
-                ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-handler/4.1.63.Final/netty-handler-4.1.63.Final.jar",
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-http2/4.1.70.Final/netty-codec-http2-4.1.70.Final-sources.jar",
                 "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-handler/4.1.63.Final/netty-handler-4.1.63.Final.jar",
-                    "https://maven.google.com/io/netty/netty-handler/4.1.63.Final/netty-handler-4.1.63.Final.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.63.Final/netty-handler-4.1.63.Final.jar"
+                    "https://jcenter.bintray.com/io/netty/netty-codec-http2/4.1.70.Final/netty-codec-http2-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-codec-http2/4.1.70.Final/netty-codec-http2-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.70.Final/netty-codec-http2-4.1.70.Final-sources.jar"
                 ],
-                "sha256": "aafd714a00e03eae36b4addbde2be44db8baa358d0d36edc8fbb506486a555fc"
+                "sha256": "bcf44e5296bcdd938077242f6399a39072685562d929a42a5375a128ebe85d66"
             },
             {
-                "coord": "io.netty:netty-handler:jar:sources:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-handler/4.1.63.Final/netty-handler-4.1.63.Final-sources.jar",
-                "directDependencies": [
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.63.Final"
+                "coord": "io.netty:netty-codec-http:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-http/4.1.70.Final/netty-codec-http-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "com.github.luben:zstd-jni",
+                    "com.aayushatharva.brotli4j:brotli4j",
+                    "io.netty:netty-common",
+                    "io.netty:netty-handler",
+                    "com.jcraft:jzlib",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-codec",
+                    "io.netty:netty-transport"
                 ],
-                "dependencies": [
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.63.Final"
-                ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-handler/4.1.63.Final/netty-handler-4.1.63.Final-sources.jar",
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-http/4.1.70.Final/netty-codec-http-4.1.70.Final.jar",
                 "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-handler/4.1.63.Final/netty-handler-4.1.63.Final-sources.jar",
-                    "https://maven.google.com/io/netty/netty-handler/4.1.63.Final/netty-handler-4.1.63.Final-sources.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.63.Final/netty-handler-4.1.63.Final-sources.jar"
+                    "https://jcenter.bintray.com/io/netty/netty-codec-http/4.1.70.Final/netty-codec-http-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-codec-http/4.1.70.Final/netty-codec-http-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.70.Final/netty-codec-http-4.1.70.Final.jar"
                 ],
-                "sha256": "a19d3cfe349d6f2c40131d20e0faad042b64b354b90ad15e32136824309a461d"
+                "sha256": "cf06a6b26ac9ecab9925da7fd270abd31a6161a46eb9f9ad6b07bc8bdebbf845"
             },
             {
-                "coord": "io.netty:netty-resolver:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-resolver/4.1.63.Final/netty-resolver-4.1.63.Final.jar",
-                "directDependencies": [
-                    "io.netty:netty-common:4.1.63.Final"
+                "coord": "io.netty:netty-codec-http:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-http/4.1.70.Final/netty-codec-http-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "com.github.luben:zstd-jni",
+                    "com.aayushatharva.brotli4j:brotli4j",
+                    "io.netty:netty-common",
+                    "io.netty:netty-handler",
+                    "com.jcraft:jzlib",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-codec",
+                    "io.netty:netty-transport"
                 ],
-                "dependencies": [
-                    "io.netty:netty-common:4.1.63.Final"
-                ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-resolver/4.1.63.Final/netty-resolver-4.1.63.Final.jar",
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-http/4.1.70.Final/netty-codec-http-4.1.70.Final-sources.jar",
                 "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-resolver/4.1.63.Final/netty-resolver-4.1.63.Final.jar",
-                    "https://maven.google.com/io/netty/netty-resolver/4.1.63.Final/netty-resolver-4.1.63.Final.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.63.Final/netty-resolver-4.1.63.Final.jar"
+                    "https://jcenter.bintray.com/io/netty/netty-codec-http/4.1.70.Final/netty-codec-http-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-codec-http/4.1.70.Final/netty-codec-http-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.70.Final/netty-codec-http-4.1.70.Final-sources.jar"
                 ],
-                "sha256": "08ca66adc460cee7bfb3b9f48971e0a758633490ab0d35df05969922c1ab7393"
+                "sha256": "121a1c1541c6872af7e3de95675c79f4ac1e623b0f65aa54a118240ed8d85bd4"
             },
             {
-                "coord": "io.netty:netty-resolver:jar:sources:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-resolver/4.1.63.Final/netty-resolver-4.1.63.Final-sources.jar",
+                "coord": "io.netty:netty-codec-memcache:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-memcache/4.1.70.Final/netty-codec-memcache-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-memcache/4.1.70.Final/netty-codec-memcache-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-memcache/4.1.70.Final/netty-codec-memcache-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-codec-memcache/4.1.70.Final/netty-codec-memcache-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-memcache/4.1.70.Final/netty-codec-memcache-4.1.70.Final.jar"
+                ],
+                "sha256": "94a882928e263513b2715f8e759b0819642b8f75c6c7cb4fea61fa13fe437562"
+            },
+            {
+                "coord": "io.netty:netty-codec-memcache:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-memcache/4.1.70.Final/netty-codec-memcache-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-memcache/4.1.70.Final/netty-codec-memcache-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-memcache/4.1.70.Final/netty-codec-memcache-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-codec-memcache/4.1.70.Final/netty-codec-memcache-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-memcache/4.1.70.Final/netty-codec-memcache-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "ad1969cbaea66c3293159f1bf2cdcea994f4052984355c3f65e5eb35aa68b24e"
+            },
+            {
+                "coord": "io.netty:netty-codec-mqtt:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-mqtt/4.1.70.Final/netty-codec-mqtt-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-mqtt/4.1.70.Final/netty-codec-mqtt-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-mqtt/4.1.70.Final/netty-codec-mqtt-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-codec-mqtt/4.1.70.Final/netty-codec-mqtt-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-mqtt/4.1.70.Final/netty-codec-mqtt-4.1.70.Final.jar"
+                ],
+                "sha256": "fada5215206bbe85f4c464041687b91ee69271dcde65839fd4f9a5524388d6e3"
+            },
+            {
+                "coord": "io.netty:netty-codec-mqtt:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-mqtt/4.1.70.Final/netty-codec-mqtt-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-mqtt/4.1.70.Final/netty-codec-mqtt-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-mqtt/4.1.70.Final/netty-codec-mqtt-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-codec-mqtt/4.1.70.Final/netty-codec-mqtt-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-mqtt/4.1.70.Final/netty-codec-mqtt-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "7406ef11821be0887cc438dec41696bf26bb7d48aab2ae60b5f01ffa9bfb1fcd"
+            },
+            {
+                "coord": "io.netty:netty-codec-redis:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-redis/4.1.70.Final/netty-codec-redis-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-redis/4.1.70.Final/netty-codec-redis-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-redis/4.1.70.Final/netty-codec-redis-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-codec-redis/4.1.70.Final/netty-codec-redis-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-redis/4.1.70.Final/netty-codec-redis-4.1.70.Final.jar"
+                ],
+                "sha256": "9eae13e61138ae9f68c7d3dfa68212cc73bf23c35c6ccd8905a11c76508c48d3"
+            },
+            {
+                "coord": "io.netty:netty-codec-redis:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-redis/4.1.70.Final/netty-codec-redis-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-redis/4.1.70.Final/netty-codec-redis-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-redis/4.1.70.Final/netty-codec-redis-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-codec-redis/4.1.70.Final/netty-codec-redis-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-redis/4.1.70.Final/netty-codec-redis-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "84d4440f67a6006563c7e1cc3da059d401ede36bb8a084f123d43af27711ab57"
+            },
+            {
+                "coord": "io.netty:netty-codec-smtp:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-smtp/4.1.70.Final/netty-codec-smtp-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-smtp/4.1.70.Final/netty-codec-smtp-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-smtp/4.1.70.Final/netty-codec-smtp-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-codec-smtp/4.1.70.Final/netty-codec-smtp-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-smtp/4.1.70.Final/netty-codec-smtp-4.1.70.Final.jar"
+                ],
+                "sha256": "6ae86df4cc2911764a7a7e083e16d90ced5f6ae16f7787a2dae48f3424fe6112"
+            },
+            {
+                "coord": "io.netty:netty-codec-smtp:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-smtp/4.1.70.Final/netty-codec-smtp-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-smtp/4.1.70.Final/netty-codec-smtp-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-smtp/4.1.70.Final/netty-codec-smtp-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-codec-smtp/4.1.70.Final/netty-codec-smtp-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-smtp/4.1.70.Final/netty-codec-smtp-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "7491c46d6e84c17e9f150ca2dc998b76f118b248d8881732d83f7fc9617aa537"
+            },
+            {
+                "coord": "io.netty:netty-codec-socks:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-socks/4.1.70.Final/netty-codec-socks-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-socks/4.1.70.Final/netty-codec-socks-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-socks/4.1.70.Final/netty-codec-socks-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-codec-socks/4.1.70.Final/netty-codec-socks-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.70.Final/netty-codec-socks-4.1.70.Final.jar"
+                ],
+                "sha256": "9911e4ffd478a120ab8fa6ea57c1a0b2f680f177ad311a25c0bbea6644d36814"
+            },
+            {
+                "coord": "io.netty:netty-codec-socks:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-socks/4.1.70.Final/netty-codec-socks-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-socks/4.1.70.Final/netty-codec-socks-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-socks/4.1.70.Final/netty-codec-socks-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-codec-socks/4.1.70.Final/netty-codec-socks-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.70.Final/netty-codec-socks-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "bd0ab58ace8d3050f6f6c9b11cc7bc11d5a28f1e3f1ce7e4e044da86e894a5b1"
+            },
+            {
+                "coord": "io.netty:netty-codec-stomp:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-stomp/4.1.70.Final/netty-codec-stomp-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-stomp/4.1.70.Final/netty-codec-stomp-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-stomp/4.1.70.Final/netty-codec-stomp-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-codec-stomp/4.1.70.Final/netty-codec-stomp-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-stomp/4.1.70.Final/netty-codec-stomp-4.1.70.Final.jar"
+                ],
+                "sha256": "57a551bcac1761d5c18f48f9c7888d5c0e8af2aaf0c5ae2cb64c929b1ec7cbba"
+            },
+            {
+                "coord": "io.netty:netty-codec-stomp:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-stomp/4.1.70.Final/netty-codec-stomp-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-stomp/4.1.70.Final/netty-codec-stomp-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-stomp/4.1.70.Final/netty-codec-stomp-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-codec-stomp/4.1.70.Final/netty-codec-stomp-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-stomp/4.1.70.Final/netty-codec-stomp-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "e928b9032f254ba76a5c22d06131a3ea0dba84169e715e218903b66b05a155cb"
+            },
+            {
+                "coord": "io.netty:netty-codec-xml:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-xml/4.1.70.Final/netty-codec-xml-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec",
+                    "com.fasterxml:aalto-xml"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-xml/4.1.70.Final/netty-codec-xml-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-xml/4.1.70.Final/netty-codec-xml-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-codec-xml/4.1.70.Final/netty-codec-xml-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-xml/4.1.70.Final/netty-codec-xml-4.1.70.Final.jar"
+                ],
+                "sha256": "b008a9df46920fcfdf666e67f56ad75a7b0f3864707e6c55d6dee8f69e4dc185"
+            },
+            {
+                "coord": "io.netty:netty-codec-xml:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec-xml/4.1.70.Final/netty-codec-xml-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-codec",
+                    "com.fasterxml:aalto-xml"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec-xml/4.1.70.Final/netty-codec-xml-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec-xml/4.1.70.Final/netty-codec-xml-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-codec-xml/4.1.70.Final/netty-codec-xml-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-xml/4.1.70.Final/netty-codec-xml-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "57660bd76eb1977b9a8dfc008e7f092ae81b18687661936e3575842712c70d3a"
+            },
+            {
+                "coord": "io.netty:netty-codec:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec/4.1.70.Final/netty-codec-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "org.jboss.marshalling:jboss-marshalling",
+                    "com.github.luben:zstd-jni",
+                    "com.aayushatharva.brotli4j:native-linux-x86_64",
+                    "com.aayushatharva.brotli4j:brotli4j",
+                    "com.aayushatharva.brotli4j:native-windows-x86_64",
+                    "io.netty:netty-common",
+                    "com.github.jponge:lzma-java",
+                    "com.aayushatharva.brotli4j:native-osx-x86_64",
+                    "com.jcraft:jzlib",
+                    "io.netty:netty-buffer",
+                    "com.google.protobuf:protobuf-java",
+                    "com.ning:compress-lzf",
+                    "io.netty:netty-transport",
+                    "net.jpountz.lz4:lz4",
+                    "com.google.protobuf.nano:protobuf-javanano"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec/4.1.70.Final/netty-codec-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec/4.1.70.Final/netty-codec-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-codec/4.1.70.Final/netty-codec-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.70.Final/netty-codec-4.1.70.Final.jar"
+                ],
+                "sha256": "7268a42a3255a1209dc291b703092fd7b8e5c2e78a263e83991c7ecf3016388a"
+            },
+            {
+                "coord": "io.netty:netty-codec:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-codec/4.1.70.Final/netty-codec-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "org.jboss.marshalling:jboss-marshalling",
+                    "com.github.luben:zstd-jni",
+                    "com.aayushatharva.brotli4j:native-linux-x86_64",
+                    "com.aayushatharva.brotli4j:brotli4j",
+                    "com.aayushatharva.brotli4j:native-windows-x86_64",
+                    "io.netty:netty-common",
+                    "com.github.jponge:lzma-java",
+                    "com.aayushatharva.brotli4j:native-osx-x86_64",
+                    "com.jcraft:jzlib",
+                    "io.netty:netty-buffer",
+                    "com.google.protobuf:protobuf-java",
+                    "com.ning:compress-lzf",
+                    "io.netty:netty-transport",
+                    "net.jpountz.lz4:lz4",
+                    "com.google.protobuf.nano:protobuf-javanano"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-codec/4.1.70.Final/netty-codec-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-codec/4.1.70.Final/netty-codec-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-codec/4.1.70.Final/netty-codec-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.70.Final/netty-codec-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "27bd5b30362e70e490d0cf98dc524d1d78777f1a28bca4e5f4e64d10f9db647e"
+            },
+            {
+                "coord": "io.netty:netty-common:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-common/4.1.70.Final/netty-common-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "org.apache.logging.log4j:log4j-1.2-api",
+                    "commons-logging:commons-logging",
+                    "org.graalvm.nativeimage:svm",
+                    "io.projectreactor.tools:blockhound",
+                    "org.slf4j:slf4j-api",
+                    "org.apache.logging.log4j:log4j-api"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-common/4.1.70.Final/netty-common-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-common/4.1.70.Final/netty-common-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-common/4.1.70.Final/netty-common-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-common/4.1.70.Final/netty-common-4.1.70.Final.jar"
+                ],
+                "sha256": "11196ace142d8f5edc1bfbf96c7f64ac69f57a31971b8f67af957c5c701b13f5"
+            },
+            {
+                "coord": "io.netty:netty-common:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-common/4.1.70.Final/netty-common-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "org.apache.logging.log4j:log4j-1.2-api",
+                    "commons-logging:commons-logging",
+                    "org.graalvm.nativeimage:svm",
+                    "io.projectreactor.tools:blockhound",
+                    "org.slf4j:slf4j-api",
+                    "org.apache.logging.log4j:log4j-api"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-common/4.1.70.Final/netty-common-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-common/4.1.70.Final/netty-common-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-common/4.1.70.Final/netty-common-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-common/4.1.70.Final/netty-common-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "de623bb754aec2eb604ce7b6595c83c6d1c8c09dc24f6c8c1ddc8c25b659b342"
+            },
+            {
+                "coord": "io.netty:netty-handler-proxy:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-handler-proxy/4.1.70.Final/netty-handler-proxy-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-codec-http",
+                    "io.netty:netty-common",
+                    "io.netty:netty-codec-socks",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-codec",
+                    "io.netty:netty-transport"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-handler-proxy/4.1.70.Final/netty-handler-proxy-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-handler-proxy/4.1.70.Final/netty-handler-proxy-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-handler-proxy/4.1.70.Final/netty-handler-proxy-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-handler-proxy/4.1.70.Final/netty-handler-proxy-4.1.70.Final.jar"
+                ],
+                "sha256": "08f8f8bf09c405903884290a4aa8758bc3a0f1ab6d86b45e40b0b83e8648ea23"
+            },
+            {
+                "coord": "io.netty:netty-handler-proxy:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-handler-proxy/4.1.70.Final/netty-handler-proxy-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-codec-http",
+                    "io.netty:netty-common",
+                    "io.netty:netty-codec-socks",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-codec",
+                    "io.netty:netty-transport"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-handler-proxy/4.1.70.Final/netty-handler-proxy-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-handler-proxy/4.1.70.Final/netty-handler-proxy-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-handler-proxy/4.1.70.Final/netty-handler-proxy-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-handler-proxy/4.1.70.Final/netty-handler-proxy-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "d2280b31a162d95d64e66f945fd2cf541b924bf53316122a900dc91c89c09181"
+            },
+            {
+                "coord": "io.netty:netty-handler:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-handler/4.1.70.Final/netty-handler-4.1.70.Final.jar",
                 "directDependencies": [
-                    "io.netty:netty-common:jar:sources:4.1.63.Final"
+                    "io.netty:netty-codec:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "dependencies": [
-                    "io.netty:netty-common:jar:sources:4.1.63.Final"
+                    "io.netty:netty-codec:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-resolver/4.1.63.Final/netty-resolver-4.1.63.Final-sources.jar",
+                "url": "https://jcenter.bintray.com/io/netty/netty-handler/4.1.70.Final/netty-handler-4.1.70.Final.jar",
                 "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-resolver/4.1.63.Final/netty-resolver-4.1.63.Final-sources.jar",
-                    "https://maven.google.com/io/netty/netty-resolver/4.1.63.Final/netty-resolver-4.1.63.Final-sources.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.63.Final/netty-resolver-4.1.63.Final-sources.jar"
+                    "https://jcenter.bintray.com/io/netty/netty-handler/4.1.70.Final/netty-handler-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-handler/4.1.70.Final/netty-handler-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.70.Final/netty-handler-4.1.70.Final.jar"
                 ],
-                "sha256": "a84a025907278f20819c8f723385a663b56070acf8eca0d098017bb0f92ef0fd"
+                "sha256": "97fcae516c2db0e8d6c7d3de369a3b2aec466b592e44c2a5a2c95176ec331b0e"
+            },
+            {
+                "coord": "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-handler/4.1.70.Final/netty-handler-4.1.70.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-handler/4.1.70.Final/netty-handler-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-handler/4.1.70.Final/netty-handler-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-handler/4.1.70.Final/netty-handler-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.70.Final/netty-handler-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "0d7b06fc5968981a4676467e43cd3d602fcdf6f5b3a1b1fd3d83a588cfe1d9f1"
+            },
+            {
+                "coord": "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-resolver-dns-classes-macos/4.1.70.Final/netty-resolver-dns-classes-macos-4.1.70.Final.jar",
+                "directDependencies": [
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-handler:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-resolver-dns-classes-macos/4.1.70.Final/netty-resolver-dns-classes-macos-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-resolver-dns-classes-macos/4.1.70.Final/netty-resolver-dns-classes-macos-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-resolver-dns-classes-macos/4.1.70.Final/netty-resolver-dns-classes-macos-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-resolver-dns-classes-macos/4.1.70.Final/netty-resolver-dns-classes-macos-4.1.70.Final.jar"
+                ],
+                "sha256": "185018c012fbf912a82cfdfa7ebbb395bdfdbb6083a70464511043191ce52a52"
+            },
+            {
+                "coord": "io.netty:netty-resolver-dns-classes-macos:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-resolver-dns-classes-macos/4.1.70.Final/netty-resolver-dns-classes-macos-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-resolver-dns",
+                    "io.netty:netty-transport-native-unix-common"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-resolver-dns-classes-macos/4.1.70.Final/netty-resolver-dns-classes-macos-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-resolver-dns-classes-macos/4.1.70.Final/netty-resolver-dns-classes-macos-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-resolver-dns-classes-macos/4.1.70.Final/netty-resolver-dns-classes-macos-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-resolver-dns-classes-macos/4.1.70.Final/netty-resolver-dns-classes-macos-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "077fb6ee8de3db0d890889d61a69973f14292955b59e219e576c04c3a1b1176d"
+            },
+            {
+                "coord": "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-resolver-dns-native-macos/4.1.70.Final/netty-resolver-dns-native-macos-4.1.70.Final-osx-aarch_64.jar",
+                "directDependencies": [
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-handler:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-resolver-dns-native-macos/4.1.70.Final/netty-resolver-dns-native-macos-4.1.70.Final-osx-aarch_64.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-resolver-dns-native-macos/4.1.70.Final/netty-resolver-dns-native-macos-4.1.70.Final-osx-aarch_64.jar",
+                    "https://maven.google.com/io/netty/netty-resolver-dns-native-macos/4.1.70.Final/netty-resolver-dns-native-macos-4.1.70.Final-osx-aarch_64.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-resolver-dns-native-macos/4.1.70.Final/netty-resolver-dns-native-macos-4.1.70.Final-osx-aarch_64.jar"
+                ],
+                "sha256": "5afe45ade7bed1b44beae4d6b2b5389ebfff42b3992c8e184058d4fc1d78ea90"
+            },
+            {
+                "coord": "io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-resolver-dns-native-macos/4.1.70.Final/netty-resolver-dns-native-macos-4.1.70.Final-osx-x86_64.jar",
+                "directDependencies": [
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-handler:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-resolver-dns-native-macos/4.1.70.Final/netty-resolver-dns-native-macos-4.1.70.Final-osx-x86_64.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-resolver-dns-native-macos/4.1.70.Final/netty-resolver-dns-native-macos-4.1.70.Final-osx-x86_64.jar",
+                    "https://maven.google.com/io/netty/netty-resolver-dns-native-macos/4.1.70.Final/netty-resolver-dns-native-macos-4.1.70.Final-osx-x86_64.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-resolver-dns-native-macos/4.1.70.Final/netty-resolver-dns-native-macos-4.1.70.Final-osx-x86_64.jar"
+                ],
+                "sha256": "e524374937754bd47025d43d52584facf5da4442fd24adbba59aa100a5e9e2a7"
+            },
+            {
+                "coord": "io.netty:netty-resolver-dns:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-resolver-dns/4.1.70.Final/netty-resolver-dns-4.1.70.Final.jar",
+                "directDependencies": [
+                    "io.netty:netty-handler:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-handler:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-resolver-dns/4.1.70.Final/netty-resolver-dns-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-resolver-dns/4.1.70.Final/netty-resolver-dns-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-resolver-dns/4.1.70.Final/netty-resolver-dns-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/4.1.70.Final/netty-resolver-dns-4.1.70.Final.jar"
+                ],
+                "sha256": "27e0972a6dea52a8ebf06020bbc5e1f54521b21c2f962b089fdb1e2978644d45"
+            },
+            {
+                "coord": "io.netty:netty-resolver-dns:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-resolver-dns/4.1.70.Final/netty-resolver-dns-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-resolver",
+                    "io.netty:netty-common",
+                    "io.netty:netty-handler",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-codec",
+                    "io.netty:netty-codec-dns",
+                    "io.netty:netty-transport"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-resolver-dns/4.1.70.Final/netty-resolver-dns-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-resolver-dns/4.1.70.Final/netty-resolver-dns-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-resolver-dns/4.1.70.Final/netty-resolver-dns-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/4.1.70.Final/netty-resolver-dns-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "cc51f032dad80b00d253544644f2a67da8593a3e4560d96820466ed2a8718b3f"
+            },
+            {
+                "coord": "io.netty:netty-resolver:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-resolver/4.1.70.Final/netty-resolver-4.1.70.Final.jar",
+                "directDependencies": [
+                    "io.netty:netty-common:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-common:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-resolver/4.1.70.Final/netty-resolver-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-resolver/4.1.70.Final/netty-resolver-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-resolver/4.1.70.Final/netty-resolver-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.70.Final/netty-resolver-4.1.70.Final.jar"
+                ],
+                "sha256": "2e72b07669ebd36ea6d66c558c5fd798ba873fc5976b057f53b2417ed76ead98"
+            },
+            {
+                "coord": "io.netty:netty-resolver:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-resolver/4.1.70.Final/netty-resolver-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-resolver/4.1.70.Final/netty-resolver-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-resolver/4.1.70.Final/netty-resolver-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-resolver/4.1.70.Final/netty-resolver-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.70.Final/netty-resolver-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "410ac558f5f76321b1e2d8f512117dd98515862ebddaa313aa9dcc97d9c916dd"
             },
             {
                 "coord": "io.netty:netty-tcnative-boringssl-static:2.0.31.Final",
@@ -2635,162 +3348,458 @@
                 "sha256": "48cd8655aa0add5eba3acc99ed125781721f43959ccb93f245c810b6dd4ee5bf"
             },
             {
-                "coord": "io.netty:netty-transport-native-epoll:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final.jar",
+                "coord": "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-classes-epoll/4.1.70.Final/netty-transport-classes-epoll-4.1.70.Final.jar",
                 "directDependencies": [
-                    "io.netty:netty-buffer:4.1.63.Final",
-                    "io.netty:netty-common:4.1.63.Final",
-                    "io.netty:netty-transport:4.1.63.Final",
-                    "io.netty:netty-transport-native-unix-common:4.1.63.Final"
+                    "io.netty:netty-buffer:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final"
                 ],
                 "dependencies": [
-                    "io.netty:netty-resolver:4.1.63.Final",
-                    "io.netty:netty-buffer:4.1.63.Final",
-                    "io.netty:netty-transport-native-unix-common:4.1.63.Final",
-                    "io.netty:netty-common:4.1.63.Final",
-                    "io.netty:netty-transport:4.1.63.Final"
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final.jar",
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-classes-epoll/4.1.70.Final/netty-transport-classes-epoll-4.1.70.Final.jar",
                 "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final.jar",
-                    "https://maven.google.com/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final.jar"
+                    "https://jcenter.bintray.com/io/netty/netty-transport-classes-epoll/4.1.70.Final/netty-transport-classes-epoll-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-transport-classes-epoll/4.1.70.Final/netty-transport-classes-epoll-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-classes-epoll/4.1.70.Final/netty-transport-classes-epoll-4.1.70.Final.jar"
                 ],
-                "sha256": "a2eeeeb80c3b8a3c97d5348e53a89496164f738c618562d136e25d8a481b537f"
+                "sha256": "f5115083a965a2642f110ce41bf111cdc91dcebd46dd8c5289902087cad58a4d"
             },
             {
-                "coord": "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final-linux-x86_64.jar",
+                "coord": "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-classes-epoll/4.1.70.Final/netty-transport-classes-epoll-4.1.70.Final-sources.jar",
                 "directDependencies": [
-                    "io.netty:netty-buffer:4.1.63.Final",
-                    "io.netty:netty-common:4.1.63.Final",
-                    "io.netty:netty-transport:4.1.63.Final",
-                    "io.netty:netty-transport-native-unix-common:4.1.63.Final"
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final"
                 ],
                 "dependencies": [
-                    "io.netty:netty-resolver:4.1.63.Final",
-                    "io.netty:netty-buffer:4.1.63.Final",
-                    "io.netty:netty-transport-native-unix-common:4.1.63.Final",
-                    "io.netty:netty-common:4.1.63.Final",
-                    "io.netty:netty-transport:4.1.63.Final"
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final"
                 ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final-linux-x86_64.jar",
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-classes-epoll/4.1.70.Final/netty-transport-classes-epoll-4.1.70.Final-sources.jar",
                 "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final-linux-x86_64.jar",
-                    "https://maven.google.com/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final-linux-x86_64.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final-linux-x86_64.jar"
+                    "https://jcenter.bintray.com/io/netty/netty-transport-classes-epoll/4.1.70.Final/netty-transport-classes-epoll-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-transport-classes-epoll/4.1.70.Final/netty-transport-classes-epoll-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-classes-epoll/4.1.70.Final/netty-transport-classes-epoll-4.1.70.Final-sources.jar"
                 ],
-                "sha256": "879d0bc91e68fab06c66dafa0b632e175ea45281f32f81d4e916868ea8b5f033"
+                "sha256": "d26857b99178add120d56b49f38f62983a3cc23989452143e0d8ae41184eb144"
             },
             {
-                "coord": "io.netty:netty-transport-native-epoll:jar:sources:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final-sources.jar",
-                "directDependencies": [
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.63.Final"
+                "coord": "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-classes-kqueue/4.1.70.Final/netty-transport-classes-kqueue-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-transport-native-unix-common"
                 ],
-                "dependencies": [
-                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final"
-                ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final-sources.jar",
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-classes-kqueue/4.1.70.Final/netty-transport-classes-kqueue-4.1.70.Final.jar",
                 "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final-sources.jar",
-                    "https://maven.google.com/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final-sources.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.63.Final/netty-transport-native-epoll-4.1.63.Final-sources.jar"
+                    "https://jcenter.bintray.com/io/netty/netty-transport-classes-kqueue/4.1.70.Final/netty-transport-classes-kqueue-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-transport-classes-kqueue/4.1.70.Final/netty-transport-classes-kqueue-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-classes-kqueue/4.1.70.Final/netty-transport-classes-kqueue-4.1.70.Final.jar"
                 ],
-                "sha256": "c8b65c3eb40167a71f4f8e169f3020ef76436092d76555a96a65caa5a0700d3c"
+                "sha256": "46b1a64b349d366b20fe299f519e0a58d7eb6090945761cd7c875236853db467"
             },
             {
-                "coord": "io.netty:netty-transport-native-unix-common:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-unix-common/4.1.63.Final/netty-transport-native-unix-common-4.1.63.Final.jar",
-                "directDependencies": [
-                    "io.netty:netty-buffer:4.1.63.Final",
-                    "io.netty:netty-common:4.1.63.Final",
-                    "io.netty:netty-transport:4.1.63.Final"
+                "coord": "io.netty:netty-transport-classes-kqueue:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-classes-kqueue/4.1.70.Final/netty-transport-classes-kqueue-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "io.netty:netty-transport-native-unix-common"
                 ],
-                "dependencies": [
-                    "io.netty:netty-common:4.1.63.Final",
-                    "io.netty:netty-resolver:4.1.63.Final",
-                    "io.netty:netty-buffer:4.1.63.Final",
-                    "io.netty:netty-transport:4.1.63.Final"
-                ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-unix-common/4.1.63.Final/netty-transport-native-unix-common-4.1.63.Final.jar",
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-classes-kqueue/4.1.70.Final/netty-transport-classes-kqueue-4.1.70.Final-sources.jar",
                 "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-transport-native-unix-common/4.1.63.Final/netty-transport-native-unix-common-4.1.63.Final.jar",
-                    "https://maven.google.com/io/netty/netty-transport-native-unix-common/4.1.63.Final/netty-transport-native-unix-common-4.1.63.Final.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.63.Final/netty-transport-native-unix-common-4.1.63.Final.jar"
+                    "https://jcenter.bintray.com/io/netty/netty-transport-classes-kqueue/4.1.70.Final/netty-transport-classes-kqueue-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-transport-classes-kqueue/4.1.70.Final/netty-transport-classes-kqueue-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-classes-kqueue/4.1.70.Final/netty-transport-classes-kqueue-4.1.70.Final-sources.jar"
                 ],
-                "sha256": "342caefdda65c8f0fb55305f6b9031b6e533c88bf1d57307b30e540f4978a735"
+                "sha256": "5c127dfd789dd829faf373f4af1d01934e8a09497544c77b78e11d6382c07dc6"
             },
             {
-                "coord": "io.netty:netty-transport-native-unix-common:jar:sources:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-unix-common/4.1.63.Final/netty-transport-native-unix-common-4.1.63.Final-sources.jar",
+                "coord": "io.netty:netty-transport-native-epoll:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final.jar",
                 "directDependencies": [
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final"
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "dependencies": [
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final"
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-unix-common/4.1.63.Final/netty-transport-native-unix-common-4.1.63.Final-sources.jar",
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final.jar",
                 "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-transport-native-unix-common/4.1.63.Final/netty-transport-native-unix-common-4.1.63.Final-sources.jar",
-                    "https://maven.google.com/io/netty/netty-transport-native-unix-common/4.1.63.Final/netty-transport-native-unix-common-4.1.63.Final-sources.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.63.Final/netty-transport-native-unix-common-4.1.63.Final-sources.jar"
+                    "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final.jar"
                 ],
-                "sha256": "a0ee04cdbf3e81c0e89ff7e6e5cf5844dbb57a89edd89f60be22bef17fd46dab"
+                "sha256": "49f20c04ea4753daefc09957be7d287f34c57d7516636c864f03af19e4aed0d8"
             },
             {
-                "coord": "io.netty:netty-transport:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport/4.1.63.Final/netty-transport-4.1.63.Final.jar",
+                "coord": "io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-linux-aarch_64.jar",
                 "directDependencies": [
-                    "io.netty:netty-buffer:4.1.63.Final",
-                    "io.netty:netty-common:4.1.63.Final",
-                    "io.netty:netty-resolver:4.1.63.Final"
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "dependencies": [
-                    "io.netty:netty-common:4.1.63.Final",
-                    "io.netty:netty-resolver:4.1.63.Final",
-                    "io.netty:netty-buffer:4.1.63.Final"
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-transport/4.1.63.Final/netty-transport-4.1.63.Final.jar",
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-linux-aarch_64.jar",
                 "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-transport/4.1.63.Final/netty-transport-4.1.63.Final.jar",
-                    "https://maven.google.com/io/netty/netty-transport/4.1.63.Final/netty-transport-4.1.63.Final.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.63.Final/netty-transport-4.1.63.Final.jar"
+                    "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-linux-aarch_64.jar",
+                    "https://maven.google.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-linux-aarch_64.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-linux-aarch_64.jar"
                 ],
-                "sha256": "55f633ee6eed311cc7d8be8675267f2dae7467de3c79144d224be38d004d3fcf"
+                "sha256": "a0a7205350145039a2bfc3d58ca059f1b6441df7770c37404b74c9252d434a94"
             },
             {
-                "coord": "io.netty:netty-transport:jar:sources:4.1.63.Final",
-                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport/4.1.63.Final/netty-transport-4.1.63.Final-sources.jar",
+                "coord": "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-linux-x86_64.jar",
                 "directDependencies": [
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final"
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "dependencies": [
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final"
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
-                "url": "https://jcenter.bintray.com/io/netty/netty-transport/4.1.63.Final/netty-transport-4.1.63.Final-sources.jar",
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-linux-x86_64.jar",
                 "mirror_urls": [
-                    "https://jcenter.bintray.com/io/netty/netty-transport/4.1.63.Final/netty-transport-4.1.63.Final-sources.jar",
-                    "https://maven.google.com/io/netty/netty-transport/4.1.63.Final/netty-transport-4.1.63.Final-sources.jar",
-                    "https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.63.Final/netty-transport-4.1.63.Final-sources.jar"
+                    "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-linux-x86_64.jar",
+                    "https://maven.google.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-linux-x86_64.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-linux-x86_64.jar"
                 ],
-                "sha256": "aaac0d3f51999fef2bd98639c052b3e6681b0e23c984398e606949cadda8e9f5"
+                "sha256": "e61f5fb0d7702200f7b422fc8b91d2ede0322138fa91a0daf65bb41d3c3ab866"
+            },
+            {
+                "coord": "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-transport-native-unix-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport-classes-epoll",
+                    "io.netty:netty-transport"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.70.Final/netty-transport-native-epoll-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "704b60ed2cf6c2ddeacb02cb93ded3786ab1cc7ab76e45ba5b8125bf35de905d"
+            },
+            {
+                "coord": "io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-osx-aarch_64.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-transport-classes-kqueue",
+                    "io.netty:netty-transport-native-unix-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-osx-aarch_64.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-osx-aarch_64.jar",
+                    "https://maven.google.com/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-osx-aarch_64.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-osx-aarch_64.jar"
+                ],
+                "sha256": "63fdeeb7006c1e51492caacef4010122f9f341c1ca7a09fcd55e2e47acd5c423"
+            },
+            {
+                "coord": "io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-osx-x86_64.jar",
+                "directDependencies": [
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-osx-x86_64.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-osx-x86_64.jar",
+                    "https://maven.google.com/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-osx-x86_64.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-osx-x86_64.jar"
+                ],
+                "sha256": "e2a712d0513991b5bd08ed2eeae802d9143ca66d0cf6a5cd5bdea5f3c3b5b984"
+            },
+            {
+                "coord": "io.netty:netty-transport-native-kqueue:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-kqueue/4.1.70.Final/netty-transport-native-kqueue-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "0cb4acfa355276ccd6399e53696ceace28512a2f74fbd9c5f9625664bd37ea88"
+            },
+            {
+                "coord": "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-unix-common/4.1.70.Final/netty-transport-native-unix-common-4.1.70.Final.jar",
+                "directDependencies": [
+                    "io.netty:netty-buffer:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-unix-common/4.1.70.Final/netty-transport-native-unix-common-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport-native-unix-common/4.1.70.Final/netty-transport-native-unix-common-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-transport-native-unix-common/4.1.70.Final/netty-transport-native-unix-common-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.70.Final/netty-transport-native-unix-common-4.1.70.Final.jar"
+                ],
+                "sha256": "e3687dfb79a09e5b039cddecdfc462beb63211f2347d5b2919f7eabeb66e883a"
+            },
+            {
+                "coord": "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-native-unix-common/4.1.70.Final/netty-transport-native-unix-common-4.1.70.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-native-unix-common/4.1.70.Final/netty-transport-native-unix-common-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport-native-unix-common/4.1.70.Final/netty-transport-native-unix-common-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-transport-native-unix-common/4.1.70.Final/netty-transport-native-unix-common-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.70.Final/netty-transport-native-unix-common-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "182c18451a5df2f28c1f5d52240137418bfcb8cdcfdbef783fe9cb5a818b5b12"
+            },
+            {
+                "coord": "io.netty:netty-transport-rxtx:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-rxtx/4.1.70.Final/netty-transport-rxtx-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "org.rxtx:rxtx"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-rxtx/4.1.70.Final/netty-transport-rxtx-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport-rxtx/4.1.70.Final/netty-transport-rxtx-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-transport-rxtx/4.1.70.Final/netty-transport-rxtx-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-rxtx/4.1.70.Final/netty-transport-rxtx-4.1.70.Final.jar"
+                ],
+                "sha256": "a188ac145f33ac9ae4a6579e26dc7de63e599e4033a92c1e82e98e0d1b24887c"
+            },
+            {
+                "coord": "io.netty:netty-transport-rxtx:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-rxtx/4.1.70.Final/netty-transport-rxtx-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "org.rxtx:rxtx"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-rxtx/4.1.70.Final/netty-transport-rxtx-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport-rxtx/4.1.70.Final/netty-transport-rxtx-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-transport-rxtx/4.1.70.Final/netty-transport-rxtx-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-rxtx/4.1.70.Final/netty-transport-rxtx-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "c11d89dc48f539d5b172eac734539112bb9fc71595ede776196efd6f56c18b0b"
+            },
+            {
+                "coord": "io.netty:netty-transport-sctp:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-sctp/4.1.70.Final/netty-transport-sctp-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-codec",
+                    "io.netty:netty-transport"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-sctp/4.1.70.Final/netty-transport-sctp-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport-sctp/4.1.70.Final/netty-transport-sctp-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-transport-sctp/4.1.70.Final/netty-transport-sctp-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-sctp/4.1.70.Final/netty-transport-sctp-4.1.70.Final.jar"
+                ],
+                "sha256": "e833bec1caed73d4c3443f667badf80c54d916234f504de4716284b994154405"
+            },
+            {
+                "coord": "io.netty:netty-transport-sctp:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-sctp/4.1.70.Final/netty-transport-sctp-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-codec",
+                    "io.netty:netty-transport"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-sctp/4.1.70.Final/netty-transport-sctp-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport-sctp/4.1.70.Final/netty-transport-sctp-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-transport-sctp/4.1.70.Final/netty-transport-sctp-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-sctp/4.1.70.Final/netty-transport-sctp-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "ff077e77fa8de5140a7421e1a3c54a8b2c6970f94fb64c7138446cf4e93ed413"
+            },
+            {
+                "coord": "io.netty:netty-transport-udt:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-udt/4.1.70.Final/netty-transport-udt-4.1.70.Final.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "com.barchart.udt:barchart-udt-bundle"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-udt/4.1.70.Final/netty-transport-udt-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport-udt/4.1.70.Final/netty-transport-udt-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-transport-udt/4.1.70.Final/netty-transport-udt-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-udt/4.1.70.Final/netty-transport-udt-4.1.70.Final.jar"
+                ],
+                "sha256": "6615ffb62f07f7ba7fbd0693728203008b2d1452df0b731b3e8d3087fee889fc"
+            },
+            {
+                "coord": "io.netty:netty-transport-udt:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport-udt/4.1.70.Final/netty-transport-udt-4.1.70.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "io.netty:netty-common",
+                    "io.netty:netty-buffer",
+                    "io.netty:netty-transport",
+                    "com.barchart.udt:barchart-udt-bundle"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport-udt/4.1.70.Final/netty-transport-udt-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport-udt/4.1.70.Final/netty-transport-udt-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-transport-udt/4.1.70.Final/netty-transport-udt-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport-udt/4.1.70.Final/netty-transport-udt-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "343460a62b4bf3ab21b94d95423786f493ca1bf4b9baa7e87ecb9a3689146032"
+            },
+            {
+                "coord": "io.netty:netty-transport:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport/4.1.70.Final/netty-transport-4.1.70.Final.jar",
+                "directDependencies": [
+                    "io.netty:netty-buffer:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-buffer:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport/4.1.70.Final/netty-transport-4.1.70.Final.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport/4.1.70.Final/netty-transport-4.1.70.Final.jar",
+                    "https://maven.google.com/io/netty/netty-transport/4.1.70.Final/netty-transport-4.1.70.Final.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.70.Final/netty-transport-4.1.70.Final.jar"
+                ],
+                "sha256": "cbf7d6fb9af32fa36b414c8f577e87ffafe59417a1f8d778b5bee773225eaf44"
+            },
+            {
+                "coord": "io.netty:netty-transport:jar:sources:4.1.70.Final",
+                "file": "v1/https/jcenter.bintray.com/io/netty/netty-transport/4.1.70.Final/netty-transport-4.1.70.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final"
+                ],
+                "url": "https://jcenter.bintray.com/io/netty/netty-transport/4.1.70.Final/netty-transport-4.1.70.Final-sources.jar",
+                "mirror_urls": [
+                    "https://jcenter.bintray.com/io/netty/netty-transport/4.1.70.Final/netty-transport-4.1.70.Final-sources.jar",
+                    "https://maven.google.com/io/netty/netty-transport/4.1.70.Final/netty-transport-4.1.70.Final-sources.jar",
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.70.Final/netty-transport-4.1.70.Final-sources.jar"
+                ],
+                "sha256": "dc4157fca3936c23c68ab31a96ffbfb19310bcd7c47d1dc85c778f23d9b7f321"
             },
             {
                 "coord": "io.swagger:swagger-annotations:1.6.2",
@@ -3502,16 +4511,16 @@
                 "file": "v1/https/jcenter.bintray.com/org/apache/bookkeeper/bookkeeper-common-allocator/4.13.0/bookkeeper-common-allocator-4.13.0.jar",
                 "directDependencies": [
                     "commons-configuration:commons-configuration:1.10",
-                    "io.netty:netty-buffer:4.1.63.Final",
+                    "io.netty:netty-buffer:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30"
                 ],
                 "dependencies": [
                     "commons-logging:commons-logging:1.2",
                     "org.slf4j:slf4j-api:1.7.30",
                     "commons-lang:commons-lang:2.6",
-                    "io.netty:netty-buffer:4.1.63.Final",
                     "commons-configuration:commons-configuration:1.10",
-                    "io.netty:netty-common:4.1.63.Final"
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/bookkeeper/bookkeeper-common-allocator/4.13.0/bookkeeper-common-allocator-4.13.0.jar",
                 "mirror_urls": [
@@ -3526,7 +4535,7 @@
                 "file": "v1/https/jcenter.bintray.com/org/apache/bookkeeper/bookkeeper-common-allocator/4.13.0/bookkeeper-common-allocator-4.13.0-sources.jar",
                 "directDependencies": [
                     "commons-configuration:commons-configuration:jar:sources:1.10",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30"
                 ],
                 "dependencies": [
@@ -3534,8 +4543,8 @@
                     "commons-configuration:commons-configuration:jar:sources:1.10",
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final"
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/bookkeeper/bookkeeper-common-allocator/4.13.0/bookkeeper-common-allocator-4.13.0-sources.jar",
                 "mirror_urls": [
@@ -3556,7 +4565,7 @@
                     "com.google.guava:guava:23.6-jre",
                     "commons-configuration:commons-configuration:1.10",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:4.13.0",
-                    "io.netty:netty-common:4.1.63.Final",
+                    "io.netty:netty-common:4.1.70.Final",
                     "com.fasterxml.jackson.core:jackson-databind:2.8.8",
                     "com.fasterxml.jackson.core:jackson-core:2.8.8"
                 ],
@@ -3573,7 +4582,7 @@
                     "commons-configuration:commons-configuration:1.10",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:4.13.0",
-                    "io.netty:netty-common:4.1.63.Final",
+                    "io.netty:netty-common:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:1.1",
                     "com.fasterxml.jackson.core:jackson-databind:2.8.8",
                     "org.apache.commons:commons-lang3:3.11",
@@ -3596,10 +4605,10 @@
                     "commons-configuration:commons-configuration:jar:sources:1.10",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.8.8",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.8.8",
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.8.8",
                     "org.apache.bookkeeper:cpu-affinity:jar:sources:4.13.0",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
                     "org.jctools:jctools-core:jar:sources:2.1.2",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:jar:sources:4.13.0"
                 ],
@@ -3613,12 +4622,12 @@
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.8.8",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.8.8",
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.8.8",
                     "org.apache.bookkeeper:cpu-affinity:jar:sources:4.13.0",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
                     "org.jctools:jctools-core:jar:sources:2.1.2",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:jar:sources:4.13.0"
@@ -3681,12 +4690,11 @@
                 "coord": "org.apache.bookkeeper:bookkeeper-server:4.13.0",
                 "file": "v1/https/jcenter.bintray.com/org/apache/bookkeeper/bookkeeper-server/4.13.0/bookkeeper-server-4.13.0.jar",
                 "directDependencies": [
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.rocksdb:rocksdbjni:6.10.2",
                     "org.apache.bookkeeper:circe-checksum:4.13.0",
                     "org.slf4j:slf4j-log4j12:1.7.25",
                     "org.bouncycastle:bcprov-ext-jdk15on:1.66",
-                    "io.netty:netty-handler:4.1.63.Final",
-                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.63.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "commons-io:commons-io:2.4",
                     "org.apache.bookkeeper.http:http-server:4.13.0",
@@ -3704,59 +4712,61 @@
                     "org.apache.commons:commons-collections4:4.4",
                     "org.apache.bookkeeper:bookkeeper-tools-framework:4.13.0",
                     "com.beust:jcommander:1.78",
-                    "org.apache.bookkeeper:bookkeeper-common-allocator:4.13.0"
+                    "org.apache.bookkeeper:bookkeeper-common-allocator:4.13.0",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final"
                 ],
                 "dependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:2.8.8",
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.rocksdb:rocksdbjni:6.10.2",
                     "org.apache.bookkeeper:circe-checksum:4.13.0",
                     "org.slf4j:slf4j-log4j12:1.7.25",
                     "org.checkerframework:checker-compat-qual:2.0.0",
                     "org.apache.bookkeeper:cpu-affinity:4.13.0",
-                    "io.netty:netty-codec:4.1.63.Final",
                     "org.bouncycastle:bcprov-ext-jdk15on:1.66",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
-                    "io.netty:netty-handler:4.1.63.Final",
-                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.63.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "org.jctools:jctools-core:2.1.2",
                     "commons-io:commons-io:2.4",
                     "org.apache.zookeeper:zookeeper-jute:3.6.3",
                     "commons-lang:commons-lang:2.6",
-                    "io.netty:netty-resolver:4.1.63.Final",
                     "com.google.guava:guava:23.6-jre",
                     "org.bouncycastle:bcprov-jdk15on:jar:1.66",
                     "com.google.protobuf:protobuf-java:3.14.0",
-                    "io.netty:netty-buffer:4.1.63.Final",
                     "log4j:log4j:1.2.17",
                     "org.apache.bookkeeper.http:http-server:4.13.0",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
                     "commons-configuration:commons-configuration:1.10",
-                    "io.netty:netty-transport-native-unix-common:4.1.63.Final",
                     "org.bouncycastle:bcpkix-jdk15on:1.66",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "io.netty:netty-transport:4.1.70.Final",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:4.13.0",
                     "commons-cli:commons-cli:1.3.1",
-                    "io.netty:netty-common:4.1.63.Final",
                     "io.netty:netty-tcnative-boringssl-static:2.0.31.Final",
                     "org.apache.yetus:audience-annotations:0.5.0",
                     "org.apache.bookkeeper:bookkeeper-proto:4.13.0",
                     "org.apache.bookkeeper:bookkeeper-common:4.13.0",
+                    "io.netty:netty-common:4.1.70.Final",
                     "commons-codec:commons-codec:1.15",
                     "org.apache.httpcomponents:httpclient:4.5.2",
                     "org.apache.zookeeper:zookeeper:3.6.3",
                     "net.java.dev.jna:jna:3.2.7",
                     "com.google.j2objc:j2objc-annotations:1.1",
-                    "io.netty:netty-transport:4.1.63.Final",
                     "com.fasterxml.jackson.core:jackson-databind:2.8.8",
                     "org.apache.commons:commons-lang3:3.11",
                     "org.apache.commons:commons-collections4:4.4",
                     "org.apache.bookkeeper:bookkeeper-tools-framework:4.13.0",
                     "com.google.errorprone:error_prone_annotations:2.1.3",
                     "org.apache.httpcomponents:httpcore:4.4.4",
+                    "io.netty:netty-resolver:4.1.70.Final",
                     "com.beust:jcommander:1.78",
                     "org.apache.bookkeeper:bookkeeper-common-allocator:4.13.0",
-                    "com.fasterxml.jackson.core:jackson-core:2.8.8"
+                    "com.fasterxml.jackson.core:jackson-core:2.8.8",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/bookkeeper/bookkeeper-server/4.13.0/bookkeeper-server-4.13.0.jar",
                 "mirror_urls": [
@@ -3781,30 +4791,30 @@
                     "commons-configuration:commons-configuration:jar:sources:1.10",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
                     "org.bouncycastle:bcpkix-jdk15on:jar:sources:1.66",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
                     "net.java.dev.jna:jna:jar:sources:3.2.7",
                     "org.apache.bookkeeper.http:http-server:jar:sources:4.13.0",
                     "org.apache.bookkeeper:bookkeeper-common-allocator:jar:sources:4.13.0",
                     "org.apache.bookkeeper:bookkeeper-tools-framework:jar:sources:4.13.0",
                     "commons-io:commons-io:jar:sources:2.4",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
                     "org.bouncycastle:bcprov-ext-jdk15on:jar:sources:1.66",
-                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.63.Final",
                     "org.slf4j:slf4j-log4j12:jar:sources:1.7.25",
                     "org.apache.bookkeeper:bookkeeper-common:jar:sources:4.13.0",
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.2",
-                    "io.netty:netty-handler:jar:sources:4.1.63.Final",
                     "org.apache.bookkeeper:circe-checksum:jar:sources:4.13.0",
                     "commons-cli:commons-cli:jar:sources:1.3.1"
                 ],
                 "dependencies": [
                     "org.apache.zookeeper:zookeeper-jute:jar:sources:3.6.3",
                     "io.netty:netty-tcnative-boringssl-static:jar:sources:2.0.31.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                     "org.rocksdb:rocksdbjni:jar:sources:6.10.2",
                     "org.apache.bookkeeper:bookkeeper-proto:jar:sources:4.13.0",
-                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final",
                     "org.apache.commons:commons-collections4:jar:sources:4.4",
                     "org.apache.zookeeper:zookeeper:jar:sources:3.6.3",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
                     "org.apache.commons:commons-lang3:jar:sources:3.11",
                     "com.google.guava:guava:jar:sources:23.6-jre",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.1.3",
@@ -3815,36 +4825,37 @@
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.8.8",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.bouncycastle:bcpkix-jdk15on:jar:sources:1.66",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
                     "com.google.protobuf:protobuf-java:jar:sources:3.14.0",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.8.8",
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
                     "org.bouncycastle:bcprov-jdk15on:jar:sources:1.66",
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.8.8",
                     "net.java.dev.jna:jna:jar:sources:3.2.7",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
                     "org.apache.bookkeeper:cpu-affinity:jar:sources:4.13.0",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
                     "org.apache.bookkeeper.http:http-server:jar:sources:4.13.0",
                     "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
                     "org.apache.bookkeeper:bookkeeper-common-allocator:jar:sources:4.13.0",
                     "org.apache.yetus:audience-annotations:jar:sources:0.5.0",
                     "org.apache.bookkeeper:bookkeeper-tools-framework:jar:sources:4.13.0",
                     "commons-io:commons-io:jar:sources:2.4",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
                     "org.bouncycastle:bcprov-ext-jdk15on:jar:sources:1.66",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
                     "org.apache.httpcomponents:httpcore:jar:sources:4.4.4",
-                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.63.Final",
                     "org.slf4j:slf4j-log4j12:jar:sources:1.7.25",
                     "org.apache.bookkeeper:bookkeeper-common:jar:sources:4.13.0",
                     "org.jctools:jctools-core:jar:sources:2.1.2",
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.2",
                     "log4j:log4j:jar:sources:1.2.17",
-                    "io.netty:netty-handler:jar:sources:4.1.63.Final",
                     "org.apache.bookkeeper:circe-checksum:jar:sources:4.13.0",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:jar:sources:4.13.0",
-                    "io.netty:netty-codec:jar:sources:4.1.63.Final",
                     "commons-cli:commons-cli:jar:sources:1.3.1"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/bookkeeper/bookkeeper-server/4.13.0/bookkeeper-server-4.13.0-sources.jar",
@@ -3877,8 +4888,8 @@
                     "commons-configuration:commons-configuration:1.10",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:4.13.0",
-                    "io.netty:netty-common:4.1.63.Final",
                     "org.apache.bookkeeper:bookkeeper-common:4.13.0",
+                    "io.netty:netty-common:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:1.1",
                     "com.fasterxml.jackson.core:jackson-databind:2.8.8",
                     "org.apache.commons:commons-lang3:3.11",
@@ -3914,12 +4925,12 @@
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.8.8",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.8.8",
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.8.8",
                     "org.apache.bookkeeper:cpu-affinity:jar:sources:4.13.0",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
                     "org.apache.bookkeeper:bookkeeper-common:jar:sources:4.13.0",
                     "org.jctools:jctools-core:jar:sources:2.1.2",
@@ -3939,7 +4950,7 @@
                 "directDependencies": [
                     "com.google.guava:guava:23.6-jre",
                     "commons-configuration:commons-configuration:1.10",
-                    "io.netty:netty-buffer:4.1.63.Final",
+                    "io.netty:netty-buffer:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30"
                 ],
                 "dependencies": [
@@ -3949,12 +4960,12 @@
                     "org.slf4j:slf4j-api:1.7.30",
                     "commons-lang:commons-lang:2.6",
                     "com.google.guava:guava:23.6-jre",
-                    "io.netty:netty-buffer:4.1.63.Final",
                     "commons-configuration:commons-configuration:1.10",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
-                    "io.netty:netty-common:4.1.63.Final",
+                    "io.netty:netty-common:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:1.1",
-                    "com.google.errorprone:error_prone_annotations:2.1.3"
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/bookkeeper/circe-checksum/4.13.0/circe-checksum-4.13.0.jar",
                 "mirror_urls": [
@@ -3970,7 +4981,7 @@
                 "directDependencies": [
                     "com.google.guava:guava:jar:sources:23.6-jre",
                     "commons-configuration:commons-configuration:jar:sources:1.10",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30"
                 ],
                 "dependencies": [
@@ -3981,11 +4992,11 @@
                     "commons-configuration:commons-configuration:jar:sources:1.10",
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
-                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1"
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/bookkeeper/circe-checksum/4.13.0/circe-checksum-4.13.0-sources.jar",
                 "mirror_urls": [
@@ -4202,25 +5213,26 @@
                     "org.slf4j:slf4j-api:1.7.30"
                 ],
                 "dependencies": [
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "io.netty:netty-codec:4.1.63.Final",
-                    "io.netty:netty-transport-native-epoll:4.1.63.Final",
                     "com.google.code.findbugs:jsr305:3.0.2",
-                    "io.netty:netty-handler:4.1.63.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "org.apache.zookeeper:zookeeper-jute:3.6.3",
-                    "io.netty:netty-resolver:4.1.63.Final",
                     "com.google.guava:guava:23.6-jre",
-                    "io.netty:netty-buffer:4.1.63.Final",
                     "log4j:log4j:1.2.17",
-                    "io.netty:netty-transport-native-unix-common:4.1.63.Final",
+                    "io.netty:netty-transport-native-epoll:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
-                    "io.netty:netty-common:4.1.63.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
                     "org.apache.yetus:audience-annotations:0.5.0",
+                    "io.netty:netty-common:4.1.70.Final",
                     "org.apache.zookeeper:zookeeper:3.6.3",
                     "com.google.j2objc:j2objc-annotations:1.1",
-                    "io.netty:netty-transport:4.1.63.Final",
-                    "com.google.errorprone:error_prone_annotations:2.1.3"
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/curator/curator-client/5.1.0/curator-client-5.1.0.jar",
                 "mirror_urls": [
@@ -4240,24 +5252,25 @@
                 ],
                 "dependencies": [
                     "org.apache.zookeeper:zookeeper-jute:jar:sources:3.6.3",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final",
                     "org.apache.zookeeper:zookeeper:jar:sources:3.6.3",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
                     "com.google.guava:guava:jar:sources:23.6-jre",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.1.3",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
                     "org.apache.yetus:audience-annotations:jar:sources:0.5.0",
-                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.63.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
                     "log4j:log4j:jar:sources:1.2.17",
-                    "io.netty:netty-handler:jar:sources:4.1.63.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.63.Final"
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/curator/curator-client/5.1.0/curator-client-5.1.0-sources.jar",
                 "mirror_urls": [
@@ -4274,26 +5287,27 @@
                     "org.apache.curator:curator-client:5.1.0"
                 ],
                 "dependencies": [
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "io.netty:netty-codec:4.1.63.Final",
-                    "io.netty:netty-transport-native-epoll:4.1.63.Final",
                     "com.google.code.findbugs:jsr305:3.0.2",
-                    "io.netty:netty-handler:4.1.63.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "org.apache.zookeeper:zookeeper-jute:3.6.3",
-                    "io.netty:netty-resolver:4.1.63.Final",
                     "com.google.guava:guava:23.6-jre",
-                    "io.netty:netty-buffer:4.1.63.Final",
                     "log4j:log4j:1.2.17",
                     "org.apache.curator:curator-client:5.1.0",
-                    "io.netty:netty-transport-native-unix-common:4.1.63.Final",
+                    "io.netty:netty-transport-native-epoll:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
-                    "io.netty:netty-common:4.1.63.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
                     "org.apache.yetus:audience-annotations:0.5.0",
+                    "io.netty:netty-common:4.1.70.Final",
                     "org.apache.zookeeper:zookeeper:3.6.3",
                     "com.google.j2objc:j2objc-annotations:1.1",
-                    "io.netty:netty-transport:4.1.63.Final",
-                    "com.google.errorprone:error_prone_annotations:2.1.3"
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/curator/curator-framework/5.1.0/curator-framework-5.1.0.jar",
                 "mirror_urls": [
@@ -4311,25 +5325,26 @@
                 ],
                 "dependencies": [
                     "org.apache.zookeeper:zookeeper-jute:jar:sources:3.6.3",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final",
                     "org.apache.zookeeper:zookeeper:jar:sources:3.6.3",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
                     "com.google.guava:guava:jar:sources:23.6-jre",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.1.3",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
                     "org.apache.yetus:audience-annotations:jar:sources:0.5.0",
-                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.63.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
                     "org.apache.curator:curator-client:jar:sources:5.1.0",
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
                     "log4j:log4j:jar:sources:1.2.17",
-                    "io.netty:netty-handler:jar:sources:4.1.63.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.63.Final"
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/curator/curator-framework/5.1.0/curator-framework-5.1.0-sources.jar",
                 "mirror_urls": [
@@ -4346,27 +5361,28 @@
                     "org.apache.curator:curator-framework:5.1.0"
                 ],
                 "dependencies": [
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "io.netty:netty-codec:4.1.63.Final",
-                    "io.netty:netty-transport-native-epoll:4.1.63.Final",
                     "com.google.code.findbugs:jsr305:3.0.2",
-                    "io.netty:netty-handler:4.1.63.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "org.apache.zookeeper:zookeeper-jute:3.6.3",
-                    "io.netty:netty-resolver:4.1.63.Final",
                     "com.google.guava:guava:23.6-jre",
-                    "io.netty:netty-buffer:4.1.63.Final",
                     "log4j:log4j:1.2.17",
                     "org.apache.curator:curator-client:5.1.0",
-                    "io.netty:netty-transport-native-unix-common:4.1.63.Final",
+                    "io.netty:netty-transport-native-epoll:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
-                    "io.netty:netty-common:4.1.63.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
                     "org.apache.yetus:audience-annotations:0.5.0",
+                    "io.netty:netty-common:4.1.70.Final",
                     "org.apache.curator:curator-framework:5.1.0",
                     "org.apache.zookeeper:zookeeper:3.6.3",
                     "com.google.j2objc:j2objc-annotations:1.1",
-                    "io.netty:netty-transport:4.1.63.Final",
-                    "com.google.errorprone:error_prone_annotations:2.1.3"
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/curator/curator-recipes/5.1.0/curator-recipes-5.1.0.jar",
                 "mirror_urls": [
@@ -4384,26 +5400,27 @@
                 ],
                 "dependencies": [
                     "org.apache.zookeeper:zookeeper-jute:jar:sources:3.6.3",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "org.apache.curator:curator-framework:jar:sources:5.1.0",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final",
                     "org.apache.zookeeper:zookeeper:jar:sources:3.6.3",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
                     "com.google.guava:guava:jar:sources:23.6-jre",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.1.3",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
                     "org.apache.yetus:audience-annotations:jar:sources:0.5.0",
-                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.63.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
                     "org.apache.curator:curator-client:jar:sources:5.1.0",
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
                     "log4j:log4j:jar:sources:1.2.17",
-                    "io.netty:netty-handler:jar:sources:4.1.63.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.63.Final"
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/curator/curator-recipes/5.1.0/curator-recipes-5.1.0-sources.jar",
                 "mirror_urls": [
@@ -4420,12 +5437,12 @@
                     "org.slf4j:slf4j-api:1.7.30",
                     "commons-lang:commons-lang:2.6",
                     "com.google.guava:guava:23.6-jre",
-                    "io.netty:netty-buffer:4.1.63.Final",
                     "commons-configuration:commons-configuration:1.10",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:4.13.0",
                     "org.apache.bookkeeper:bookkeeper-common:4.13.0",
                     "commons-codec:commons-codec:1.15",
                     "org.apache.commons:commons-lang3:3.11",
+                    "io.netty:netty-buffer:4.1.70.Final",
                     "net.jpountz.lz4:lz4:1.3.0"
                 ],
                 "dependencies": [
@@ -4438,18 +5455,18 @@
                     "org.jctools:jctools-core:2.1.2",
                     "commons-lang:commons-lang:2.6",
                     "com.google.guava:guava:23.6-jre",
-                    "io.netty:netty-buffer:4.1.63.Final",
                     "commons-configuration:commons-configuration:1.10",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:4.13.0",
-                    "io.netty:netty-common:4.1.63.Final",
                     "org.apache.bookkeeper:bookkeeper-common:4.13.0",
+                    "io.netty:netty-common:4.1.70.Final",
                     "commons-codec:commons-codec:1.15",
                     "com.google.j2objc:j2objc-annotations:1.1",
                     "com.fasterxml.jackson.core:jackson-databind:2.8.8",
                     "org.apache.commons:commons-lang3:3.11",
                     "com.google.errorprone:error_prone_annotations:2.1.3",
                     "com.fasterxml.jackson.core:jackson-core:2.8.8",
+                    "io.netty:netty-buffer:4.1.70.Final",
                     "net.jpountz.lz4:lz4:1.3.0"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/distributedlog/distributedlog-common/4.13.0/distributedlog-common-4.13.0.jar",
@@ -4471,7 +5488,7 @@
                     "commons-codec:commons-codec:jar:sources:1.15",
                     "commons-configuration:commons-configuration:jar:sources:1.10",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
                     "org.apache.bookkeeper:bookkeeper-common:jar:sources:4.13.0",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:jar:sources:4.13.0"
                 ],
@@ -4487,14 +5504,14 @@
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.8.8",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.8.8",
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.8.8",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
                     "org.apache.bookkeeper:cpu-affinity:jar:sources:4.13.0",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
                     "org.apache.bookkeeper:bookkeeper-common:jar:sources:4.13.0",
                     "org.jctools:jctools-core:jar:sources:2.1.2",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:jar:sources:4.13.0"
@@ -4520,49 +5537,46 @@
                 ],
                 "dependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:2.8.8",
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.rocksdb:rocksdbjni:6.10.2",
                     "org.apache.bookkeeper:circe-checksum:4.13.0",
                     "org.slf4j:slf4j-log4j12:1.7.25",
                     "org.checkerframework:checker-compat-qual:2.0.0",
                     "org.apache.bookkeeper:cpu-affinity:4.13.0",
                     "org.apache.bookkeeper:bookkeeper-server:4.13.0",
-                    "io.netty:netty-codec:4.1.63.Final",
                     "org.bouncycastle:bcprov-ext-jdk15on:1.66",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
-                    "io.netty:netty-handler:4.1.63.Final",
-                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.63.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "org.apache.distributedlog:distributedlog-protocol:4.13.0",
                     "org.jctools:jctools-core:2.1.2",
                     "commons-io:commons-io:2.4",
                     "org.apache.zookeeper:zookeeper-jute:3.6.3",
                     "commons-lang:commons-lang:2.6",
-                    "io.netty:netty-resolver:4.1.63.Final",
                     "com.google.guava:guava:23.6-jre",
                     "org.bouncycastle:bcprov-jdk15on:jar:1.66",
                     "com.google.protobuf:protobuf-java:3.14.0",
-                    "io.netty:netty-buffer:4.1.63.Final",
                     "log4j:log4j:1.2.17",
                     "org.apache.bookkeeper.http:http-server:4.13.0",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
                     "commons-configuration:commons-configuration:1.10",
-                    "io.netty:netty-transport-native-unix-common:4.1.63.Final",
                     "org.bouncycastle:bcpkix-jdk15on:1.66",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "io.netty:netty-transport:4.1.70.Final",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:4.13.0",
                     "org.apache.thrift:libthrift:0.12.0",
                     "commons-cli:commons-cli:1.3.1",
-                    "io.netty:netty-common:4.1.63.Final",
                     "io.netty:netty-tcnative-boringssl-static:2.0.31.Final",
                     "org.apache.yetus:audience-annotations:0.5.0",
                     "org.apache.bookkeeper:bookkeeper-proto:4.13.0",
                     "org.apache.bookkeeper:bookkeeper-common:4.13.0",
+                    "io.netty:netty-common:4.1.70.Final",
                     "commons-codec:commons-codec:1.15",
                     "org.apache.httpcomponents:httpclient:4.5.2",
                     "org.apache.zookeeper:zookeeper:3.6.3",
                     "net.java.dev.jna:jna:3.2.7",
                     "com.google.j2objc:j2objc-annotations:1.1",
-                    "io.netty:netty-transport:4.1.63.Final",
                     "com.fasterxml.jackson.core:jackson-databind:2.8.8",
                     "org.apache.commons:commons-lang3:3.11",
                     "org.apache.commons:commons-collections4:4.4",
@@ -4570,9 +5584,13 @@
                     "com.google.errorprone:error_prone_annotations:2.1.3",
                     "org.apache.httpcomponents:httpcore:4.4.4",
                     "org.apache.distributedlog:distributedlog-common:4.13.0",
+                    "io.netty:netty-resolver:4.1.70.Final",
                     "com.beust:jcommander:1.78",
                     "org.apache.bookkeeper:bookkeeper-common-allocator:4.13.0",
                     "com.fasterxml.jackson.core:jackson-core:2.8.8",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final",
                     "net.jpountz.lz4:lz4:1.3.0"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/distributedlog/distributedlog-core/4.13.0/distributedlog-core-4.13.0.jar",
@@ -4597,15 +5615,15 @@
                 "dependencies": [
                     "org.apache.zookeeper:zookeeper-jute:jar:sources:3.6.3",
                     "io.netty:netty-tcnative-boringssl-static:jar:sources:2.0.31.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                     "net.jpountz.lz4:lz4:jar:sources:1.3.0",
                     "org.rocksdb:rocksdbjni:jar:sources:6.10.2",
                     "org.apache.bookkeeper:bookkeeper-proto:jar:sources:4.13.0",
-                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final",
                     "org.apache.commons:commons-collections4:jar:sources:4.4",
                     "org.apache.thrift:libthrift:jar:sources:0.12.0",
                     "org.apache.zookeeper:zookeeper:jar:sources:3.6.3",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
                     "org.apache.distributedlog:distributedlog-protocol:jar:sources:4.13.0",
                     "org.apache.commons:commons-lang3:jar:sources:3.11",
                     "com.google.guava:guava:jar:sources:23.6-jre",
@@ -4617,18 +5635,17 @@
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.8.8",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.bouncycastle:bcpkix-jdk15on:jar:sources:1.66",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
                     "com.google.protobuf:protobuf-java:jar:sources:3.14.0",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.8.8",
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
                     "org.bouncycastle:bcprov-jdk15on:jar:sources:1.66",
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.8.8",
                     "net.java.dev.jna:jna:jar:sources:3.2.7",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
                     "org.apache.bookkeeper:cpu-affinity:jar:sources:4.13.0",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
                     "org.apache.bookkeeper.http:http-server:jar:sources:4.13.0",
                     "org.apache.distributedlog:distributedlog-common:jar:sources:4.13.0",
                     "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
@@ -4636,19 +5653,21 @@
                     "org.apache.yetus:audience-annotations:jar:sources:0.5.0",
                     "org.apache.bookkeeper:bookkeeper-tools-framework:jar:sources:4.13.0",
                     "commons-io:commons-io:jar:sources:2.4",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
                     "org.bouncycastle:bcprov-ext-jdk15on:jar:sources:1.66",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
                     "org.apache.httpcomponents:httpcore:jar:sources:4.4.4",
-                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.63.Final",
                     "org.slf4j:slf4j-log4j12:jar:sources:1.7.25",
                     "org.apache.bookkeeper:bookkeeper-common:jar:sources:4.13.0",
                     "org.jctools:jctools-core:jar:sources:2.1.2",
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.2",
                     "log4j:log4j:jar:sources:1.2.17",
-                    "io.netty:netty-handler:jar:sources:4.1.63.Final",
                     "org.apache.bookkeeper:bookkeeper-server:jar:sources:4.13.0",
                     "org.apache.bookkeeper:circe-checksum:jar:sources:4.13.0",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:jar:sources:4.13.0",
-                    "io.netty:netty-codec:jar:sources:4.1.63.Final",
                     "commons-cli:commons-cli:jar:sources:1.3.1"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/distributedlog/distributedlog-core/4.13.0/distributedlog-core-4.13.0-sources.jar",
@@ -4664,7 +5683,7 @@
                 "file": "v1/https/jcenter.bintray.com/org/apache/distributedlog/distributedlog-protocol/4.13.0/distributedlog-protocol-4.13.0.jar",
                 "directDependencies": [
                     "commons-configuration:commons-configuration:1.10",
-                    "io.netty:netty-buffer:4.1.63.Final",
+                    "io.netty:netty-buffer:4.1.70.Final",
                     "org.apache.distributedlog:distributedlog-common:4.13.0",
                     "org.slf4j:slf4j-api:1.7.30"
                 ],
@@ -4678,12 +5697,11 @@
                     "org.jctools:jctools-core:2.1.2",
                     "commons-lang:commons-lang:2.6",
                     "com.google.guava:guava:23.6-jre",
-                    "io.netty:netty-buffer:4.1.63.Final",
                     "commons-configuration:commons-configuration:1.10",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:4.13.0",
-                    "io.netty:netty-common:4.1.63.Final",
                     "org.apache.bookkeeper:bookkeeper-common:4.13.0",
+                    "io.netty:netty-common:4.1.70.Final",
                     "commons-codec:commons-codec:1.15",
                     "com.google.j2objc:j2objc-annotations:1.1",
                     "com.fasterxml.jackson.core:jackson-databind:2.8.8",
@@ -4691,6 +5709,7 @@
                     "com.google.errorprone:error_prone_annotations:2.1.3",
                     "org.apache.distributedlog:distributedlog-common:4.13.0",
                     "com.fasterxml.jackson.core:jackson-core:2.8.8",
+                    "io.netty:netty-buffer:4.1.70.Final",
                     "net.jpountz.lz4:lz4:1.3.0"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/distributedlog/distributedlog-protocol/4.13.0/distributedlog-protocol-4.13.0.jar",
@@ -4706,7 +5725,7 @@
                 "file": "v1/https/jcenter.bintray.com/org/apache/distributedlog/distributedlog-protocol/4.13.0/distributedlog-protocol-4.13.0-sources.jar",
                 "directDependencies": [
                     "commons-configuration:commons-configuration:jar:sources:1.10",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
                     "org.apache.distributedlog:distributedlog-common:jar:sources:4.13.0",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30"
                 ],
@@ -4722,15 +5741,15 @@
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.8.8",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.8.8",
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.8.8",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
                     "org.apache.bookkeeper:cpu-affinity:jar:sources:4.13.0",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
                     "org.apache.distributedlog:distributedlog-common:jar:sources:4.13.0",
                     "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
                     "org.apache.bookkeeper:bookkeeper-common:jar:sources:4.13.0",
                     "org.jctools:jctools-core:jar:sources:2.1.2",
                     "org.apache.bookkeeper.stats:bookkeeper-stats-api:jar:sources:4.13.0"
@@ -5013,18 +6032,50 @@
                 "file": "v1/https/jcenter.bintray.com/org/apache/pulsar/pulsar-checksum/1.19.0-incubating/pulsar-checksum-1.19.0-incubating.jar",
                 "directDependencies": [
                     "com.google.guava:guava:23.6-jre",
-                    "io.netty:netty-all:4.1.50.Final",
+                    "io.netty:netty-all:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30"
                 ],
                 "dependencies": [
+                    "io.netty:netty-codec-socks:4.1.70.Final",
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "io.netty:netty-all:4.1.50.Final",
+                    "io.netty:netty-codec-http:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-codec-http2:4.1.70.Final",
+                    "io.netty:netty-codec-mqtt:4.1.70.Final",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "io.netty:netty-handler-proxy:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "com.google.guava:guava:23.6-jre",
+                    "io.netty:netty-codec-memcache:4.1.70.Final",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-transport-sctp:4.1.70.Final",
+                    "io.netty:netty-codec-redis:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.70.Final",
+                    "io.netty:netty-all:4.1.70.Final",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:1.1",
-                    "com.google.errorprone:error_prone_annotations:2.1.3"
+                    "io.netty:netty-codec-xml:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:4.1.70.Final",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "io.netty:netty-codec-smtp:4.1.70.Final",
+                    "io.netty:netty-codec-haproxy:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-transport-udt:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/pulsar/pulsar-checksum/1.19.0-incubating/pulsar-checksum-1.19.0-incubating.jar",
                 "mirror_urls": [
@@ -5039,18 +6090,47 @@
                 "file": "v1/https/jcenter.bintray.com/org/apache/pulsar/pulsar-checksum/1.19.0-incubating/pulsar-checksum-1.19.0-incubating-sources.jar",
                 "directDependencies": [
                     "com.google.guava:guava:jar:sources:23.6-jre",
-                    "io.netty:netty-all:jar:sources:4.1.50.Final",
+                    "io.netty:netty-all:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30"
                 ],
                 "dependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "io.netty:netty-codec-smtp:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-sctp:jar:sources:4.1.70.Final",
+                    "io.netty:netty-all:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-memcache:jar:sources:4.1.70.Final",
                     "com.google.guava:guava:jar:sources:23.6-jre",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.1.3",
+                    "io.netty:netty-codec-socks:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
+                    "io.netty:netty-transport-native-kqueue:jar:sources:4.1.70.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
-                    "io.netty:netty-all:jar:sources:4.1.50.Final",
-                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1"
+                    "io.netty:netty-resolver-dns:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-haproxy:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-redis:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-dns:jar:sources:4.1.70.Final",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "io.netty:netty-transport-classes-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-udt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler-proxy:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-xml:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http2:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-mqtt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/pulsar/pulsar-checksum/1.19.0-incubating/pulsar-checksum-1.19.0-incubating-sources.jar",
                 "mirror_urls": [
@@ -5073,29 +6153,61 @@
                 ],
                 "dependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:2.8.8",
+                    "io.netty:netty-codec-socks:4.1.70.Final",
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.apache.pulsar:pulsar-checksum:1.19.0-incubating",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "io.netty:netty-all:4.1.50.Final",
+                    "io.netty:netty-codec-http:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-codec-http2:4.1.70.Final",
+                    "io.netty:netty-codec-mqtt:4.1.70.Final",
                     "org.asynchttpclient:netty-codec-dns:2.0.31",
                     "org.asynchttpclient:netty-resolver:2.0.31",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "io.netty:netty-handler-proxy:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "com.google.guava:guava:23.6-jre",
+                    "io.netty:netty-codec-memcache:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:3.14.0",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
                     "org.reactivestreams:reactive-streams:1.0.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
                     "com.typesafe.netty:netty-reactive-streams:1.0.8",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-transport-sctp:4.1.70.Final",
+                    "io.netty:netty-codec-redis:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
                     "org.asynchttpclient:netty-resolver-dns:2.0.31",
+                    "io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.70.Final",
+                    "io.netty:netty-all:4.1.70.Final",
                     "commons-codec:commons-codec:1.15",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:1.1",
                     "org.apache.pulsar:pulsar-common:1.19.0-incubating",
                     "com.fasterxml.jackson.core:jackson-databind:2.8.8",
                     "org.apache.commons:commons-lang3:3.11",
+                    "io.netty:netty-codec-xml:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:4.1.70.Final",
                     "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "io.netty:netty-codec-smtp:4.1.70.Final",
+                    "io.netty:netty-codec-haproxy:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
                     "com.yahoo.datasketches:sketches-core:0.6.0",
                     "org.asynchttpclient:async-http-client:2.0.31",
+                    "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:4.1.70.Final",
                     "org.asynchttpclient:async-http-client-netty-utils:2.0.31",
                     "com.fasterxml.jackson.core:jackson-core:2.8.8",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-transport-udt:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final",
                     "net.jpountz.lz4:lz4:1.3.0"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/pulsar/pulsar-client/1.19.0-incubating/pulsar-client-1.19.0-incubating-shaded.jar",
@@ -5118,31 +6230,60 @@
                     "org.apache.pulsar:pulsar-common:jar:sources:1.19.0-incubating"
                 ],
                 "dependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                     "org.asynchttpclient:netty-resolver-dns:jar:sources:2.0.31",
+                    "io.netty:netty-codec-smtp:jar:sources:4.1.70.Final",
                     "net.jpountz.lz4:lz4:jar:sources:1.3.0",
                     "org.asynchttpclient:async-http-client:jar:sources:2.0.31",
+                    "io.netty:netty-transport-sctp:jar:sources:4.1.70.Final",
+                    "io.netty:netty-all:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
                     "com.yahoo.datasketches:sketches-core:jar:sources:0.6.0",
+                    "io.netty:netty-codec-memcache:jar:sources:4.1.70.Final",
                     "org.apache.commons:commons-lang3:jar:sources:3.11",
                     "com.google.guava:guava:jar:sources:23.6-jre",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.1.3",
+                    "io.netty:netty-codec-socks:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:jar:sources:4.1.70.Final",
                     "commons-codec:commons-codec:jar:sources:1.15",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.8.8",
+                    "io.netty:netty-resolver-dns-classes-macos:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
                     "org.apache.pulsar:pulsar-common:jar:sources:1.19.0-incubating",
+                    "io.netty:netty-transport-native-kqueue:jar:sources:4.1.70.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.asynchttpclient:netty-resolver:jar:sources:2.0.31",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
+                    "io.netty:netty-resolver-dns:jar:sources:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:jar:sources:3.14.0",
+                    "io.netty:netty-codec-haproxy:jar:sources:4.1.70.Final",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.8.8",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
                     "org.asynchttpclient:netty-codec-dns:jar:sources:2.0.31",
                     "org.apache.pulsar:pulsar-checksum:jar:sources:1.19.0-incubating",
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.8.8",
-                    "io.netty:netty-all:jar:sources:4.1.50.Final",
+                    "io.netty:netty-codec-redis:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-dns:jar:sources:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "io.netty:netty-transport-classes-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-udt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
                     "org.asynchttpclient:async-http-client-netty-utils:jar:sources:2.0.31",
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler-proxy:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-xml:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final",
                     "org.reactivestreams:reactive-streams:jar:sources:1.0.0",
-                    "com.typesafe.netty:netty-reactive-streams:jar:sources:1.0.8"
+                    "io.netty:netty-codec-http2:jar:sources:4.1.70.Final",
+                    "com.typesafe.netty:netty-reactive-streams:jar:sources:1.0.8",
+                    "io.netty:netty-codec-mqtt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/pulsar/pulsar-client/1.19.0-incubating/pulsar-client-1.19.0-incubating-sources.jar",
                 "mirror_urls": [
@@ -5157,27 +6298,59 @@
                 "file": "v1/https/jcenter.bintray.com/org/apache/pulsar/pulsar-common/1.19.0-incubating/pulsar-common-1.19.0-incubating.jar",
                 "directDependencies": [
                     "org.apache.pulsar:pulsar-checksum:1.19.0-incubating",
-                    "io.netty:netty-all:4.1.50.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "com.google.guava:guava:23.6-jre",
                     "com.google.protobuf:protobuf-java:3.14.0",
+                    "io.netty:netty-all:4.1.70.Final",
                     "com.fasterxml.jackson.core:jackson-databind:2.8.8",
                     "net.jpountz.lz4:lz4:1.3.0"
                 ],
                 "dependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:2.8.8",
+                    "io.netty:netty-codec-socks:4.1.70.Final",
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.apache.pulsar:pulsar-checksum:1.19.0-incubating",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "io.netty:netty-all:4.1.50.Final",
+                    "io.netty:netty-codec-http:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-codec-http2:4.1.70.Final",
+                    "io.netty:netty-codec-mqtt:4.1.70.Final",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "io.netty:netty-handler-proxy:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "com.google.guava:guava:23.6-jre",
+                    "io.netty:netty-codec-memcache:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:3.14.0",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "io.netty:netty-transport:4.1.70.Final",
+                    "io.netty:netty-transport-sctp:4.1.70.Final",
+                    "io.netty:netty-codec-redis:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.70.Final",
+                    "io.netty:netty-all:4.1.70.Final",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
                     "com.google.j2objc:j2objc-annotations:1.1",
                     "com.fasterxml.jackson.core:jackson-databind:2.8.8",
+                    "io.netty:netty-codec-xml:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:4.1.70.Final",
                     "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "io.netty:netty-codec-smtp:4.1.70.Final",
+                    "io.netty:netty-codec-haproxy:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:4.1.70.Final",
                     "com.fasterxml.jackson.core:jackson-core:2.8.8",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-transport-udt:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final",
                     "net.jpountz.lz4:lz4:1.3.0"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/pulsar/pulsar-common/1.19.0-incubating/pulsar-common-1.19.0-incubating.jar",
@@ -5193,28 +6366,57 @@
                 "file": "v1/https/jcenter.bintray.com/org/apache/pulsar/pulsar-common/1.19.0-incubating/pulsar-common-1.19.0-incubating-sources.jar",
                 "directDependencies": [
                     "net.jpountz.lz4:lz4:jar:sources:1.3.0",
+                    "io.netty:netty-all:jar:sources:4.1.70.Final",
                     "com.google.guava:guava:jar:sources:23.6-jre",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
                     "com.google.protobuf:protobuf-java:jar:sources:3.14.0",
                     "org.apache.pulsar:pulsar-checksum:jar:sources:1.19.0-incubating",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.8.8",
-                    "io.netty:netty-all:jar:sources:4.1.50.Final"
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.8.8"
                 ],
                 "dependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "io.netty:netty-codec-smtp:jar:sources:4.1.70.Final",
                     "net.jpountz.lz4:lz4:jar:sources:1.3.0",
+                    "io.netty:netty-transport-sctp:jar:sources:4.1.70.Final",
+                    "io.netty:netty-all:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-memcache:jar:sources:4.1.70.Final",
                     "com.google.guava:guava:jar:sources:23.6-jre",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.1.3",
+                    "io.netty:netty-codec-socks:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:jar:sources:4.1.70.Final",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.8.8",
+                    "io.netty:netty-resolver-dns-classes-macos:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
+                    "io.netty:netty-transport-native-kqueue:jar:sources:4.1.70.Final",
                     "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.14",
+                    "io.netty:netty-resolver-dns:jar:sources:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:jar:sources:3.14.0",
+                    "io.netty:netty-codec-haproxy:jar:sources:4.1.70.Final",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.8.8",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
                     "org.apache.pulsar:pulsar-checksum:jar:sources:1.19.0-incubating",
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.8.8",
-                    "io.netty:netty-all:jar:sources:4.1.50.Final",
-                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1"
+                    "io.netty:netty-codec-redis:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-dns:jar:sources:4.1.70.Final",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "io.netty:netty-transport-classes-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-udt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler-proxy:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-xml:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http2:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-mqtt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/pulsar/pulsar-common/1.19.0-incubating/pulsar-common-1.19.0-incubating-sources.jar",
                 "mirror_urls": [
@@ -5265,28 +6467,60 @@
                 ],
                 "dependencies": [
                     "org.apache.avro:avro:1.7.4",
+                    "io.netty:netty-codec-socks:4.1.70.Final",
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.apache.reef:wake:0.14.0",
-                    "io.netty:netty-all:4.1.50.Final",
+                    "io.netty:netty-codec-http:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-codec-http2:4.1.70.Final",
+                    "io.netty:netty-codec-mqtt:4.1.70.Final",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "io.netty:netty-handler-proxy:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "org.ow2.asm:asm:5.0.3",
                     "com.thoughtworks.paranamer:paranamer:2.3",
                     "org.apache.commons:commons-compress:1.14",
                     "commons-lang:commons-lang:2.6",
+                    "io.netty:netty-codec-memcache:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:3.14.0",
                     "org.apache.reef:reef-annotations:0.14.0",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
                     "cglib:cglib:3.1",
                     "commons-configuration:commons-configuration:1.10",
                     "org.apache.reef:reef-utils:0.14.0",
                     "org.apache.reef:tang:0.14.0",
                     "net.jcip:jcip-annotations:1.0",
+                    "io.netty:netty-transport:4.1.70.Final",
                     "org.xerial.snappy:snappy-java:1.1.7.2",
                     "commons-cli:commons-cli:1.3.1",
+                    "io.netty:netty-transport-sctp:4.1.70.Final",
+                    "io.netty:netty-codec-redis:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.70.Final",
+                    "io.netty:netty-all:4.1.70.Final",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
                     "org.apache.commons:commons-lang3:3.11",
+                    "io.netty:netty-codec-xml:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:4.1.70.Final",
+                    "io.netty:netty-codec-smtp:4.1.70.Final",
                     "org.codehaus.jackson:jackson-mapper-asl:1.8.8",
                     "javax.inject:javax.inject:1",
-                    "org.codehaus.jackson:jackson-core-asl:1.8.8"
+                    "io.netty:netty-codec-haproxy:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "org.codehaus.jackson:jackson-core-asl:1.8.8",
+                    "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-transport-udt:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/reef/reef-common/0.14.0/reef-common-0.14.0.jar",
                 "mirror_urls": [
@@ -5311,28 +6545,57 @@
                 ],
                 "dependencies": [
                     "org.ow2.asm:asm:jar:sources:5.0.3",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "org.codehaus.jackson:jackson-mapper-asl:jar:sources:1.8.8",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "io.netty:netty-codec-smtp:jar:sources:4.1.70.Final",
                     "org.codehaus.jackson:jackson-core-asl:jar:sources:1.8.8",
+                    "io.netty:netty-transport-sctp:jar:sources:4.1.70.Final",
+                    "io.netty:netty-all:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
                     "com.thoughtworks.paranamer:paranamer:jar:sources:2.3",
+                    "io.netty:netty-codec-memcache:jar:sources:4.1.70.Final",
                     "org.apache.commons:commons-lang3:jar:sources:3.11",
                     "net.jcip:jcip-annotations:jar:sources:1.0",
                     "org.apache.reef:reef-annotations:jar:sources:0.14.0",
                     "commons-lang:commons-lang:jar:sources:2.6",
+                    "io.netty:netty-codec-socks:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:jar:sources:4.1.70.Final",
                     "org.apache.reef:reef-utils:jar:sources:0.14.0",
                     "commons-configuration:commons-configuration:jar:sources:1.10",
                     "commons-logging:commons-logging:jar:sources:1.2",
+                    "io.netty:netty-resolver-dns-classes-macos:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
+                    "io.netty:netty-transport-native-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:jar:sources:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:jar:sources:3.14.0",
+                    "io.netty:netty-codec-haproxy:jar:sources:4.1.70.Final",
                     "org.apache.reef:wake:jar:sources:0.14.0",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
                     "org.xerial.snappy:snappy-java:jar:sources:1.1.7.2",
                     "javax.inject:javax.inject:jar:sources:1",
                     "cglib:cglib:jar:sources:3.1",
-                    "io.netty:netty-all:jar:sources:4.1.50.Final",
+                    "io.netty:netty-codec-redis:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-dns:jar:sources:4.1.70.Final",
                     "org.apache.commons:commons-compress:jar:sources:1.14",
+                    "io.netty:netty-transport-classes-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-udt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
                     "org.apache.reef:tang:jar:sources:0.14.0",
                     "org.apache.avro:avro:jar:sources:1.7.4",
-                    "commons-cli:commons-cli:jar:sources:1.3.1"
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler-proxy:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-xml:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http2:jar:sources:4.1.70.Final",
+                    "commons-cli:commons-cli:jar:sources:1.3.1",
+                    "io.netty:netty-codec-mqtt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/reef/reef-common/0.14.0/reef-common-0.14.0-sources.jar",
                 "mirror_urls": [
@@ -5350,29 +6613,61 @@
                 ],
                 "dependencies": [
                     "org.apache.avro:avro:1.7.4",
+                    "io.netty:netty-codec-socks:4.1.70.Final",
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.apache.reef:wake:0.14.0",
-                    "io.netty:netty-all:4.1.50.Final",
+                    "io.netty:netty-codec-http:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-codec-http2:4.1.70.Final",
+                    "io.netty:netty-codec-mqtt:4.1.70.Final",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "io.netty:netty-handler-proxy:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "org.ow2.asm:asm:5.0.3",
                     "com.thoughtworks.paranamer:paranamer:2.3",
                     "org.apache.commons:commons-compress:1.14",
                     "commons-lang:commons-lang:2.6",
+                    "io.netty:netty-codec-memcache:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:3.14.0",
                     "org.apache.reef:reef-annotations:0.14.0",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
                     "cglib:cglib:3.1",
                     "commons-configuration:commons-configuration:1.10",
                     "org.apache.reef:reef-utils:0.14.0",
                     "org.apache.reef:tang:0.14.0",
                     "net.jcip:jcip-annotations:1.0",
+                    "io.netty:netty-transport:4.1.70.Final",
                     "org.xerial.snappy:snappy-java:1.1.7.2",
                     "commons-cli:commons-cli:1.3.1",
+                    "io.netty:netty-transport-sctp:4.1.70.Final",
+                    "io.netty:netty-codec-redis:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.70.Final",
+                    "io.netty:netty-all:4.1.70.Final",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
                     "org.apache.commons:commons-lang3:3.11",
+                    "io.netty:netty-codec-xml:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:4.1.70.Final",
+                    "io.netty:netty-codec-smtp:4.1.70.Final",
                     "org.codehaus.jackson:jackson-mapper-asl:1.8.8",
                     "javax.inject:javax.inject:1",
                     "org.apache.reef:reef-common:0.14.0",
-                    "org.codehaus.jackson:jackson-core-asl:1.8.8"
+                    "io.netty:netty-codec-haproxy:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "org.codehaus.jackson:jackson-core-asl:1.8.8",
+                    "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-transport-udt:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/reef/reef-runtime-local/0.14.0/reef-runtime-local-0.14.0.jar",
                 "mirror_urls": [
@@ -5390,29 +6685,58 @@
                 ],
                 "dependencies": [
                     "org.ow2.asm:asm:jar:sources:5.0.3",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "org.codehaus.jackson:jackson-mapper-asl:jar:sources:1.8.8",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "io.netty:netty-codec-smtp:jar:sources:4.1.70.Final",
                     "org.codehaus.jackson:jackson-core-asl:jar:sources:1.8.8",
+                    "io.netty:netty-transport-sctp:jar:sources:4.1.70.Final",
+                    "io.netty:netty-all:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
                     "com.thoughtworks.paranamer:paranamer:jar:sources:2.3",
+                    "io.netty:netty-codec-memcache:jar:sources:4.1.70.Final",
                     "org.apache.commons:commons-lang3:jar:sources:3.11",
                     "net.jcip:jcip-annotations:jar:sources:1.0",
                     "org.apache.reef:reef-annotations:jar:sources:0.14.0",
                     "commons-lang:commons-lang:jar:sources:2.6",
+                    "io.netty:netty-codec-socks:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:jar:sources:4.1.70.Final",
                     "org.apache.reef:reef-utils:jar:sources:0.14.0",
                     "commons-configuration:commons-configuration:jar:sources:1.10",
                     "commons-logging:commons-logging:jar:sources:1.2",
+                    "io.netty:netty-resolver-dns-classes-macos:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
+                    "io.netty:netty-transport-native-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:jar:sources:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:jar:sources:3.14.0",
+                    "io.netty:netty-codec-haproxy:jar:sources:4.1.70.Final",
                     "org.apache.reef:wake:jar:sources:0.14.0",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
                     "org.xerial.snappy:snappy-java:jar:sources:1.1.7.2",
                     "javax.inject:javax.inject:jar:sources:1",
                     "cglib:cglib:jar:sources:3.1",
-                    "io.netty:netty-all:jar:sources:4.1.50.Final",
+                    "io.netty:netty-codec-redis:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-dns:jar:sources:4.1.70.Final",
                     "org.apache.commons:commons-compress:jar:sources:1.14",
+                    "io.netty:netty-transport-classes-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:jar:sources:4.1.70.Final",
                     "org.apache.reef:reef-common:jar:sources:0.14.0",
+                    "io.netty:netty-transport-udt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
                     "org.apache.reef:tang:jar:sources:0.14.0",
                     "org.apache.avro:avro:jar:sources:1.7.4",
-                    "commons-cli:commons-cli:jar:sources:1.3.1"
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler-proxy:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-xml:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http2:jar:sources:4.1.70.Final",
+                    "commons-cli:commons-cli:jar:sources:1.3.1",
+                    "io.netty:netty-codec-mqtt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/reef/reef-runtime-local/0.14.0/reef-runtime-local-0.14.0-sources.jar",
                 "mirror_urls": [
@@ -5431,30 +6755,62 @@
                 ],
                 "dependencies": [
                     "org.apache.avro:avro:1.7.4",
+                    "io.netty:netty-codec-socks:4.1.70.Final",
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.apache.reef:wake:0.14.0",
-                    "io.netty:netty-all:4.1.50.Final",
+                    "io.netty:netty-codec-http:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-codec-http2:4.1.70.Final",
+                    "io.netty:netty-codec-mqtt:4.1.70.Final",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "io.netty:netty-handler-proxy:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "org.ow2.asm:asm:5.0.3",
                     "com.thoughtworks.paranamer:paranamer:2.3",
                     "org.apache.commons:commons-compress:1.14",
                     "commons-lang:commons-lang:2.6",
+                    "io.netty:netty-codec-memcache:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:3.14.0",
                     "org.apache.reef:reef-annotations:0.14.0",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
                     "cglib:cglib:3.1",
                     "org.apache.reef:reef-utils-hadoop:0.14.0",
                     "commons-configuration:commons-configuration:1.10",
                     "org.apache.reef:reef-utils:0.14.0",
                     "org.apache.reef:tang:0.14.0",
                     "net.jcip:jcip-annotations:1.0",
+                    "io.netty:netty-transport:4.1.70.Final",
                     "org.xerial.snappy:snappy-java:1.1.7.2",
                     "commons-cli:commons-cli:1.3.1",
+                    "io.netty:netty-transport-sctp:4.1.70.Final",
+                    "io.netty:netty-codec-redis:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.70.Final",
+                    "io.netty:netty-all:4.1.70.Final",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
                     "org.apache.commons:commons-lang3:3.11",
+                    "io.netty:netty-codec-xml:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:4.1.70.Final",
+                    "io.netty:netty-codec-smtp:4.1.70.Final",
                     "org.codehaus.jackson:jackson-mapper-asl:1.8.8",
                     "javax.inject:javax.inject:1",
                     "org.apache.reef:reef-common:0.14.0",
-                    "org.codehaus.jackson:jackson-core-asl:1.8.8"
+                    "io.netty:netty-codec-haproxy:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "org.codehaus.jackson:jackson-core-asl:1.8.8",
+                    "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-transport-udt:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/reef/reef-runtime-yarn/0.14.0/reef-runtime-yarn-0.14.0.jar",
                 "mirror_urls": [
@@ -5473,30 +6829,59 @@
                 ],
                 "dependencies": [
                     "org.ow2.asm:asm:jar:sources:5.0.3",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "org.codehaus.jackson:jackson-mapper-asl:jar:sources:1.8.8",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "io.netty:netty-codec-smtp:jar:sources:4.1.70.Final",
                     "org.codehaus.jackson:jackson-core-asl:jar:sources:1.8.8",
+                    "io.netty:netty-transport-sctp:jar:sources:4.1.70.Final",
+                    "io.netty:netty-all:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
                     "com.thoughtworks.paranamer:paranamer:jar:sources:2.3",
+                    "io.netty:netty-codec-memcache:jar:sources:4.1.70.Final",
                     "org.apache.commons:commons-lang3:jar:sources:3.11",
                     "net.jcip:jcip-annotations:jar:sources:1.0",
                     "org.apache.reef:reef-annotations:jar:sources:0.14.0",
                     "commons-lang:commons-lang:jar:sources:2.6",
+                    "io.netty:netty-codec-socks:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:jar:sources:4.1.70.Final",
                     "org.apache.reef:reef-utils:jar:sources:0.14.0",
                     "commons-configuration:commons-configuration:jar:sources:1.10",
                     "commons-logging:commons-logging:jar:sources:1.2",
+                    "io.netty:netty-resolver-dns-classes-macos:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
+                    "io.netty:netty-transport-native-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:jar:sources:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:jar:sources:3.14.0",
+                    "io.netty:netty-codec-haproxy:jar:sources:4.1.70.Final",
                     "org.apache.reef:wake:jar:sources:0.14.0",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
                     "org.xerial.snappy:snappy-java:jar:sources:1.1.7.2",
                     "javax.inject:javax.inject:jar:sources:1",
                     "org.apache.reef:reef-utils-hadoop:jar:sources:0.14.0",
                     "cglib:cglib:jar:sources:3.1",
-                    "io.netty:netty-all:jar:sources:4.1.50.Final",
+                    "io.netty:netty-codec-redis:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-dns:jar:sources:4.1.70.Final",
                     "org.apache.commons:commons-compress:jar:sources:1.14",
+                    "io.netty:netty-transport-classes-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:jar:sources:4.1.70.Final",
                     "org.apache.reef:reef-common:jar:sources:0.14.0",
+                    "io.netty:netty-transport-udt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
                     "org.apache.reef:tang:jar:sources:0.14.0",
                     "org.apache.avro:avro:jar:sources:1.7.4",
-                    "commons-cli:commons-cli:jar:sources:1.3.1"
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler-proxy:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-xml:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http2:jar:sources:4.1.70.Final",
+                    "commons-cli:commons-cli:jar:sources:1.3.1",
+                    "io.netty:netty-codec-mqtt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/reef/reef-runtime-yarn/0.14.0/reef-runtime-yarn-0.14.0-sources.jar",
                 "mirror_urls": [
@@ -5514,29 +6899,61 @@
                 ],
                 "dependencies": [
                     "org.apache.avro:avro:1.7.4",
+                    "io.netty:netty-codec-socks:4.1.70.Final",
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.apache.reef:wake:0.14.0",
-                    "io.netty:netty-all:4.1.50.Final",
+                    "io.netty:netty-codec-http:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-codec-http2:4.1.70.Final",
+                    "io.netty:netty-codec-mqtt:4.1.70.Final",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "io.netty:netty-handler-proxy:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "org.ow2.asm:asm:5.0.3",
                     "com.thoughtworks.paranamer:paranamer:2.3",
                     "org.apache.commons:commons-compress:1.14",
                     "commons-lang:commons-lang:2.6",
+                    "io.netty:netty-codec-memcache:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:3.14.0",
                     "org.apache.reef:reef-annotations:0.14.0",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
                     "cglib:cglib:3.1",
                     "commons-configuration:commons-configuration:1.10",
                     "org.apache.reef:reef-utils:0.14.0",
                     "org.apache.reef:tang:0.14.0",
                     "net.jcip:jcip-annotations:1.0",
+                    "io.netty:netty-transport:4.1.70.Final",
                     "org.xerial.snappy:snappy-java:1.1.7.2",
                     "commons-cli:commons-cli:1.3.1",
+                    "io.netty:netty-transport-sctp:4.1.70.Final",
+                    "io.netty:netty-codec-redis:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.70.Final",
+                    "io.netty:netty-all:4.1.70.Final",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
                     "org.apache.commons:commons-lang3:3.11",
+                    "io.netty:netty-codec-xml:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:4.1.70.Final",
+                    "io.netty:netty-codec-smtp:4.1.70.Final",
                     "org.codehaus.jackson:jackson-mapper-asl:1.8.8",
                     "javax.inject:javax.inject:1",
                     "org.apache.reef:reef-common:0.14.0",
-                    "org.codehaus.jackson:jackson-core-asl:1.8.8"
+                    "io.netty:netty-codec-haproxy:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "org.codehaus.jackson:jackson-core-asl:1.8.8",
+                    "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-transport-udt:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/reef/reef-utils-hadoop/0.14.0/reef-utils-hadoop-0.14.0.jar",
                 "mirror_urls": [
@@ -5554,29 +6971,58 @@
                 ],
                 "dependencies": [
                     "org.ow2.asm:asm:jar:sources:5.0.3",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "org.codehaus.jackson:jackson-mapper-asl:jar:sources:1.8.8",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "io.netty:netty-codec-smtp:jar:sources:4.1.70.Final",
                     "org.codehaus.jackson:jackson-core-asl:jar:sources:1.8.8",
+                    "io.netty:netty-transport-sctp:jar:sources:4.1.70.Final",
+                    "io.netty:netty-all:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
                     "com.thoughtworks.paranamer:paranamer:jar:sources:2.3",
+                    "io.netty:netty-codec-memcache:jar:sources:4.1.70.Final",
                     "org.apache.commons:commons-lang3:jar:sources:3.11",
                     "net.jcip:jcip-annotations:jar:sources:1.0",
                     "org.apache.reef:reef-annotations:jar:sources:0.14.0",
                     "commons-lang:commons-lang:jar:sources:2.6",
+                    "io.netty:netty-codec-socks:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:jar:sources:4.1.70.Final",
                     "org.apache.reef:reef-utils:jar:sources:0.14.0",
                     "commons-configuration:commons-configuration:jar:sources:1.10",
                     "commons-logging:commons-logging:jar:sources:1.2",
+                    "io.netty:netty-resolver-dns-classes-macos:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
+                    "io.netty:netty-transport-native-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:jar:sources:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:jar:sources:3.14.0",
+                    "io.netty:netty-codec-haproxy:jar:sources:4.1.70.Final",
                     "org.apache.reef:wake:jar:sources:0.14.0",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
                     "org.xerial.snappy:snappy-java:jar:sources:1.1.7.2",
                     "javax.inject:javax.inject:jar:sources:1",
                     "cglib:cglib:jar:sources:3.1",
-                    "io.netty:netty-all:jar:sources:4.1.50.Final",
+                    "io.netty:netty-codec-redis:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-dns:jar:sources:4.1.70.Final",
                     "org.apache.commons:commons-compress:jar:sources:1.14",
+                    "io.netty:netty-transport-classes-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:jar:sources:4.1.70.Final",
                     "org.apache.reef:reef-common:jar:sources:0.14.0",
+                    "io.netty:netty-transport-udt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
                     "org.apache.reef:tang:jar:sources:0.14.0",
                     "org.apache.avro:avro:jar:sources:1.7.4",
-                    "commons-cli:commons-cli:jar:sources:1.3.1"
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler-proxy:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-xml:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http2:jar:sources:4.1.70.Final",
+                    "commons-cli:commons-cli:jar:sources:1.3.1",
+                    "io.netty:netty-codec-mqtt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/reef/reef-utils-hadoop/0.14.0/reef-utils-hadoop-0.14.0-sources.jar",
                 "mirror_urls": [
@@ -5694,31 +7140,63 @@
                 "coord": "org.apache.reef:wake:0.14.0",
                 "file": "v1/https/jcenter.bintray.com/org/apache/reef/wake/0.14.0/wake-0.14.0.jar",
                 "directDependencies": [
-                    "io.netty:netty-all:4.1.50.Final",
                     "com.google.protobuf:protobuf-java:3.14.0",
                     "cglib:cglib:3.1",
                     "org.apache.reef:tang:0.14.0",
-                    "net.jcip:jcip-annotations:1.0"
+                    "net.jcip:jcip-annotations:1.0",
+                    "io.netty:netty-all:4.1.70.Final"
                 ],
                 "dependencies": [
                     "org.apache.avro:avro:1.7.4",
-                    "io.netty:netty-all:4.1.50.Final",
+                    "io.netty:netty-codec-socks:4.1.70.Final",
+                    "io.netty:netty-handler:4.1.70.Final",
+                    "io.netty:netty-codec-http:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-codec-http2:4.1.70.Final",
+                    "io.netty:netty-codec-mqtt:4.1.70.Final",
                     "commons-logging:commons-logging:1.2",
+                    "io.netty:netty-handler-proxy:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:4.1.70.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "org.ow2.asm:asm:5.0.3",
                     "com.thoughtworks.paranamer:paranamer:2.3",
                     "org.apache.commons:commons-compress:1.14",
                     "commons-lang:commons-lang:2.6",
+                    "io.netty:netty-codec-memcache:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:3.14.0",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-codec-dns:4.1.70.Final",
                     "cglib:cglib:3.1",
                     "commons-configuration:commons-configuration:1.10",
                     "org.apache.reef:tang:0.14.0",
                     "net.jcip:jcip-annotations:1.0",
+                    "io.netty:netty-transport:4.1.70.Final",
                     "org.xerial.snappy:snappy-java:1.1.7.2",
                     "commons-cli:commons-cli:1.3.1",
+                    "io.netty:netty-transport-sctp:4.1.70.Final",
+                    "io.netty:netty-codec-redis:4.1.70.Final",
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.70.Final",
+                    "io.netty:netty-all:4.1.70.Final",
+                    "io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-classes-macos:4.1.70.Final",
+                    "io.netty:netty-codec-xml:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:4.1.70.Final",
+                    "io.netty:netty-codec-smtp:4.1.70.Final",
                     "org.codehaus.jackson:jackson-mapper-asl:1.8.8",
                     "javax.inject:javax.inject:1",
-                    "org.codehaus.jackson:jackson-core-asl:1.8.8"
+                    "io.netty:netty-codec-haproxy:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "org.codehaus.jackson:jackson-core-asl:1.8.8",
+                    "io.netty:netty-transport-classes-kqueue:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-transport-udt:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/reef/wake/0.14.0/wake-0.14.0.jar",
                 "mirror_urls": [
@@ -5732,31 +7210,60 @@
                 "coord": "org.apache.reef:wake:jar:sources:0.14.0",
                 "file": "v1/https/jcenter.bintray.com/org/apache/reef/wake/0.14.0/wake-0.14.0-sources.jar",
                 "directDependencies": [
+                    "io.netty:netty-all:jar:sources:4.1.70.Final",
                     "net.jcip:jcip-annotations:jar:sources:1.0",
                     "com.google.protobuf:protobuf-java:jar:sources:3.14.0",
                     "cglib:cglib:jar:sources:3.1",
-                    "io.netty:netty-all:jar:sources:4.1.50.Final",
                     "org.apache.reef:tang:jar:sources:0.14.0"
                 ],
                 "dependencies": [
                     "org.ow2.asm:asm:jar:sources:5.0.3",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
                     "org.codehaus.jackson:jackson-mapper-asl:jar:sources:1.8.8",
+                    "io.netty:netty-codec-smtp:jar:sources:4.1.70.Final",
                     "org.codehaus.jackson:jackson-core-asl:jar:sources:1.8.8",
+                    "io.netty:netty-transport-sctp:jar:sources:4.1.70.Final",
+                    "io.netty:netty-all:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
                     "com.thoughtworks.paranamer:paranamer:jar:sources:2.3",
+                    "io.netty:netty-codec-memcache:jar:sources:4.1.70.Final",
                     "net.jcip:jcip-annotations:jar:sources:1.0",
                     "commons-lang:commons-lang:jar:sources:2.6",
+                    "io.netty:netty-codec-socks:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-stomp:jar:sources:4.1.70.Final",
                     "commons-configuration:commons-configuration:jar:sources:1.10",
                     "commons-logging:commons-logging:jar:sources:1.2",
+                    "io.netty:netty-resolver-dns-classes-macos:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
+                    "io.netty:netty-transport-native-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns:jar:sources:4.1.70.Final",
                     "com.google.protobuf:protobuf-java:jar:sources:3.14.0",
+                    "io.netty:netty-codec-haproxy:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
                     "org.xerial.snappy:snappy-java:jar:sources:1.1.7.2",
                     "javax.inject:javax.inject:jar:sources:1",
                     "cglib:cglib:jar:sources:3.1",
-                    "io.netty:netty-all:jar:sources:4.1.50.Final",
+                    "io.netty:netty-codec-redis:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-dns:jar:sources:4.1.70.Final",
                     "org.apache.commons:commons-compress:jar:sources:1.14",
+                    "io.netty:netty-transport-classes-kqueue:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver-dns-native-macos:jar:sources:4.1.70.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-rxtx:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-udt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
                     "org.apache.reef:tang:jar:sources:0.14.0",
                     "org.apache.avro:avro:jar:sources:1.7.4",
-                    "commons-cli:commons-cli:jar:sources:1.3.1"
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler-proxy:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-xml:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http2:jar:sources:4.1.70.Final",
+                    "commons-cli:commons-cli:jar:sources:1.3.1",
+                    "io.netty:netty-codec-mqtt:jar:sources:4.1.70.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/reef/wake/0.14.0/wake-0.14.0-sources.jar",
                 "mirror_urls": [
@@ -5876,28 +7383,29 @@
                 "coord": "org.apache.zookeeper:zookeeper:3.6.3",
                 "file": "v1/https/jcenter.bintray.com/org/apache/zookeeper/zookeeper/3.6.3/zookeeper-3.6.3.jar",
                 "directDependencies": [
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.slf4j:slf4j-log4j12:1.7.25",
-                    "io.netty:netty-transport-native-epoll:4.1.63.Final",
-                    "io.netty:netty-handler:4.1.63.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "org.apache.zookeeper:zookeeper-jute:3.6.3",
                     "log4j:log4j:1.2.17",
+                    "io.netty:netty-transport-native-epoll:4.1.70.Final",
                     "org.apache.yetus:audience-annotations:0.5.0"
                 ],
                 "dependencies": [
+                    "io.netty:netty-handler:4.1.70.Final",
                     "org.slf4j:slf4j-log4j12:1.7.25",
-                    "io.netty:netty-codec:4.1.63.Final",
-                    "io.netty:netty-transport-native-epoll:4.1.63.Final",
-                    "io.netty:netty-handler:4.1.63.Final",
+                    "io.netty:netty-codec:4.1.70.Final",
                     "org.slf4j:slf4j-api:1.7.30",
                     "org.apache.zookeeper:zookeeper-jute:3.6.3",
-                    "io.netty:netty-resolver:4.1.63.Final",
-                    "io.netty:netty-buffer:4.1.63.Final",
                     "log4j:log4j:1.2.17",
-                    "io.netty:netty-transport-native-unix-common:4.1.63.Final",
-                    "io.netty:netty-common:4.1.63.Final",
+                    "io.netty:netty-transport-native-epoll:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:4.1.70.Final",
+                    "io.netty:netty-transport:4.1.70.Final",
                     "org.apache.yetus:audience-annotations:0.5.0",
-                    "io.netty:netty-transport:4.1.63.Final"
+                    "io.netty:netty-common:4.1.70.Final",
+                    "io.netty:netty-resolver:4.1.70.Final",
+                    "io.netty:netty-transport-native-unix-common:4.1.70.Final",
+                    "io.netty:netty-buffer:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/zookeeper/zookeeper/3.6.3/zookeeper-3.6.3.jar",
                 "mirror_urls": [
@@ -5913,26 +7421,27 @@
                 "directDependencies": [
                     "org.apache.zookeeper:zookeeper-jute:jar:sources:3.6.3",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
                     "org.apache.yetus:audience-annotations:jar:sources:0.5.0",
-                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.63.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-log4j12:jar:sources:1.7.25",
-                    "log4j:log4j:jar:sources:1.2.17",
-                    "io.netty:netty-handler:jar:sources:4.1.63.Final"
+                    "log4j:log4j:jar:sources:1.2.17"
                 ],
                 "dependencies": [
                     "org.apache.zookeeper:zookeeper-jute:jar:sources:3.6.3",
-                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.63.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.70.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-api:jar:sources:1.7.30",
-                    "io.netty:netty-common:jar:sources:4.1.63.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.63.Final",
-                    "io.netty:netty-buffer:jar:sources:4.1.63.Final",
+                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.70.Final",
+                    "io.netty:netty-common:jar:sources:4.1.70.Final",
                     "org.apache.yetus:audience-annotations:jar:sources:0.5.0",
-                    "io.netty:netty-transport-native-epoll:jar:sources:4.1.63.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.70.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.70.Final",
+                    "io.netty:netty-transport-classes-epoll:jar:sources:4.1.70.Final",
                     "org.slf4j:slf4j-log4j12:jar:sources:1.7.25",
+                    "io.netty:netty-codec:jar:sources:4.1.70.Final",
                     "log4j:log4j:jar:sources:1.2.17",
-                    "io.netty:netty-handler:jar:sources:4.1.63.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.63.Final"
+                    "io.netty:netty-transport-native-unix-common:jar:sources:4.1.70.Final"
                 ],
                 "url": "https://jcenter.bintray.com/org/apache/zookeeper/zookeeper/3.6.3/zookeeper-3.6.3-sources.jar",
                 "mirror_urls": [
@@ -8666,6 +10175,6 @@
             }
         ],
         "version": "0.1.0",
-        "__AUTOGENERATED_FILE_DO_NOT_MODIFY_THIS_FILE_MANUALLY": -164312140
+        "__AUTOGENERATED_FILE_DO_NOT_MODIFY_THIS_FILE_MANUALLY": 1015199925
     }
 }


### PR DESCRIPTION
In production we see error messages about not finding the native epoll library. This may be fixed in newer versions of Netty as referenced here. (https://github.com/netty/netty/issues/10537)