### PR TITLE
Restart a Topology on Kubernetes

### DIFF
--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -299,6 +299,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - deletecollection
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -156,12 +156,23 @@ public class V1Controller extends KubernetesController {
     return true;
   }
 
+  /**
+   * Restarts a topology by deleting the Pods associated with it using <code>Selector Labels</code>.
+   * @param shardId Not used but required because of interface.
+   * @return Indicator of successful submission of restart request to Kubernetes cluster.
+   */
   @Override
   boolean restart(int shardId) {
-    final String message = "Restarting the whole topology is not supported yet. "
-        + "Please kill and resubmit the topology.";
-    LOG.log(Level.SEVERE, message);
-    return false;
+    try {
+      coreClient.deleteCollectionNamespacedPod(getNamespace(), null, null, null, null,
+          0, createTopologySelectorLabels(), null, null, null, null,
+          null, null, null);
+      LOG.log(Level.WARNING, String.format("Restarting topology '%s'...", getTopologyName()));
+    } catch (ApiException e) {
+      LOG.log(Level.SEVERE, String.format("Failed to restart topology '%s'...", getTopologyName()));
+      return false;
+    }
+    return true;
   }
 
   @Override
@@ -838,5 +849,15 @@ public class V1Controller extends KubernetesController {
       KubernetesUtils.logExceptionWithDetails(LOG, message, e);
       throw new TopologySubmissionException(String.format("%s: %s", message, e.getMessage()));
     }
+  }
+
+  /**
+   * Generates the <code>Selector</code> match labels with which resources in this topology can be found.
+   * @return A label of the form <code>app=heron,topology=topology-name</code>.
+   */
+  private String createTopologySelectorLabels() {
+    return String.format("%s=%s,%s=%s",
+        KubernetesConstants.LABEL_APP, KubernetesConstants.LABEL_APP_VALUE,
+        KubernetesConstants.LABEL_TOPOLOGY, getTopologyName());
   }
 }


### PR DESCRIPTION
This PR adds the ability to `restart` a topology on the Kubernetes scheduler. It achieves this by deleting all Pods associated with the topology using a `Selector` match label for:

```yaml
metadata:
  labels:
    app: heron
    topology: <topology-name>
```

I have done some very quick deployment testing.