### PR TITLE
Kazoo version bump for Python 3.8

### DIFF
--- a/heron/statemgrs/src/python/BUILD
+++ b/heron/statemgrs/src/python/BUILD
@@ -5,7 +5,7 @@ pex_library(
     srcs = glob(["**/*.py"]),
     reqs = [
         "PyYAML==3.13",
-        "kazoo==2.7.0",
+        "kazoo==2.8.0",
         "zope.interface==4.0.5",
     ],
     deps = [


### PR DESCRIPTION
Bump kazoo library from 2.7.0 to 2.8.0 to fix a compatibility issue of Python 3.8