### PR TITLE
[Heron-3723] Add support for Empty Dir, Host Path, and NFS via CLI

### DIFF
--- a/deploy/kubernetes/general/apiserver.yaml
+++ b/deploy/kubernetes/general/apiserver.yaml
@@ -92,7 +92,7 @@ spec:
               -D heron.statefulstorage.classname=org.apache.heron.statefulstorage.dlog.DlogStorage
               -D heron.statefulstorage.dlog.namespace.uri=distributedlog://zookeeper:2181/heron
               -D heron.kubernetes.pod.template.disabled=false
-              -D heron.kubernetes.persistent.volume.claims.cli.disabled=false
+              -D heron.kubernetes.volume.from.cli.disabled=false
 
 ---
 apiVersion: v1

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -159,7 +159,7 @@ spec:
               {{- end }}
               -D heron.kubernetes.resource.request.mode={{ .Values.topologyResourceRequestMode }}
               -D heron.kubernetes.pod.template.disabled={{ .Values.disablePodTemplates }}
-              -D heron.kubernetes.persistent.volume.claims.cli.disabled={{ .Values.disablePersistentVolumeMountsCLI }}
+              -D heron.kubernetes.volume.from.cli.disabled={{ .Values.disableVolumesFromCLI }}
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-tools-config

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -77,8 +77,8 @@ packing: RoundRobin # ResourceCompliantRR, FirstFitDecreasing
 # Support for ConfigMap mounted PodTemplates
 disablePodTemplates: false
 
-# Support for Dynamic Persistent Volume Mounts from CLI input
-disablePersistentVolumeMountsCLI: false
+# Support for Voume specification from CLI input
+disableVolumesFromCLI: false
 
 # Number of replicas for storage bookies, memory and storage requirements
 bookieReplicas: 3

--- a/deploy/kubernetes/minikube/apiserver.yaml
+++ b/deploy/kubernetes/minikube/apiserver.yaml
@@ -83,7 +83,7 @@ spec:
               -D heron.statefulstorage.classname=org.apache.heron.statefulstorage.dlog.DlogStorage
               -D heron.statefulstorage.dlog.namespace.uri=distributedlog://zookeeper:2181/heronbkdl
               -D heron.kubernetes.pod.template.disabled=false
-              -D heron.kubernetes.persistent.volume.claims.cli.disabled=false
+              -D heron.kubernetes.volume.from.cli.disabled=false
 
 ---
 apiVersion: v1

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -22,8 +22,10 @@ package org.apache.heron.scheduler.kubernetes;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.apache.heron.scheduler.utils.SchedulerUtils.ExecutorPort;
@@ -128,4 +130,19 @@ public final class KubernetesConstants {
     path,               // Added to container, nfsVolume, hostPath.
     subPath,            // Added to container.
   }
+
+  protected static final Set<String> VALID_VOLUME_HOSTPATH_TYPES = Collections.unmodifiableSet(
+      new HashSet<String>() {
+        {
+          add("");
+          add("DirectoryOrCreate");
+          add("Directory");
+          add("FileOrCreate");
+          add("File");
+          add("Socket");
+          add("CharDevice");
+          add("BlockDevice");
+        }
+      }
+  );
 }

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -127,6 +127,8 @@ public final class KubernetesConstants {
     type,
     readOnly,
     server,
+    pathOnHost,
+    pathOnNFS,
     path,               // Added to container, nfsVolume, hostPath.
     subPath,            // Added to container.
   }

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -115,13 +115,17 @@ public final class KubernetesConstants {
       )
   );
 
-  enum VolumeClaimTemplateConfigKeys {
+  protected enum VolumeConfigKeys {
     claimName,
     storageClassName,
     sizeLimit,
     accessModes,
     volumeMode,
-    path,               // Added to container.
+    medium,
+    type,
+    readOnly,
+    server,
+    path,               // Added to container, nfsVolume, hostPath.
     subPath,            // Added to container.
   }
 }

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -332,13 +332,13 @@ public final class KubernetesContext extends Context {
 
       // Claim name is required.
       if (!volume.getValue().containsKey(KubernetesConstants.VolumeConfigKeys.claimName)) {
-        throw new TopologySubmissionException(String.format("Volume `%s`: `Persistent Volume"
+        throw new TopologySubmissionException(String.format("Volume `%s`: Persistent Volume"
             + " Claims require a `claimName`.", volume.getKey()));
       }
 
       final String path = volume.getValue().get(KubernetesConstants.VolumeConfigKeys.path);
       if (path == null || path.isEmpty()) {
-        throw new TopologySubmissionException(String.format("Volume `%s`: `Persistent Volume"
+        throw new TopologySubmissionException(String.format("Volume `%s`: Persistent Volume"
             + " Claims require a `path`.", volume.getKey()));
       }
 
@@ -368,6 +368,31 @@ public final class KubernetesContext extends Context {
             throw new TopologySubmissionException(String.format("Volume `%s`: Invalid Persistent"
                 + " Volume Claim type option for '%s'", volume.getKey(), key));
         }
+      }
+    }
+
+    return volumes;
+  }
+
+  /**
+   * Collects parameters form the <code>CLI</code> and validates options for <code>Empty Directory</code>s.
+   * @param config Contains the configuration options collected from the <code>CLI</code>.
+   * @param isExecutor Flag used to collect CLI commands for the <code>Executor</code> and <code>Manager</code>.
+   * @return A mapping between <code>Volumes</code> and their configuration <code>key-value</code> pairs.
+   * Will return an empty list if there are no Volume Claim Templates to be generated.
+   */
+  public static Map<String, Map<KubernetesConstants.VolumeConfigKeys, String>>
+      getVolumeEmptyDir(Config config, boolean isExecutor) {
+    final Map<String, Map<KubernetesConstants.VolumeConfigKeys, String>> volumes =
+        getVolumeConfigs(config, KubernetesContext.KUBERNETES_VOLUME_EMPTYDIR_PREFIX, isExecutor);
+
+    for (Map.Entry<String, Map<KubernetesConstants.VolumeConfigKeys, String>> volume
+        : volumes.entrySet()) {
+      final String medium = volume.getValue().get(KubernetesConstants.VolumeConfigKeys.medium);
+
+      if (medium != null && !medium.isEmpty() && !"Memory".equals(medium)) {
+        throw new TopologySubmissionException(String.format("Volume `%s`: Empty Directory"
+            + " `medium` must be `Memory` or empty.", volume.getKey()));
       }
     }
 

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -373,7 +373,7 @@ public final class KubernetesContext extends Context {
                   + " does not match lowercase RFC-1123 pattern", volume.getKey()));
             }
             break;
-          case sizeLimit: case accessModes: case volumeMode: case path: case subPath:
+          case sizeLimit: case accessModes: case volumeMode: case readOnly: case path: case subPath:
             break;
           default:
             throw new TopologySubmissionException(String.format("Volume `%s`: Invalid Persistent"
@@ -410,7 +410,7 @@ public final class KubernetesContext extends Context {
         final KubernetesConstants.VolumeConfigKeys key = volumeConfig.getKey();
 
         switch (key) {
-          case sizeLimit: case medium: case path: case subPath:
+          case sizeLimit: case medium: case readOnly: case path: case subPath:
             break;
           default:
             throw new TopologySubmissionException(String.format("Volume `%s`: Invalid Empty"
@@ -453,7 +453,7 @@ public final class KubernetesContext extends Context {
         final KubernetesConstants.VolumeConfigKeys key = volumeConfig.getKey();
 
         switch (key) {
-          case type: case pathOnHost: case path: case subPath:
+          case type: case pathOnHost: case readOnly: case path: case subPath:
             break;
           default:
             throw new TopologySubmissionException(String.format("Volume `%s`: Invalid Host Path"
@@ -496,7 +496,7 @@ public final class KubernetesContext extends Context {
         final KubernetesConstants.VolumeConfigKeys key = volumeConfig.getKey();
 
         switch (key) {
-          case readOnly: case server: case pathOnNFS: case path: case subPath:
+          case server: case pathOnNFS: case readOnly: case path: case subPath:
             break;
           default:
             throw new TopologySubmissionException(String.format("Volume `%s`: Invalid NFS option"

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -398,6 +398,18 @@ public final class KubernetesContext extends Context {
         throw new TopologySubmissionException(String.format("Volume `%s`: Empty Directory"
             + " `medium` must be `Memory` or empty.", volume.getKey()));
       }
+      for (Map.Entry<KubernetesConstants.VolumeConfigKeys, String> volumeConfig
+          : volume.getValue().entrySet()) {
+        final KubernetesConstants.VolumeConfigKeys key = volumeConfig.getKey();
+
+        switch (key) {
+          case sizeLimit: case medium: case path: case subPath:
+            break;
+          default:
+            throw new TopologySubmissionException(String.format("Volume `%s`: Invalid Empty"
+                + " Directory type option for '%s'", volume.getKey(), key));
+        }
+      }
     }
 
     return volumes;

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -310,6 +310,16 @@ public final class KubernetesContext extends Context {
       throw new TopologySubmissionException(message);
     }
 
+    // All Volumes must contain a path.
+    for (Map.Entry<String, Map<KubernetesConstants.VolumeConfigKeys, String>> volume
+        : volumes.entrySet()) {
+      final String path = volume.getValue().get(KubernetesConstants.VolumeConfigKeys.path);
+      if (path == null || path.isEmpty()) {
+        throw new TopologySubmissionException(String.format("Volume `%s`: All Volumes require a"
+            + " `path`.", volume.getKey()));
+      }
+    }
+
     return volumes;
   }
 
@@ -334,12 +344,6 @@ public final class KubernetesContext extends Context {
       if (!volume.getValue().containsKey(KubernetesConstants.VolumeConfigKeys.claimName)) {
         throw new TopologySubmissionException(String.format("Volume `%s`: Persistent Volume"
             + " Claims require a `claimName`.", volume.getKey()));
-      }
-
-      final String path = volume.getValue().get(KubernetesConstants.VolumeConfigKeys.path);
-      if (path == null || path.isEmpty()) {
-        throw new TopologySubmissionException(String.format("Volume `%s`: Persistent Volume"
-            + " Claims require a `path`.", volume.getKey()));
       }
 
       for (Map.Entry<KubernetesConstants.VolumeConfigKeys, String> volumeConfig

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -116,8 +116,8 @@ public final class KubernetesContext extends Context {
       "heron.kubernetes.pod.secretKeyRef.";
 
   // Persistent Volume Claims
-  public static final String KUBERNETES_PERSISTENT_VOLUME_CLAIMS_CLI_DISABLED =
-      "heron.kubernetes.persistent.volume.claims.cli.disabled";
+  public static final String KUBERNETES_VOLUME_FROM_CLI_DISABLED =
+      "heron.kubernetes.volume.from.cli.disabled";
   // heron.kubernetes.[executor | manager].volumes.persistentVolumeClaim.VOLUME_NAME.OPTION=VALUE
   public static final String KUBERNETES_VOLUME_CLAIM_PREFIX =
       "heron.kubernetes.%s.volumes.persistentVolumeClaim.";
@@ -253,8 +253,8 @@ public final class KubernetesContext extends Context {
     return getConfigItemsByPrefix(config, key);
   }
 
-  public static boolean getPersistentVolumeClaimDisabled(Config config) {
-    final String disabled = config.getStringValue(KUBERNETES_PERSISTENT_VOLUME_CLAIMS_CLI_DISABLED);
+  public static boolean getVolumesFromCLIDisabled(Config config) {
+    final String disabled = config.getStringValue(KUBERNETES_VOLUME_FROM_CLI_DISABLED);
     return "true".equalsIgnoreCase(disabled);
   }
 
@@ -271,6 +271,13 @@ public final class KubernetesContext extends Context {
   protected static Map<String, Map<KubernetesConstants.VolumeConfigKeys, String>>
       getVolumeConfigs(Config config, String prefix, boolean isExecutor) {
     final Logger LOG = Logger.getLogger(V1Controller.class.getName());
+
+    // Check to see if functionality is disabled.
+    if (KubernetesContext.getVolumesFromCLIDisabled(config)) {
+      final String message = "Configuring Volumes from the CLI is disabled.";
+      LOG.log(Level.WARNING, message);
+      throw new TopologySubmissionException(message);
+    }
 
     final String prefixKey = String.format(prefix,
         isExecutor ? KubernetesConstants.EXECUTOR_NAME : KubernetesConstants.MANAGER_NAME);

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -316,7 +316,7 @@ public final class KubernetesContext extends Context {
       final String path = volume.getValue().get(KubernetesConstants.VolumeConfigKeys.path);
       if (path == null || path.isEmpty()) {
         throw new TopologySubmissionException(String.format("Volume `%s`: All Volumes require a"
-            + " `path`.", volume.getKey()));
+            + " 'path'.", volume.getKey()));
       }
     }
 

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -437,8 +437,8 @@ public final class KubernetesContext extends Context {
       final String hostOnPath =
           volume.getValue().get(KubernetesConstants.VolumeConfigKeys.pathOnHost);
       if (hostOnPath == null || hostOnPath.isEmpty()) {
-        throw new TopologySubmissionException(String.format("Volume `%s`: Host Path"
-            + " requires a path on the host.", volume.getKey()));
+        throw new TopologySubmissionException(String.format("Volume `%s`: Host Path  requires a"
+            + " path on the host.", volume.getKey()));
       }
 
       for (Map.Entry<KubernetesConstants.VolumeConfigKeys, String> volumeConfig
@@ -477,17 +477,23 @@ public final class KubernetesContext extends Context {
         throw new TopologySubmissionException(String.format("Volume `%s`: `NFS` volumes require a"
             + " `server` to be specified", volume.getKey()));
       }
+      final String hostOnNFS =
+          volume.getValue().get(KubernetesConstants.VolumeConfigKeys.pathOnNFS);
+      if (hostOnNFS == null || hostOnNFS.isEmpty()) {
+        throw new TopologySubmissionException(String.format("Volume `%s`: NFS requires a path on"
+            + " the NFS server.", volume.getKey()));
+      }
 
       for (Map.Entry<KubernetesConstants.VolumeConfigKeys, String> volumeConfig
           : volume.getValue().entrySet()) {
         final KubernetesConstants.VolumeConfigKeys key = volumeConfig.getKey();
 
         switch (key) {
-          case readOnly: case server: case path: case subPath:
+          case readOnly: case server: case pathOnNFS: case path: case subPath:
             break;
           default:
-            throw new TopologySubmissionException(String.format("Volume `%s`: Invalid NFS type"
-                + " option for '%s'", volume.getKey(), key));
+            throw new TopologySubmissionException(String.format("Volume `%s`: Invalid NFS option"
+                + " for '%s'", volume.getKey(), key));
         }
       }
     }

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -121,6 +121,15 @@ public final class KubernetesContext extends Context {
   // heron.kubernetes.[executor | manager].volumes.persistentVolumeClaim.VOLUME_NAME.OPTION=VALUE
   public static final String KUBERNETES_VOLUME_CLAIM_PREFIX =
       "heron.kubernetes.%s.volumes.persistentVolumeClaim.";
+  // heron.kubernetes.[executor | manager].volumes.emptyDir.VOLUME_NAME.OPTION=VALUE
+  public static final String KUBERNETES_VOLUME_EMPTYDIR_PREFIX =
+      "heron.kubernetes.%s.volumes.emptyDir.";
+  // heron.kubernetes.[executor | manager].volumes.hostPath.VOLUME_NAME.OPTION=VALUE
+  public static final String KUBERNETES_VOLUME_HOSTPATH_PREFIX =
+      "heron.kubernetes.%s.volumes.hostPath.";
+  // heron.kubernetes.[executor | manager].volumes.nfs.VOLUME_NAME.OPTION=VALUE
+  public static final String KUBERNETES_VOLUME_NFS_PREFIX =
+      "heron.kubernetes.%s.volumes.nfs.";
   // heron.kubernetes.[executor | manager].limits.OPTION=VALUE
   public static final String KUBERNETES_RESOURCE_LIMITS_PREFIX =
       "heron.kubernetes.%s.limits.";

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -452,6 +452,43 @@ public final class KubernetesContext extends Context {
     return volumes;
   }
 
+  /**
+   * Collects parameters form the <code>CLI</code> and validates options for <code>NFS</code>s.
+   * @param config Contains the configuration options collected from the <code>CLI</code>.
+   * @param isExecutor Flag used to collect CLI commands for the <code>Executor</code> and <code>Manager</code>.
+   * @return A mapping between <code>Volumes</code> and their configuration <code>key-value</code> pairs.
+   * Will return an empty list if there are no Volume Claim Templates to be generated.
+   */
+  public static Map<String, Map<KubernetesConstants.VolumeConfigKeys, String>>
+      getVolumeNFS(Config config, boolean isExecutor) {
+    final Map<String, Map<KubernetesConstants.VolumeConfigKeys, String>> volumes =
+        getVolumeConfigs(config, KubernetesContext.KUBERNETES_VOLUME_NFS_PREFIX, isExecutor);
+
+    for (Map.Entry<String, Map<KubernetesConstants.VolumeConfigKeys, String>> volume
+        : volumes.entrySet()) {
+      final String server = volume.getValue().get(KubernetesConstants.VolumeConfigKeys.server);
+      if (server == null || server.isEmpty()) {
+        throw new TopologySubmissionException(String.format("Volume `%s`: `NFS` volumes require a"
+            + " `server` to be specified", volume.getKey()));
+      }
+
+      for (Map.Entry<KubernetesConstants.VolumeConfigKeys, String> volumeConfig
+          : volume.getValue().entrySet()) {
+        final KubernetesConstants.VolumeConfigKeys key = volumeConfig.getKey();
+
+        switch (key) {
+          case readOnly: case server: case path: case subPath:
+            break;
+          default:
+            throw new TopologySubmissionException(String.format("Volume `%s`: Invalid NFS type"
+                + " option for '%s'", volume.getKey(), key));
+        }
+      }
+    }
+
+    return volumes;
+  }
+
   static Set<String> getConfigKeys(Config config, String keyPrefix) {
     Set<String> annotations = new HashSet<>();
     for (String s : config.getKeySet()) {

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -396,7 +396,7 @@ public final class KubernetesContext extends Context {
 
       if (medium != null && !medium.isEmpty() && !"Memory".equals(medium)) {
         throw new TopologySubmissionException(String.format("Volume `%s`: Empty Directory"
-            + " `medium` must be `Memory` or empty.", volume.getKey()));
+            + " 'medium' must be 'Memory' or empty.", volume.getKey()));
       }
       for (Map.Entry<KubernetesConstants.VolumeConfigKeys, String> volumeConfig
           : volume.getValue().entrySet()) {
@@ -432,7 +432,13 @@ public final class KubernetesContext extends Context {
       final String type = volume.getValue().get(KubernetesConstants.VolumeConfigKeys.type);
       if (type != null && !KubernetesConstants.VALID_VOLUME_HOSTPATH_TYPES.contains(type)) {
         throw new TopologySubmissionException(String.format("Volume `%s`: Host Path"
-            + " `type` of '%s' is invalid.", volume.getKey(), type));
+            + " 'type' of '%s' is invalid.", volume.getKey(), type));
+      }
+      final String hostOnPath =
+          volume.getValue().get(KubernetesConstants.VolumeConfigKeys.pathOnHost);
+      if (hostOnPath == null || hostOnPath.isEmpty()) {
+        throw new TopologySubmissionException(String.format("Volume `%s`: Host Path"
+            + " requires a path on the host.", volume.getKey()));
       }
 
       for (Map.Entry<KubernetesConstants.VolumeConfigKeys, String> volumeConfig
@@ -440,11 +446,11 @@ public final class KubernetesContext extends Context {
         final KubernetesConstants.VolumeConfigKeys key = volumeConfig.getKey();
 
         switch (key) {
-          case type: case path: case subPath:
+          case type: case pathOnHost: case path: case subPath:
             break;
           default:
             throw new TopologySubmissionException(String.format("Volume `%s`: Invalid Host Path"
-                + " type option for '%s'", volume.getKey(), key));
+                + " option for '%s'", volume.getKey(), key));
         }
       }
     }

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesContext.java
@@ -255,7 +255,7 @@ public final class KubernetesContext extends Context {
    * @return A mapping between <code>Volumes</code> and their configuration <code>key-value</code> pairs.
    * Will return an empty list if there are no Volume Claim Templates to be generated.
    */
-  public static Map<String, Map<KubernetesConstants.VolumeClaimTemplateConfigKeys, String>>
+  public static Map<String, Map<KubernetesConstants.VolumeConfigKeys, String>>
       getVolumeClaimTemplates(Config config, boolean isExecutor) {
     final Logger LOG = Logger.getLogger(V1Controller.class.getName());
 
@@ -267,19 +267,17 @@ public final class KubernetesContext extends Context {
     final int optionIdx = 1;
     final Matcher matcher = KubernetesConstants.VALID_LOWERCASE_RFC_1123_REGEX.matcher("");
 
-    final Map<String, Map<KubernetesConstants.VolumeClaimTemplateConfigKeys, String>> volumes
-        = new HashMap<>();
+    final Map<String, Map<KubernetesConstants.VolumeConfigKeys, String>> volumes = new HashMap<>();
 
     try {
       for (String param : completeConfigParam) {
         final String[] tokens = param.substring(prefixLength).split("\\.");
         final String volumeName = tokens[volumeNameIdx];
-        final KubernetesConstants.VolumeClaimTemplateConfigKeys key =
-            KubernetesConstants.VolumeClaimTemplateConfigKeys.valueOf(tokens[optionIdx]);
+        final KubernetesConstants.VolumeConfigKeys key =
+            KubernetesConstants.VolumeConfigKeys.valueOf(tokens[optionIdx]);
         final String value = config.getStringValue(param);
 
-        Map<KubernetesConstants.VolumeClaimTemplateConfigKeys, String> volume =
-            volumes.get(volumeName);
+        Map<KubernetesConstants.VolumeConfigKeys, String> volume = volumes.get(volumeName);
         if (volume == null) {
           // Validate new Volume Names.
           if (!matcher.reset(volumeName).matches()) {
@@ -298,11 +296,10 @@ public final class KubernetesContext extends Context {
           [3] Check for a valid lowercase RFC-1123 pattern.
          */
         boolean claimNameNotOnDemand =
-            KubernetesConstants.VolumeClaimTemplateConfigKeys.claimName.equals(key)
+            KubernetesConstants.VolumeConfigKeys.claimName.equals(key)
                 && !KubernetesConstants.LABEL_ON_DEMAND.equalsIgnoreCase(value);
         if ((claimNameNotOnDemand // [1]
-            ||
-            KubernetesConstants.VolumeClaimTemplateConfigKeys.storageClassName.equals(key)) // [2]
+            || KubernetesConstants.VolumeConfigKeys.storageClassName.equals(key)) // [2]
             && !matcher.reset(value).matches()) { // [3]
           throw new TopologySubmissionException(
               String.format("Option `%s` value `%s` does not match lowercase RFC-1123 pattern",

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -418,14 +418,6 @@ public class V1Controller extends KubernetesController {
     // Get and then create Persistent Volume Claims from the CLI.
     final Map<String, Map<KubernetesConstants.VolumeConfigKeys, String>> configsPVC =
         KubernetesContext.getVolumeClaimTemplates(getConfiguration(), isExecutor);
-    if (KubernetesContext.getPersistentVolumeClaimDisabled(getConfiguration())
-        && !configsPVC.isEmpty()) {
-      final String message =
-          String.format("'%s': Configuring Persistent Volume Claim from CLI is disabled",
-              topologyName);
-      LOG.log(Level.WARNING, message);
-      throw new TopologySubmissionException(message);
-    }
 
     final V1StatefulSet statefulSet = new V1StatefulSet();
 

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -1070,6 +1070,7 @@ public class V1Controller extends KubernetesController {
             .withLabels(getPersistentVolumeClaimLabels(getTopologyName()))
           .endMetadata()
           .withNewSpec()
+            .withStorageClassName("")
           .endSpec()
           .build();
 

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -1113,16 +1113,26 @@ public class V1Controller extends KubernetesController {
   @VisibleForTesting
   protected V1VolumeMount createVolumeMountsCLI(String volumeName,
       Map<KubernetesConstants.VolumeConfigKeys, String> configs) {
-    final V1VolumeMountBuilder volumeMount = new V1VolumeMountBuilder()
+    final V1VolumeMount volumeMount = new V1VolumeMountBuilder()
         .withName(volumeName)
-        .withMountPath(configs.get(KubernetesConstants.VolumeConfigKeys.path));
-
-    final String subPath = configs.get(KubernetesConstants.VolumeConfigKeys.subPath);
-    if (subPath != null && !subPath.isEmpty()) {
-      volumeMount.withSubPath(subPath);
+        .build();
+    for (Map.Entry<KubernetesConstants.VolumeConfigKeys, String> config : configs.entrySet()) {
+      switch (config.getKey()) {
+        case path:
+          volumeMount.mountPath(config.getValue());
+          break;
+        case subPath:
+          volumeMount.subPath(config.getValue());
+          break;
+        case readOnly:
+          volumeMount.readOnly(Boolean.parseBoolean(config.getValue()));
+          break;
+        default:
+          break;
+      }
     }
 
-    return volumeMount.build();
+    return volumeMount;
   }
 
   /**

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -1136,6 +1136,38 @@ public class V1Controller extends KubernetesController {
   }
 
   /**
+   * Generates the <code>Volume</code>s and <code>Volume Mounts</code> for <code>Persistent Volume Claims</code>s
+   *  to be placed in the <code>Executor</code> and <code>Manager</code> from options on the CLI.
+   * @param mapConfig Mapping of <code>Volume</code> option <code>key-value</code> configuration pairs.
+   * @param volumes A list of <code>Volume</code> to append to.
+   * @param volumeMounts A list of <code>Volume Mounts</code> to append to.
+   */
+  @VisibleForTesting
+  protected void createVolumeAndMountsPersistentVolumeClaimCLI(
+      Map<String, Map<KubernetesConstants.VolumeConfigKeys, String>> mapConfig,
+      List<V1Volume> volumes, List<V1VolumeMount> volumeMounts) {
+    for (Map.Entry<String, Map<KubernetesConstants.VolumeConfigKeys, String>> configs
+        : mapConfig.entrySet()) {
+      final String volumeName = configs.getKey();
+
+      // Do not create Volumes for `OnDemand`.
+      final String claimName = configs.getValue()
+          .get(KubernetesConstants.VolumeConfigKeys.claimName);
+      if (claimName != null && !KubernetesConstants.LABEL_ON_DEMAND.equalsIgnoreCase(claimName)) {
+        volumes.add(
+            new V1VolumeBuilder()
+                .withName(volumeName)
+                .withNewPersistentVolumeClaim()
+                  .withClaimName(claimName)
+                .endPersistentVolumeClaim()
+                .build()
+        );
+      }
+      volumeMounts.add(createVolumeMountsCLI(volumeName, configs.getValue()));
+    }
+  }
+
+  /**
    * Generates the <code>Volume</code>s and <code>Volume Mounts</code> for <code>emptyDir</code>s to be
    * placed in the <code>Executor</code> and <code>Manager</code> from options on the CLI.
    * @param mapOfOpts Mapping of <code>Volume</code> option <code>key-value</code> configuration pairs.
@@ -1252,38 +1284,6 @@ public class V1Controller extends KubernetesController {
     }
   }
 
-
-  /**
-   * Generates the <code>Volume</code>s and <code>Volume Mounts</code> for <code>Persistent Volume Claims</code>s
-   *  to be placed in the <code>Executor</code> and <code>Manager</code> from options on the CLI.
-   * @param mapConfig Mapping of <code>Volume</code> option <code>key-value</code> configuration pairs.
-   * @param volumes A list of <code>Volume</code> to append to.
-   * @param volumeMounts A list of <code>Volume Mounts</code> to append to.
-   */
-  @VisibleForTesting
-  protected void createVolumeAndMountsPersistentVolumeClaimCLI(
-      Map<String, Map<KubernetesConstants.VolumeConfigKeys, String>> mapConfig,
-      List<V1Volume> volumes, List<V1VolumeMount> volumeMounts) {
-    for (Map.Entry<String, Map<KubernetesConstants.VolumeConfigKeys, String>> configs
-        : mapConfig.entrySet()) {
-      final String volumeName = configs.getKey();
-
-      // Do not create Volumes for `OnDemand`.
-      final String claimName = configs.getValue()
-          .get(KubernetesConstants.VolumeConfigKeys.claimName);
-      if (claimName != null && !KubernetesConstants.LABEL_ON_DEMAND.equalsIgnoreCase(claimName)) {
-        volumes.add(
-            new V1VolumeBuilder()
-                .withName(volumeName)
-                .withNewPersistentVolumeClaim()
-                  .withClaimName(claimName)
-                .endPersistentVolumeClaim()
-                .build()
-        );
-      }
-      volumeMounts.add(createVolumeMountsCLI(volumeName, configs.getValue()));
-    }
-  }
   /**
    * Configures the Pod Spec and Heron container with <code>Volumes</code> and <code>Volume Mounts</code>.
    * @param podSpec All generated <code>V1Volume</code> will be placed in the <code>Pod Spec</code>.

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -1096,7 +1096,30 @@ public class V1Controller extends KubernetesController {
   }
 
   /**
-   * Generates the <code>Volume</code> and <code>Volume Mounts</code> to be placed in the <code>executor container</code>.
+   * Generates the <code>Volume Mounts</code> to be placed in the <code>Executor</code>
+   * and <code>Manager</code> from options on the CLI.
+   * @param volumeName Name of the <code>Volume</code>.
+   * @param configs Mapping of <code>Volume</code> option <code>key-value</code> configuration pairs.
+   * @return A pair of configured lists of <code>V1VolumeMount</code>.
+   */
+  @VisibleForTesting
+  protected V1VolumeMount createVolumeMountsCLI(String volumeName,
+      Map<KubernetesConstants.VolumeConfigKeys, String> configs) {
+    final V1VolumeMountBuilder volumeMount = new V1VolumeMountBuilder()
+        .withName(volumeName)
+        .withMountPath(configs.get(KubernetesConstants.VolumeConfigKeys.path));
+
+    final String subPath = configs.get(KubernetesConstants.VolumeConfigKeys.subPath);
+    if (subPath != null && !subPath.isEmpty()) {
+      volumeMount.withSubPath(subPath);
+    }
+
+    return volumeMount.build();
+  }
+
+  /**
+   * Generates the <code>Volume</code>s and <code>Volume Mounts</code> to be placed in the <code>Executor</code>
+   * and <code>Manager</code> from options on the CLI.
    * @param mapConfig Mapping of <code>Volumes</code> to <code>key-value</code> configuration pairs.
    * @return A pair of configured lists of <code>V1Volume</code> and <code>V1VolumeMount</code>.
    */

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -1086,12 +1086,8 @@ public class V1Controller extends KubernetesController {
             claim.getSpec().setVolumeMode(optionValue);
             break;
           // Valid ignored options not used in a PVC.
-          case path: case subPath: case claimName:
-            break;
           default:
-            throw new TopologySubmissionException(
-                String.format("Invalid Persistent Volume Claim type option for '%s'",
-                    option.getKey()));
+            break;
         }
       }
       listOfPVCs.add(claim);
@@ -1116,11 +1112,6 @@ public class V1Controller extends KubernetesController {
           .get(KubernetesConstants.VolumeConfigKeys.path);
       final String subPath = configs.getValue()
           .get(KubernetesConstants.VolumeConfigKeys.subPath);
-
-      if (path == null || path.isEmpty()) {
-        throw new TopologySubmissionException(
-            String.format("A mount path is required and missing from '%s'", volumeName));
-      }
 
       // Do not create Volumes for `OnDemand`.
       final String claimName = configs.getValue()

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java
@@ -415,9 +415,21 @@ public class V1Controller extends KubernetesController {
     final String topologyName = getTopologyName();
     final Config runtimeConfiguration = getRuntimeConfiguration();
 
-    // Get and then create Persistent Volume Claims from the CLI.
+    final List<V1Volume> volumes = new LinkedList<>();
+    final List<V1VolumeMount> volumeMounts = new LinkedList<>();
+
+    // Collect Persistent Volume Claim configurations from the CLI.
     final Map<String, Map<KubernetesConstants.VolumeConfigKeys, String>> configsPVC =
         KubernetesContext.getVolumeClaimTemplates(getConfiguration(), isExecutor);
+
+    // Collect all Volume configurations from the CLI and generate Volumes and Volume Mounts.
+    createVolumeAndMountsPVCCLI(configsPVC, volumes, volumeMounts);
+    createVolumeAndMountsHostPathCLI(
+        KubernetesContext.getVolumeHostPath(getConfiguration(), isExecutor), volumes, volumeMounts);
+    createVolumeAndMountsEmptyDirCLI(
+        KubernetesContext.getVolumeEmptyDir(getConfiguration(), isExecutor), volumes, volumeMounts);
+    createVolumeAndMountsNFSCLI(
+        KubernetesContext.getVolumeNFS(getConfiguration(), isExecutor), volumes, volumeMounts);
 
     final V1StatefulSet statefulSet = new V1StatefulSet();
 

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
@@ -231,13 +231,6 @@ public class KubernetesContextTest {
     testCases.add(new TestTuple<>("Invalid option key should trigger exception",
         configInvalidOption, generalFailureMessage));
 
-    // Just the prefix.
-    final Config configJustPrefix = Config.newBuilder()
-        .put(KubernetesContext.KUBERNETES_VOLUME_CLAIM_PREFIX, failureValue)
-        .build();
-    testCases.add(new TestTuple<>("Only a key prefix should trigger exception",
-        configJustPrefix, generalFailureMessage));
-
     // Invalid Volume Name.
     final Config configInvalidVolumeName = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameInvalid, "path"), failureValue)
@@ -259,15 +252,17 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "medium"), passingValue)
         .build();
     testCases.add(new TestTuple<>("Missing path should trigger exception",
-        configRequiredPath, "All Volumes require a `path`."));
+        configRequiredPath, "All Volumes require a 'path'."));
 
     // Testing loop.
     for (TestTuple<Config, String> testCase : testCases) {
+      String message = "";
       try {
         KubernetesContext.getVolumeConfigs(testCase.input, prefix, true);
       } catch (TopologySubmissionException e) {
-        Assert.assertTrue(testCase.description, e.getMessage().contains(testCase.expected));
+        message = e.getMessage();
       }
+      Assert.assertTrue(testCase.description, message.contains(testCase.expected));
     }
   }
 
@@ -434,11 +429,13 @@ public class KubernetesContextTest {
 
     // Testing loop.
     for (TestTuple<Pair<Config, Boolean>, String> testCase : testCases) {
+      String message = "";
       try {
         KubernetesContext.getVolumeClaimTemplates(testCase.input.first, testCase.input.second);
       } catch (TopologySubmissionException e) {
-        Assert.assertTrue(testCase.description, e.getMessage().contains(testCase.expected));
+        message = e.getMessage();
       }
+      Assert.assertTrue(testCase.description, message.contains(testCase.expected));
     }
   }
 
@@ -587,11 +584,13 @@ public class KubernetesContextTest {
 
     // Testing loop.
     for (TestTuple<Pair<Config, Boolean>, String> testCase : testCases) {
+      String message = "";
       try {
         KubernetesContext.getVolumeEmptyDir(testCase.input.first, testCase.input.second);
       } catch (TopologySubmissionException e) {
-        Assert.assertTrue(testCase.description, e.getMessage().contains(testCase.expected));
+        message = e.getMessage();
       }
+      Assert.assertTrue(testCase.description, message.contains(testCase.expected));
     }
   }
 
@@ -741,11 +740,13 @@ public class KubernetesContextTest {
 
     // Testing loop.
     for (TestTuple<Pair<Config, Boolean>, String> testCase : testCases) {
+      String message = "";
       try {
         KubernetesContext.getVolumeHostPath(testCase.input.first, testCase.input.second);
       } catch (TopologySubmissionException e) {
-        Assert.assertTrue(testCase.description, e.getMessage().contains(testCase.expected));
+        message = e.getMessage();
       }
+      Assert.assertTrue(testCase.description, message.contains(testCase.expected));
     }
   }
 
@@ -884,11 +885,13 @@ public class KubernetesContextTest {
 
     // Testing loop.
     for (TestTuple<Pair<Config, Boolean>, String> testCase : testCases) {
+      String message = "";
       try {
         KubernetesContext.getVolumeNFS(testCase.input.first, testCase.input.second);
       } catch (TopologySubmissionException e) {
-        Assert.assertTrue(testCase.description, e.getMessage().contains(testCase.expected));
+        message = e.getMessage();
       }
+      Assert.assertTrue(testCase.description, message.contains(testCase.expected));
     }
   }
 }

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
@@ -85,18 +85,18 @@ public class KubernetesContextTest {
   }
 
   @Test
-  public void testPersistentVolumeClaimDisabled() {
-    Assert.assertFalse(KubernetesContext.getPersistentVolumeClaimDisabled(config));
+  public void testVolumesFromCLIDisabled() {
+    Assert.assertFalse(KubernetesContext.getVolumesFromCLIDisabled(config));
     Assert.assertFalse(KubernetesContext
-        .getPersistentVolumeClaimDisabled(configWithPodTemplateConfigMap));
+        .getVolumesFromCLIDisabled(configWithPodTemplateConfigMap));
 
     final Config configWithPodTemplateConfigMapOff = Config.newBuilder()
         .put(KubernetesContext.KUBERNETES_POD_TEMPLATE_LOCATION,
             POD_TEMPLATE_CONFIGMAP_NAME)
-        .put(KubernetesContext.KUBERNETES_PERSISTENT_VOLUME_CLAIMS_CLI_DISABLED, "TRUE")
+        .put(KubernetesContext.KUBERNETES_VOLUME_FROM_CLI_DISABLED, "TRUE")
         .build();
     Assert.assertTrue(KubernetesContext
-        .getPersistentVolumeClaimDisabled(configWithPodTemplateConfigMapOff));
+        .getVolumesFromCLIDisabled(configWithPodTemplateConfigMapOff));
   }
 
   /**
@@ -253,6 +253,13 @@ public class KubernetesContextTest {
         .build();
     testCases.add(new TestTuple<>("Missing path should trigger exception",
         configRequiredPath, "All Volumes require a 'path'."));
+
+    // Disabled.
+    final Config configDisabled = Config.newBuilder()
+        .put(KubernetesContext.KUBERNETES_VOLUME_FROM_CLI_DISABLED, "true")
+        .build();
+    testCases.add(new TestTuple<>("Disabled functionality should trigger exception",
+        configDisabled, "Configuring Volumes from the CLI is disabled."));
 
     // Testing loop.
     for (TestTuple<Config, String> testCase : testCases) {

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
@@ -566,6 +566,17 @@ public class KubernetesContextTest {
         .build();
     testCases.add(new TestTuple<>(processName + ": Invalid `medium` should trigger exception",
         new Pair<>(configInvalidMedium, isExecutor), "must be `Memory` or empty."));
+
+    // Medium is invalid.
+    final Config configInvalidOption = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "medium"), "Memory")
+        .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": Invalid option should trigger exception",
+        new Pair<>(configInvalidOption, isExecutor), "Directory type option"));
   }
 
   @Test

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
@@ -32,7 +32,7 @@ import org.apache.heron.scheduler.TopologySubmissionException;
 import org.apache.heron.scheduler.kubernetes.KubernetesUtils.TestTuple;
 import org.apache.heron.spi.common.Config;
 
-import static org.apache.heron.scheduler.kubernetes.KubernetesConstants.VolumeClaimTemplateConfigKeys;
+import static org.apache.heron.scheduler.kubernetes.KubernetesConstants.VolumeConfigKeys;
 
 public class KubernetesContextTest {
 
@@ -105,9 +105,9 @@ public class KubernetesContextTest {
     final String keyExecutor = String.format(keyPattern, KubernetesConstants.EXECUTOR_NAME);
     final String keyManager = String.format(keyPattern, KubernetesConstants.MANAGER_NAME);
 
-    final String storageClassField = VolumeClaimTemplateConfigKeys.storageClassName.name();
-    final String pathField = VolumeClaimTemplateConfigKeys.path.name();
-    final String claimNameField = VolumeClaimTemplateConfigKeys.claimName.name();
+    final String storageClassField = VolumeConfigKeys.storageClassName.name();
+    final String pathField = VolumeConfigKeys.path.name();
+    final String claimNameField = VolumeConfigKeys.claimName.name();
     final String expectedStorageClass = "expected-storage-class";
     final String expectedPath = "/path/for/volume/expected";
 
@@ -149,10 +149,10 @@ public class KubernetesContextTest {
           .build();
 
       final List<String> expectedKeys = Arrays.asList(volumeNameOne, volumeNameTwo);
-      final List<VolumeClaimTemplateConfigKeys> expectedOptionsKeys =
-          Arrays.asList(VolumeClaimTemplateConfigKeys.path,
-              VolumeClaimTemplateConfigKeys.storageClassName,
-              VolumeClaimTemplateConfigKeys.claimName);
+      final List<VolumeConfigKeys> expectedOptionsKeys =
+          Arrays.asList(VolumeConfigKeys.path,
+              VolumeConfigKeys.storageClassName,
+              VolumeConfigKeys.claimName);
       final List<String> expectedOptionsValues =
           Arrays.asList(expectedPath, expectedStorageClass, claimName);
 
@@ -163,14 +163,14 @@ public class KubernetesContextTest {
 
     // Test loop.
     for (TestTuple<Pair<Config, Boolean>, Object[]> testCase : testCases) {
-      final Map<String, Map<VolumeClaimTemplateConfigKeys, String>> mapOfPVC =
+      final Map<String, Map<VolumeConfigKeys, String>> mapOfPVC =
           KubernetesContext.getVolumeClaimTemplates(testCase.input.first, testCase.input.second);
 
       Assert.assertTrue(testCase.description + ": Contains all provided Volumes",
           mapOfPVC.keySet().containsAll((List<String>) testCase.expected[0]));
-      for (Map<VolumeClaimTemplateConfigKeys, String> items : mapOfPVC.values()) {
+      for (Map<VolumeConfigKeys, String> items : mapOfPVC.values()) {
         Assert.assertTrue(testCase.description + ": Contains all provided option keys",
-            items.keySet().containsAll((List<VolumeClaimTemplateConfigKeys>) testCase.expected[1]));
+            items.keySet().containsAll((List<VolumeConfigKeys>) testCase.expected[1]));
         Assert.assertTrue(testCase.description + ": Contains all provided option values",
             items.values().containsAll((List<String>) testCase.expected[2]));
       }
@@ -179,7 +179,7 @@ public class KubernetesContextTest {
     // Empty PVC.
     final Boolean[] emptyPVCTestCases = new Boolean[] {true, false};
     for (boolean testCase : emptyPVCTestCases) {
-      final Map<String, Map<VolumeClaimTemplateConfigKeys, String>> emptyPVC =
+      final Map<String, Map<VolumeConfigKeys, String>> emptyPVC =
           KubernetesContext.getVolumeClaimTemplates(Config.newBuilder().build(), testCase);
       Assert.assertTrue("Empty PVC is returned when no options provided", emptyPVC.isEmpty());
     }

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
@@ -245,16 +245,28 @@ public class KubernetesContextTest {
     testCases.add(new TestTuple<>("Invalid Volume Name should trigger exception",
         configInvalidVolumeName, "lowercase RFC-1123"));
 
+    // Required Path.
+    final Config configRequiredPath = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "claimName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "storageClassName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "volumeMode"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "server"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "type"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "medium"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>("Missing path should trigger exception",
+        configRequiredPath, "All Volumes require a `path`."));
+
     // Testing loop.
-    final Boolean[] executorFlags = new Boolean[] {true, false};
     for (TestTuple<Config, String> testCase : testCases) {
-      // Test for both Executor and Manager.
-      for (boolean isExecutor : executorFlags) {
-        try {
-          KubernetesContext.getVolumeConfigs(testCase.input, prefix, isExecutor);
-        } catch (TopologySubmissionException e) {
-          Assert.assertTrue(testCase.description, e.getMessage().contains(testCase.expected));
-        }
+      try {
+        KubernetesContext.getVolumeConfigs(testCase.input, prefix, true);
+      } catch (TopologySubmissionException e) {
+        Assert.assertTrue(testCase.description, e.getMessage().contains(testCase.expected));
       }
     }
   }
@@ -386,13 +398,6 @@ public class KubernetesContextTest {
     testCases.add(new TestTuple<>(processName + ": Invalid Claim Name should trigger exception",
         new Pair<>(configInvalidClaimName, isExecutor),
         String.format("Volume `%s`: `claimName`", volumeNameValid)));
-
-    // Required Path.
-    final Config configRequiredPath = Config.newBuilder()
-        .put(String.format(keyPattern, volumeNameValid, "claimName"), passingValue)
-        .build();
-    testCases.add(new TestTuple<>(processName + ": Invalid Claim Name should trigger exception",
-        new Pair<>(configRequiredPath, isExecutor), "require a `path`"));
 
     // Invalid Storage Class Name.
     final Config configInvalidStorageClassName = Config.newBuilder()

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
@@ -773,6 +773,7 @@ public class KubernetesContextTest {
           {
             put(VolumeConfigKeys.server, "nfs-server.default.local");
             put(VolumeConfigKeys.readOnly, "true");
+            put(VolumeConfigKeys.pathOnNFS, passingValue);
             put(VolumeConfigKeys.path, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
           }
@@ -780,6 +781,7 @@ public class KubernetesContextTest {
     final Config configWithReadOnly = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameValid, "server"), "nfs-server.default.local")
         .put(String.format(keyPattern, volumeNameValid, "readOnly"), "true")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
         .build();
@@ -791,12 +793,14 @@ public class KubernetesContextTest {
         ImmutableMap.of(volumeNameValid, new HashMap<VolumeConfigKeys, String>() {
           {
             put(VolumeConfigKeys.server, "nfs-server.default.local");
+            put(VolumeConfigKeys.pathOnNFS, passingValue);
             put(VolumeConfigKeys.path, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
           }
         });
     final Config configWithoutReadOnly = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameValid, "server"), "nfs-server.default.local")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
         .build();
@@ -807,6 +811,7 @@ public class KubernetesContextTest {
     final Config configIgnored = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameValid, "server"), "nfs-server.default.local")
         .put(String.format(keyPattern, volumeNameValid, "readOnly"), "true")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
         .build();
@@ -850,6 +855,7 @@ public class KubernetesContextTest {
     final Config configNoServer = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameValid, "readOnly"), "false")
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": No `server` should trigger exception",
@@ -859,22 +865,45 @@ public class KubernetesContextTest {
     final Config configInvalidServer = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameValid, "server"), "")
         .put(String.format(keyPattern, volumeNameValid, "readOnly"), "false")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": Invalid `server` should trigger exception",
         new Pair<>(configInvalidServer, isExecutor), "`NFS` volumes require a"));
 
+    // Path on NFS missing.
+    final Config configNoNFSPath = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "server"), "nfs-server.default.local")
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), "false")
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": No path on NFS should trigger exception",
+        new Pair<>(configNoNFSPath, isExecutor), "NFS requires a path on"));
+
+    // Path on NFS is empty.
+    final Config configEmptyNFSPath = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "server"), "nfs-server.default.local")
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), "false")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), "")
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": No path on NFS should trigger exception",
+        new Pair<>(configEmptyNFSPath, isExecutor), "NFS requires a path on"));
+
     // Invalid option.
     final Config configInvalidOption = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameValid, "server"), "nfs-server.default.local")
         .put(String.format(keyPattern, volumeNameValid, "readOnly"), "false")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": Invalid option should trigger exception",
-        new Pair<>(configInvalidOption, isExecutor), "Invalid NFS type"));
+        new Pair<>(configInvalidOption, isExecutor), "Invalid NFS option"));
   }
 
   @Test

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
@@ -301,6 +301,7 @@ public class KubernetesContextTest {
             put(VolumeConfigKeys.volumeMode, passingValue);
             put(VolumeConfigKeys.path, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
           }
         });
     final Config configWithStorageClass = Config.newBuilder()
@@ -311,6 +312,7 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "volumeMode"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": PVC with Storage Class name",
         new Pair<>(configWithStorageClass, isExecutor), expectedWithStorageClassName));
@@ -325,6 +327,7 @@ public class KubernetesContextTest {
             put(VolumeConfigKeys.volumeMode, passingValue);
             put(VolumeConfigKeys.path, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
           }
         });
     final Config configWithoutStorageClass = Config.newBuilder()
@@ -334,6 +337,7 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "volumeMode"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": PVC with Storage Class name",
         new Pair<>(configWithoutStorageClass, isExecutor), expectedWithoutStorageClassName));
@@ -347,6 +351,7 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "volumeMode"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": PVC with ignored keys",
         new Pair<>(configIgnored, !isExecutor), new HashMap<>()));
@@ -471,6 +476,7 @@ public class KubernetesContextTest {
             put(VolumeConfigKeys.medium, "Memory");
             put(VolumeConfigKeys.path, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
           }
         });
     final Config configWithMedium = Config.newBuilder()
@@ -478,6 +484,7 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "medium"), "Memory")
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": `emptyDir` with `medium`",
         new Pair<>(configWithMedium, isExecutor), expectedWithMedium));
@@ -490,6 +497,7 @@ public class KubernetesContextTest {
             put(VolumeConfigKeys.medium, "");
             put(VolumeConfigKeys.path, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
           }
         });
     final Config configEmptyMedium = Config.newBuilder()
@@ -497,6 +505,7 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "medium"), "")
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": `emptyDir` with empty `medium`",
         new Pair<>(configEmptyMedium, isExecutor), expectedEmptyMedium));
@@ -508,12 +517,14 @@ public class KubernetesContextTest {
             put(VolumeConfigKeys.sizeLimit, passingValue);
             put(VolumeConfigKeys.path, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
           }
         });
     final Config configNoMedium = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": `emptyDir` without `medium`",
         new Pair<>(configNoMedium, isExecutor), expectedNoMedium));
@@ -524,6 +535,7 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "medium"), "")
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": `emptyDir` ignored",
         new Pair<>(configIgnored, !isExecutor), new HashMap<>()));
@@ -626,6 +638,7 @@ public class KubernetesContextTest {
             put(VolumeConfigKeys.path, passingValue);
             put(VolumeConfigKeys.pathOnHost, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
           }
         });
     final Config configWithType = Config.newBuilder()
@@ -633,6 +646,7 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": 'hostPath' with 'type'",
         new Pair<>(configWithType, isExecutor), expectedWithType));
@@ -644,12 +658,14 @@ public class KubernetesContextTest {
             put(VolumeConfigKeys.pathOnHost, passingValue);
             put(VolumeConfigKeys.path, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
           }
         });
     final Config configWithoutType = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": 'hostPath' without 'type'",
         new Pair<>(configWithoutType, isExecutor), expectedWithoutType));
@@ -660,6 +676,7 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": 'hostPath' ignored",
         new Pair<>(configIgnored, !isExecutor), new HashMap<>()));
@@ -783,6 +800,7 @@ public class KubernetesContextTest {
             put(VolumeConfigKeys.pathOnNFS, passingValue);
             put(VolumeConfigKeys.path, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
           }
         });
     final Config configWithReadOnly = Config.newBuilder()
@@ -791,6 +809,7 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": `NFS` with `readOnly`",
         new Pair<>(configWithReadOnly, isExecutor), expectedWithReadOnly));
@@ -803,6 +822,7 @@ public class KubernetesContextTest {
             put(VolumeConfigKeys.pathOnNFS, passingValue);
             put(VolumeConfigKeys.path, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
           }
         });
     final Config configWithoutReadOnly = Config.newBuilder()
@@ -810,6 +830,7 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": `NFS` without `readOnly`",
         new Pair<>(configWithoutReadOnly, isExecutor), expectedWithoutReadOnly));
@@ -821,6 +842,7 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": `NFS` ignored",
         new Pair<>(configIgnored, !isExecutor), new HashMap<>()));

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
@@ -564,8 +564,8 @@ public class KubernetesContextTest {
         .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "medium"), failureValue)
         .build();
-    testCases.add(new TestTuple<>(processName + ": Invalid `medium` should trigger exception",
-        new Pair<>(configInvalidMedium, isExecutor), "must be `Memory` or empty."));
+    testCases.add(new TestTuple<>(processName + ": Invalid 'medium' should trigger exception",
+        new Pair<>(configInvalidMedium, isExecutor), "must be 'Memory' or empty."));
 
     // Invalid option.
     final Config configInvalidOption = Config.newBuilder()
@@ -618,39 +618,44 @@ public class KubernetesContextTest {
           {
             put(VolumeConfigKeys.type, "DirectoryOrCreate");
             put(VolumeConfigKeys.path, passingValue);
+            put(VolumeConfigKeys.pathOnHost, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
           }
         });
     final Config configWithType = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameValid, "type"), "DirectoryOrCreate")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
         .build();
-    testCases.add(new TestTuple<>(processName + ": `hostPath` with `type`",
+    testCases.add(new TestTuple<>(processName + ": 'hostPath' with 'type'",
         new Pair<>(configWithType, isExecutor), expectedWithType));
 
     // Without type.
     final Map<String, Map<VolumeConfigKeys, String>> expectedWithoutType =
         ImmutableMap.of(volumeNameValid, new HashMap<VolumeConfigKeys, String>() {
           {
+            put(VolumeConfigKeys.pathOnHost, passingValue);
             put(VolumeConfigKeys.path, passingValue);
             put(VolumeConfigKeys.subPath, passingValue);
           }
         });
     final Config configWithoutType = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
         .build();
-    testCases.add(new TestTuple<>(processName + ": `hostPath` without `type`",
+    testCases.add(new TestTuple<>(processName + ": 'hostPath' without 'type'",
         new Pair<>(configWithoutType, isExecutor), expectedWithoutType));
 
     // Ignored.
     final Config configIgnored = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameValid, "type"), "BlockDevice")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
         .build();
-    testCases.add(new TestTuple<>(processName + ": `hostPath` ignored",
+    testCases.add(new TestTuple<>(processName + ": 'hostPath' ignored",
         new Pair<>(configIgnored, !isExecutor), new HashMap<>()));
   }
 
@@ -690,21 +695,42 @@ public class KubernetesContextTest {
     // Type is invalid.
     final Config configInvalidMedium = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameValid, "type"), failureValue)
+        .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
         .build();
-    testCases.add(new TestTuple<>(processName + ": Invalid `type should trigger exception",
-        new Pair<>(configInvalidMedium, isExecutor), "Host Path `type` of"));
+    testCases.add(new TestTuple<>(processName + ": Invalid 'type' should trigger exception",
+        new Pair<>(configInvalidMedium, isExecutor), "Host Path 'type' of"));
+
+    // Path on Host is missing.
+    final Config configNoHostOnPath = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "type"), "BlockDevice")
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": No 'hostOnPath' should trigger exception",
+        new Pair<>(configNoHostOnPath, isExecutor), "requires a path on the host"));
+
+    // Path on Host is empty.
+    final Config configEmptyHostOnPath = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "type"), "BlockDevice")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), "")
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": Empty 'hostOnPath' should trigger exception",
+        new Pair<>(configEmptyHostOnPath, isExecutor), "requires a path on the host"));
 
     // Invalid option.
     final Config configInvalidOption = Config.newBuilder()
         .put(String.format(keyPattern, volumeNameValid, "type"), "BlockDevice")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
         .build();
     testCases.add(new TestTuple<>(processName + ": Invalid option should trigger exception",
-        new Pair<>(configInvalidOption, isExecutor), "Invalid Host Path type option for"));
+        new Pair<>(configInvalidOption, isExecutor), "Invalid Host Path option for"));
   }
 
   @Test

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -981,13 +981,13 @@ public class V1ControllerTest {
         .build();
 
     // Test case container.
-    final List<TestTuple<Pair<List<V1Volume>, List<V1VolumeMount>>,
+    // Input: Map of Volume configurations.
+    // Output: The expected lists of Volumes and Volume Mounts.
+    final List<TestTuple<Map<String, Map<VolumeConfigKeys, String>>,
         Pair<List<V1Volume>, List<V1VolumeMount>>>> testCases = new LinkedList<>();
 
     // Default case: No PVC provided.
-    final Pair<List<V1Volume>, List<V1VolumeMount>> actualEmpty =
-        v1ControllerPodTemplate.createPersistentVolumeClaimVolumesAndMounts(new HashMap<>());
-    testCases.add(new TestTuple<>("Generated an empty list of Volumes", actualEmpty,
+    testCases.add(new TestTuple<>("Generated an empty list of Volumes", new HashMap<>(),
         new Pair<>(new LinkedList<>(), new LinkedList<>())));
 
     // PVC Provided.
@@ -995,18 +995,21 @@ public class V1ControllerTest {
         new Pair<>(
             new LinkedList<>(Arrays.asList(volumeOne, volumeTwo)),
             new LinkedList<>(Arrays.asList(volumeMountOne, volumeMountTwo)));
-    final Pair<List<V1Volume>, List<V1VolumeMount>> actualFull =
-        v1ControllerPodTemplate.createPersistentVolumeClaimVolumesAndMounts(mapOfOpts);
-    testCases.add(new TestTuple<>("Generated a list of Volumes", actualFull,
+    testCases.add(new TestTuple<>("Generated a list of Volumes", mapOfOpts,
         new Pair<>(expectedFull.first, expectedFull.second)));
 
     // Testing loop.
-    for (TestTuple<Pair<List<V1Volume>, List<V1VolumeMount>>,
+    for (TestTuple<Map<String, Map<VolumeConfigKeys, String>>,
              Pair<List<V1Volume>, List<V1VolumeMount>>> testCase : testCases) {
+      List<V1Volume> actualVolume = new LinkedList<>();
+      List<V1VolumeMount> actualVolumeMount = new LinkedList<>();
+      v1ControllerPodTemplate.createVolumeAndMountsPVCCLI(testCase.input, actualVolume,
+          actualVolumeMount);
+
       Assert.assertTrue(testCase.description,
-          (testCase.expected.first).containsAll(testCase.input.first));
+          (testCase.expected.first).containsAll(actualVolume));
       Assert.assertTrue(testCase.description + " Mounts",
-          (testCase.expected.second).containsAll(testCase.input.second));
+          (testCase.expected.second).containsAll(actualVolumeMount));
     }
   }
 

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -66,7 +66,7 @@ import io.kubernetes.client.openapi.models.V1VolumeBuilder;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import io.kubernetes.client.openapi.models.V1VolumeMountBuilder;
 
-import static org.apache.heron.scheduler.kubernetes.KubernetesConstants.VolumeClaimTemplateConfigKeys;
+import static org.apache.heron.scheduler.kubernetes.KubernetesConstants.VolumeConfigKeys;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -866,37 +866,37 @@ public class V1ControllerTest {
     final String volumeMode = "VolumeMode";
     final String path = "/path/to/mount/";
     final String subPath = "/sub/path/to/mount/";
-    final Map<String, Map<VolumeClaimTemplateConfigKeys, String>> mapPVCOpts =
+    final Map<String, Map<VolumeConfigKeys, String>> mapPVCOpts =
         ImmutableMap.of(
-            volumeNameOne, new HashMap<VolumeClaimTemplateConfigKeys, String>() {
+            volumeNameOne, new HashMap<VolumeConfigKeys, String>() {
               {
-                put(VolumeClaimTemplateConfigKeys.claimName, claimNameOne);
-                put(VolumeClaimTemplateConfigKeys.storageClassName, storageClassName);
-                put(VolumeClaimTemplateConfigKeys.sizeLimit, sizeLimit);
-                put(VolumeClaimTemplateConfigKeys.accessModes, accessModesList);
-                put(VolumeClaimTemplateConfigKeys.volumeMode, volumeMode);
-                put(VolumeClaimTemplateConfigKeys.path, path);
+                put(VolumeConfigKeys.claimName, claimNameOne);
+                put(VolumeConfigKeys.storageClassName, storageClassName);
+                put(VolumeConfigKeys.sizeLimit, sizeLimit);
+                put(VolumeConfigKeys.accessModes, accessModesList);
+                put(VolumeConfigKeys.volumeMode, volumeMode);
+                put(VolumeConfigKeys.path, path);
               }
             },
-            volumeNameTwo, new HashMap<VolumeClaimTemplateConfigKeys, String>() {
+            volumeNameTwo, new HashMap<VolumeConfigKeys, String>() {
               {
-                put(VolumeClaimTemplateConfigKeys.claimName, claimNameTwo);
-                put(VolumeClaimTemplateConfigKeys.storageClassName, storageClassName);
-                put(VolumeClaimTemplateConfigKeys.sizeLimit, sizeLimit);
-                put(VolumeClaimTemplateConfigKeys.accessModes, accessModes);
-                put(VolumeClaimTemplateConfigKeys.volumeMode, volumeMode);
-                put(VolumeClaimTemplateConfigKeys.path, path);
-                put(VolumeClaimTemplateConfigKeys.subPath, subPath);
+                put(VolumeConfigKeys.claimName, claimNameTwo);
+                put(VolumeConfigKeys.storageClassName, storageClassName);
+                put(VolumeConfigKeys.sizeLimit, sizeLimit);
+                put(VolumeConfigKeys.accessModes, accessModes);
+                put(VolumeConfigKeys.volumeMode, volumeMode);
+                put(VolumeConfigKeys.path, path);
+                put(VolumeConfigKeys.subPath, subPath);
               }
             },
-            volumeNameStatic, new HashMap<VolumeClaimTemplateConfigKeys, String>() {
+            volumeNameStatic, new HashMap<VolumeConfigKeys, String>() {
               {
-                put(VolumeClaimTemplateConfigKeys.claimName, claimNameStatic);
-                put(VolumeClaimTemplateConfigKeys.sizeLimit, sizeLimit);
-                put(VolumeClaimTemplateConfigKeys.accessModes, accessModes);
-                put(VolumeClaimTemplateConfigKeys.volumeMode, volumeMode);
-                put(VolumeClaimTemplateConfigKeys.path, path);
-                put(VolumeClaimTemplateConfigKeys.subPath, subPath);
+                put(VolumeConfigKeys.claimName, claimNameStatic);
+                put(VolumeConfigKeys.sizeLimit, sizeLimit);
+                put(VolumeConfigKeys.accessModes, accessModes);
+                put(VolumeConfigKeys.volumeMode, volumeMode);
+                put(VolumeConfigKeys.path, path);
+                put(VolumeConfigKeys.subPath, subPath);
               }
             }
         );
@@ -948,15 +948,15 @@ public class V1ControllerTest {
     final String mountPathOne = "/mount/path/ONE";
     final String mountPathTwo = "/mount/path/TWO";
     final String mountSubPathTwo = "/mount/sub/path/TWO";
-    Map<String, Map<VolumeClaimTemplateConfigKeys, String>> mapOfOpts =
+    Map<String, Map<VolumeConfigKeys, String>> mapOfOpts =
         ImmutableMap.of(
             volumeNameOne, ImmutableMap.of(
-                VolumeClaimTemplateConfigKeys.claimName, claimNameOne,
-                VolumeClaimTemplateConfigKeys.path, mountPathOne),
+                VolumeConfigKeys.claimName, claimNameOne,
+                VolumeConfigKeys.path, mountPathOne),
             volumeNameTwo, ImmutableMap.of(
-                VolumeClaimTemplateConfigKeys.claimName, claimNameTwo,
-                VolumeClaimTemplateConfigKeys.path, mountPathTwo,
-                VolumeClaimTemplateConfigKeys.subPath, mountSubPathTwo)
+                VolumeConfigKeys.claimName, claimNameTwo,
+                VolumeConfigKeys.path, mountPathTwo,
+                VolumeConfigKeys.subPath, mountSubPathTwo)
         );
     final V1Volume volumeOne = new V1VolumeBuilder()
         .withName(volumeNameOne)

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -1222,4 +1222,93 @@ public class V1ControllerTest {
       Assert.assertEquals(testCase.description, testCase.expected, actual);
     }
   }
+
+  @Test
+  public void testCreateVolumeMountsCLI() {
+    final String volumeNamePVC = "volume-name-pvc";
+    final String volumeNameHostPath = "volume-name-host-path";
+    final String volumeNameEmptyDir = "volume-name-empty-dir";
+    final String volumeNameNFS = "volume-name-nfs";
+    final String value = "inserted-value";
+
+    // Test case container.
+    // Input: [0] volume name, [1] volume options
+    // Output: The expected <V1VolumeMount>.
+    final List<TestTuple<Pair<String, Map<VolumeConfigKeys, String>>, V1VolumeMount>> testCases =
+        new LinkedList<>();
+
+    // PVC.
+    final Map<VolumeConfigKeys, String> configPVC = ImmutableMap.<VolumeConfigKeys, String>builder()
+        .put(VolumeConfigKeys.claimName, value)
+        .put(VolumeConfigKeys.storageClassName, value)
+        .put(VolumeConfigKeys.sizeLimit, value)
+        .put(VolumeConfigKeys.accessModes, value)
+        .put(VolumeConfigKeys.volumeMode, value)
+        .put(VolumeConfigKeys.path, value)
+        .put(VolumeConfigKeys.subPath, value)
+        .build();
+    final V1VolumeMount volumeMountPVC = new V1VolumeMountBuilder()
+        .withName(volumeNamePVC)
+        .withMountPath(value)
+        .withSubPath(value)
+        .build();
+    testCases.add(new TestTuple<>("PVC volume mount",
+        new Pair<>(volumeNamePVC, configPVC), volumeMountPVC));
+
+    // Host Path.
+    final Map<VolumeConfigKeys, String> configHostPath =
+        ImmutableMap.<VolumeConfigKeys, String>builder()
+            .put(VolumeConfigKeys.type, "DirectoryOrCreate")
+            .put(VolumeConfigKeys.pathOnHost, value)
+            .put(VolumeConfigKeys.path, value)
+            .put(VolumeConfigKeys.subPath, value)
+            .build();
+    final V1VolumeMount volumeMountHostPath = new V1VolumeMountBuilder()
+        .withName(volumeNameHostPath)
+        .withMountPath(value)
+        .withSubPath(value)
+        .build();
+    testCases.add(new TestTuple<>("Host Path volume mount",
+        new Pair<>(volumeNameHostPath, configHostPath), volumeMountHostPath));
+
+    // Empty Dir.
+    final Map<VolumeConfigKeys, String> configEmptyDir =
+        ImmutableMap.<VolumeConfigKeys, String>builder()
+            .put(VolumeConfigKeys.sizeLimit, value)
+            .put(VolumeConfigKeys.medium, "Memory")
+            .put(VolumeConfigKeys.path, value)
+            .put(VolumeConfigKeys.subPath, value)
+            .build();
+    final V1VolumeMount volumeMountEmptyDir = new V1VolumeMountBuilder()
+        .withName(volumeNameEmptyDir)
+        .withMountPath(value)
+        .withSubPath(value)
+        .build();
+    testCases.add(new TestTuple<>("Empty Dir volume mount",
+        new Pair<>(volumeNameEmptyDir, configEmptyDir), volumeMountEmptyDir));
+
+    // NFS.
+    final Map<VolumeConfigKeys, String> configNFS = ImmutableMap.<VolumeConfigKeys, String>builder()
+        .put(VolumeConfigKeys.type, "DirectoryOrCreate")
+        .put(VolumeConfigKeys.pathOnHost, value)
+        .put(VolumeConfigKeys.path, value)
+        .put(VolumeConfigKeys.subPath, value)
+        .build();
+    final V1VolumeMount volumeMountNFS = new V1VolumeMountBuilder()
+        .withName(volumeNameNFS)
+        .withMountPath(value)
+        .withSubPath(value)
+        .build();
+    testCases.add(new TestTuple<>("NFS volume mount",
+        new Pair<>(volumeNameNFS, configNFS), volumeMountNFS));
+
+    // Test loop.
+    for (TestTuple<Pair<String, Map<VolumeConfigKeys, String>>, V1VolumeMount> testCase
+        : testCases) {
+      V1VolumeMount actual = v1ControllerPodTemplate.createVolumeMountsCLI(
+          testCase.input.first, testCase.input.second);
+      Assert.assertEquals(testCase.description, testCase.expected, actual);
+    }
+
+  }
 }

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -921,6 +921,7 @@ public class V1ControllerTest {
           .withLabels(V1Controller.getPersistentVolumeClaimLabels(topologyName))
         .endMetadata()
         .withNewSpec()
+          .withStorageClassName("")
           .withAccessModes(Collections.singletonList(accessModes))
           .withVolumeMode(volumeMode)
           .withNewResources()

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -1239,11 +1239,13 @@ public class V1ControllerTest {
         .put(VolumeConfigKeys.volumeMode, value)
         .put(VolumeConfigKeys.path, value)
         .put(VolumeConfigKeys.subPath, value)
+        .put(VolumeConfigKeys.readOnly, "true")
         .build();
     final V1VolumeMount volumeMountPVC = new V1VolumeMountBuilder()
         .withName(volumeNamePVC)
         .withMountPath(value)
         .withSubPath(value)
+        .withReadOnly(true)
         .build();
     testCases.add(new TestTuple<>("PVC volume mount",
         new Pair<>(volumeNamePVC, configPVC), volumeMountPVC));
@@ -1255,11 +1257,13 @@ public class V1ControllerTest {
             .put(VolumeConfigKeys.pathOnHost, value)
             .put(VolumeConfigKeys.path, value)
             .put(VolumeConfigKeys.subPath, value)
+            .put(VolumeConfigKeys.readOnly, "true")
             .build();
     final V1VolumeMount volumeMountHostPath = new V1VolumeMountBuilder()
         .withName(volumeNameHostPath)
         .withMountPath(value)
         .withSubPath(value)
+        .withReadOnly(true)
         .build();
     testCases.add(new TestTuple<>("Host Path volume mount",
         new Pair<>(volumeNameHostPath, configHostPath), volumeMountHostPath));
@@ -1271,11 +1275,13 @@ public class V1ControllerTest {
             .put(VolumeConfigKeys.medium, "Memory")
             .put(VolumeConfigKeys.path, value)
             .put(VolumeConfigKeys.subPath, value)
+            .put(VolumeConfigKeys.readOnly, "true")
             .build();
     final V1VolumeMount volumeMountEmptyDir = new V1VolumeMountBuilder()
         .withName(volumeNameEmptyDir)
         .withMountPath(value)
         .withSubPath(value)
+        .withReadOnly(true)
         .build();
     testCases.add(new TestTuple<>("Empty Dir volume mount",
         new Pair<>(volumeNameEmptyDir, configEmptyDir), volumeMountEmptyDir));
@@ -1292,6 +1298,7 @@ public class V1ControllerTest {
         .withName(volumeNameNFS)
         .withMountPath(value)
         .withSubPath(value)
+        .withReadOnly(true)
         .build();
     testCases.add(new TestTuple<>("NFS volume mount",
         new Pair<>(volumeNameNFS, configNFS), volumeMountNFS));
@@ -1425,6 +1432,7 @@ public class V1ControllerTest {
             .withName(volumeName)
             .withMountPath(path)
             .withSubPath(subPath)
+            .withReadOnly(true)
             .build()
     );
 

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -1289,8 +1289,9 @@ public class V1ControllerTest {
 
     // NFS.
     final Map<VolumeConfigKeys, String> configNFS = ImmutableMap.<VolumeConfigKeys, String>builder()
-        .put(VolumeConfigKeys.type, "DirectoryOrCreate")
-        .put(VolumeConfigKeys.pathOnHost, value)
+        .put(VolumeConfigKeys.server, "nfs.server.address")
+        .put(VolumeConfigKeys.readOnly, "true")
+        .put(VolumeConfigKeys.pathOnNFS, value)
         .put(VolumeConfigKeys.path, value)
         .put(VolumeConfigKeys.subPath, value)
         .build();
@@ -1310,5 +1311,134 @@ public class V1ControllerTest {
       Assert.assertEquals(testCase.description, testCase.expected, actual);
     }
 
+  }
+
+  @Test
+  public void testCreateVolumeAndMountsEmptyDirCLI() {
+    final String volumeName = "volume-name-empty-dir";
+    final String medium = "Memory";
+    final String sizeLimit = "1Gi";
+    final String path = "/path/to/mount";
+    final String subPath = "/sub/path/to/mount";
+
+    // Empty Dir.
+    final Map<String, Map<VolumeConfigKeys, String>> config =
+        ImmutableMap.of(volumeName, new HashMap<VolumeConfigKeys, String>() {
+          {
+            put(VolumeConfigKeys.sizeLimit, sizeLimit);
+            put(VolumeConfigKeys.medium, "Memory");
+            put(VolumeConfigKeys.path, path);
+            put(VolumeConfigKeys.subPath, subPath);
+          }
+        });
+    final List<V1Volume> expectedVolumes = Collections.singletonList(
+        new V1VolumeBuilder()
+            .withName(volumeName)
+            .withNewEmptyDir()
+              .withMedium(medium)
+              .withNewSizeLimit(sizeLimit)
+            .endEmptyDir()
+            .build()
+    );
+    final List<V1VolumeMount> expectedMounts = Collections.singletonList(
+        new V1VolumeMountBuilder()
+            .withName(volumeName)
+              .withMountPath(path)
+              .withSubPath(subPath)
+            .build()
+    );
+
+    List<V1Volume> actualVolumes = new LinkedList<>();
+    List<V1VolumeMount> actualMounts = new LinkedList<>();
+    v1ControllerPodTemplate.createVolumeAndMountsEmptyDirCLI(config, actualVolumes, actualMounts);
+    Assert.assertEquals("Empty Dir Volume populated", expectedVolumes, actualVolumes);
+    Assert.assertEquals("Empty Dir Volume Mount populated", expectedMounts, actualMounts);
+  }
+
+  @Test
+  public void testCreateVolumeAndMountsHostPathCLI() {
+    final String volumeName = "volume-name-host-path";
+    final String type = "DirectoryOrCreate";
+    final String pathOnHost = "path.on.host";
+    final String path = "/path/to/mount";
+    final String subPath = "/sub/path/to/mount";
+
+    // Host Path.
+    final Map<String, Map<VolumeConfigKeys, String>> config =
+        ImmutableMap.of(volumeName, new HashMap<VolumeConfigKeys, String>() {
+          {
+            put(VolumeConfigKeys.type, type);
+            put(VolumeConfigKeys.pathOnHost, pathOnHost);
+            put(VolumeConfigKeys.path, path);
+            put(VolumeConfigKeys.subPath, subPath);
+          }
+        });
+    final List<V1Volume> expectedVolumes = Collections.singletonList(
+        new V1VolumeBuilder()
+            .withName(volumeName)
+            .withNewHostPath()
+              .withNewType(type)
+              .withNewPath(pathOnHost)
+            .endHostPath()
+            .build()
+    );
+    final List<V1VolumeMount> expectedMounts = Collections.singletonList(
+        new V1VolumeMountBuilder()
+            .withName(volumeName)
+              .withMountPath(path)
+              .withSubPath(subPath)
+            .build()
+    );
+
+    List<V1Volume> actualVolumes = new LinkedList<>();
+    List<V1VolumeMount> actualMounts = new LinkedList<>();
+    v1ControllerPodTemplate.createVolumeAndMountsHostPathCLI(config, actualVolumes, actualMounts);
+    Assert.assertEquals("Host Path Volume populated", expectedVolumes, actualVolumes);
+    Assert.assertEquals("Host Path Volume Mount populated", expectedMounts, actualMounts);
+  }
+
+  @Test
+  public void testCreateVolumeAndMountsNFSCLI() {
+    final String volumeName = "volume-name-nfs";
+    final String server = "nfs.server.address";
+    final String pathOnNFS = "path.on.host";
+    final String readOnly = "true";
+    final String path = "/path/to/mount";
+    final String subPath = "/sub/path/to/mount";
+
+    // NFS.
+    final Map<String, Map<VolumeConfigKeys, String>> config =
+        ImmutableMap.of(volumeName, new HashMap<VolumeConfigKeys, String>() {
+          {
+            put(VolumeConfigKeys.server, server);
+            put(VolumeConfigKeys.readOnly, readOnly);
+            put(VolumeConfigKeys.pathOnNFS, pathOnNFS);
+            put(VolumeConfigKeys.path, path);
+            put(VolumeConfigKeys.subPath, subPath);
+          }
+        });
+    final List<V1Volume> expectedVolumes = Collections.singletonList(
+        new V1VolumeBuilder()
+            .withName(volumeName)
+            .withNewNfs()
+              .withServer(server)
+              .withNewPath(pathOnNFS)
+              .withNewReadOnly(readOnly)
+            .endNfs()
+            .build()
+    );
+    final List<V1VolumeMount> expectedMounts = Collections.singletonList(
+        new V1VolumeMountBuilder()
+            .withName(volumeName)
+            .withMountPath(path)
+            .withSubPath(subPath)
+            .build()
+    );
+
+    List<V1Volume> actualVolumes = new LinkedList<>();
+    List<V1VolumeMount> actualMounts = new LinkedList<>();
+    v1ControllerPodTemplate.createVolumeAndMountsNFSCLI(config, actualVolumes, actualMounts);
+    Assert.assertEquals("NFS Volume populated", expectedVolumes, actualVolumes);
+    Assert.assertEquals("NFS Volume Mount populated", expectedMounts, actualMounts);
   }
 }

--- a/website2/docs/schedulers-k8s-execution-environment.md
+++ b/website2/docs/schedulers-k8s-execution-environment.md
@@ -269,7 +269,7 @@ metadata:
 
 > ***System Administrators:***
 >
-> * You may wish to disable the ability to configure Persistent Volume Claims specified via the CLI. To achieve this, you must pass the define option `-D heron.kubernetes.persistent.volume.claims.cli.disabled=true`to the Heron API Server on the command line when launching. This command has been added to the Kubernetes configuration files to deploy the Heron API Server and is set to `false` by default.
+> * You may wish to disable the ability to configure Persistent Volume Claims specified via the CLI. To achieve this, you must pass the define option `-D heron.kubernetes.volume.from.cli.disabled=true`to the Heron API Server on the command line when launching. This command has been added to the Kubernetes configuration files to deploy the Heron API Server and is set to `false` by default.
 > * If you have a custom `Role`/`ClusterRole` for the Heron API Server you will need to ensure the `ServiceAccount` attached to the API server has the correct permissions to access the `Persistent Volume Claim`s:
 >
 >```yaml

--- a/website2/docs/schedulers-k8s-execution-environment.md
+++ b/website2/docs/schedulers-k8s-execution-environment.md
@@ -304,12 +304,13 @@ The currently supported CLI `options` are:
 * `volumeMode`
 * `path`
 * `subPath`
+* `readOnly`
 
 ***Note:*** A `claimName` of `OnDemand` will create unique Volumes for each `Heron container` as well as deploy a Persistent Volume Claim for each Volume. Any other claim name will result in a shared Volume being created between all Pods in the topology.
 
 ***Note:*** The `accessModes` must be a comma-separated list of values *without* any white space. Valid values can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes).
 
-***Note:*** If a `storageClassName` is specified and there are no matching Persistent Volumes then [dynamic provisioning](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) must be enabled. Kubernetes will attempt to locate a Persistent Volume that matches the `storageClassName` before it attempts to use dynamic provisioning. If a `storageClassName` is not specified there must be [Persistent Volumes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/) provisioned manually with the `storageClassName` of `standard`.
+***Note:*** If a `storageClassName` is specified and there are no matching Persistent Volumes then [dynamic provisioning](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) must be enabled. Kubernetes will attempt to locate a Persistent Volume that matches the `storageClassName` before it attempts to use dynamic provisioning. If a `storageClassName` is not specified there must be [Persistent Volumes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/) provisioned manually. For more on statically and dynamically provisioned volumes please read [this](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#lifecycle-of-a-volume-and-claim).
 
 <br>
 
@@ -458,6 +459,7 @@ The following table outlines CLI options which are either ***required*** ( &#x27
 | `accessModes` | &#x2705; | &#x2705; | &#x274c;
 | `sizeLimit` | &#x2754; | &#x2754; | &#x274c;
 | `volumeMode` | &#x2754; | &#x2754; | &#x274c;
+| `readOnly` | &#x2754; | &#x2754; | &#x2754;
 
 <br>
 

--- a/website2/docs/schedulers-k8s-execution-environment.md
+++ b/website2/docs/schedulers-k8s-execution-environment.md
@@ -42,7 +42,7 @@ This document demonstrates how you can customize various aspects of the Heron ex
     - [Submitting](#submitting-1)
     - [Required and Optional Configuration Items](#required-and-optional-configuration-items)
     - [Configuration Items Created and Entries Made](#configuration-items-created-and-entries-made)
-  - [Adding Empty Directory, Host Path, and Nework File Storage Volumes via the Command Line Interface](#adding-empty-directory-host-path-and-nework-file-storage-volumes-via-the-command-line-interface)
+  - [Adding Empty Directory, Host Path, and Nework File System Volumes via the Command Line Interface](#adding-empty-directory-host-path-and-nework-file-system-volumes-via-the-command-line-interface)
     - [Usage](#usage-1)
       - [Example](#example-1)
     - [Submitting](#submitting-2)
@@ -497,7 +497,7 @@ A `Volume` and a `Volume Mount` will be created for each `volume name` which you
 
 <br>
 
-## Adding Empty Directory, Host Path, and Nework File Storage Volumes via the Command Line Interface
+## Adding Empty Directory, Host Path, and Nework File System Volumes via the Command Line Interface
 
 <br>
 
@@ -688,12 +688,12 @@ The following table outlines CLI options which are either ***required*** ( &#x27
 | `path` | &#x2705; | &#x2705; | &#x2705;
 | `subPath` | &#x2754; | &#x2754; | &#x2754;
 | `readOnly` | &#x2754; | &#x2754; | &#x2754;
-| `pathOnHost` | &#x274c; | &#x2705; | &#x274c;
-| `pathOnNFS` | &#x274c; | &#x274c; | &#x2705;
-| `server` | &#x274c; | &#x274c; | &#x2705;
-| `type` | &#x274c; | &#x2754; | &#x274c;
 | `medium` | &#x2754; | &#x274c; | &#x274c;
 | `sizeLimit` | &#x2754; | &#x274c; | &#x274c;
+| `pathOnHost` | &#x274c; | &#x2705; | &#x274c;
+| `type` | &#x274c; | &#x2754; | &#x274c;
+| `pathOnNFS` | &#x274c; | &#x274c; | &#x2705;
+| `server` | &#x274c; | &#x274c; | &#x2705;
 
 <br>
 
@@ -709,14 +709,14 @@ A `Volume` and a `Volume Mount` will be created for each `volume name` which you
 
 | Name | Description | Policy |
 |---|---|---|
-| `VOLUME NAME` | The `name` of the `Volume`. | Entries are made in the Pod Spec's `Volumes`, and the `Heron containers` `volumeMounts`.
-| `path` | The `mountPath` of the `Volume`. | Entries are made in the `Heron container`s `volumeMounts`.
-| `subPath` | The `subPath` of the `Volume`. | Entries are made in the `Heron container`s `volumeMounts`.
+| `VOLUME NAME` | The `name` of the `Volume`. | Entries are made in the Pod Spec's `Volumes`, and the `Heron container`'s `volumeMounts`.
+| `path` | The `mountPath` of the `Volume`. | Entries are made in the `Heron container`'s `volumeMounts`.
+| `subPath` | The `subPath` of the `Volume`. | Entries are made in the `Heron container`'s `volumeMounts`.
 | `readOnly` | A boolean value which defaults to `false` and indicates whether the medium has read-write permissions. | Entries are made in the `Heron container`s `volumeMount`. When used with an `NFS` volume an entry is also made in the associated `Volume`.
-| `medium` | The type of storage medium that will back the `EmptyDir` and defaults to "", please read more [here](https://kubernetes.io/docs/concepts/storage/volumes#emptydir). | An entry is made in the `EmptyDir`'s `Volume`.
-| `sizeLimit` | Total amount of local storage required for this `EmptyDir` volume. | An entry is made `EmptyDir`'s `Volume`.
-| `pathOnHost` | The directory path to be mounted the host. | A `path` entry is made `hostPath`'s `Volume`.
-| `type` | The type of the `hostPath` volume and defaults to "", please read more [here](https://kubernetes.io/docs/concepts/storage/volumes#hostpath). | An entry is made `hostPath`'s `Volume`.
+| `medium` | The type of storage medium that will back the `Empty Dir` and defaults to "", please read more [here](https://kubernetes.io/docs/concepts/storage/volumes#emptydir). | An entry is made in the `Empty Dir`'s `Volume`.
+| `sizeLimit` | Total [amount](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) of local storage required for this `Empty Dir` Volume. | An entry is made `Empty Dir`'s `Volume`.
+| `pathOnHost` | The directory path to be mounted the host. | A `path` entry is made `Host Path`'s `Volume`.
+| `type` | The type of the `Host Path` volume and defaults to "", please read more [here](https://kubernetes.io/docs/concepts/storage/volumes#hostpath). | An entry is made `Host Path`'s `Volume`.
 | `pathOnNFS` | The directory path to be mounted the NFS server. | A `path` entry is made `NFS`'s `Volume`.
 | `server` | The hostname or IP address of the NFS server. | An entry is made `NFS`'s `Volume`.
 


### PR DESCRIPTION
**_Feature #3723: Add support for Empty Dir, Host Path, and NFS via CLI_**

This PR adds support for specifying `Empty Dir`, `Host Path`, and `NFS` via CLI commands.

For further details please see the [documentation](https://github.com/apache/incubator-heron/blob/8d5d070c2d5ba8214a606b235e836a05ca650a18/website2/docs/schedulers-k8s-execution-environment.md) and the [relevant section](https://github.com/apache/incubator-heron/blob/8d5d070c2d5ba8214a606b235e836a05ca650a18/website2/docs/schedulers-k8s-execution-environment.md#adding-empty-directory-host-path-and-nework-file-system-volumes-via-the-command-line-interface). Please note that the Helm charts and the commands to disable Volumes configuration specification via the CLI has been updated as well.

<details><summary>Commands</summary>

```bash
~/bin/heron submit kubernetes ~/.heron/examples/heron-api-examples.jar \
org.apache.heron.examples.api.AckingTopology acking \
--verbose \
\
--config-property heron.kubernetes.executor.pod.template=pod-templ-executor.pod-template-executor.yaml \
--config-property heron.kubernetes.manager.pod.template=pod-templ-manager.pod-template-manager.yaml \
\
--config-property heron.kubernetes.manager.limits.cpu=2 \
--config-property heron.kubernetes.manager.limits.memory=3 \
--config-property heron.kubernetes.manager.requests.cpu=1 \
--config-property heron.kubernetes.manager.requests.memory=2 \
\
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.claimName=OnDemand \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.storageClassName=storage-class-name-manager \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.accessModes=ReadWriteOnce,ReadOnlyMany \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.sizeLimit=256Gi \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.volumeMode=Block \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.path=path/to/mount/dynamic/volume \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.subPath=sub/path/to/mount/dynamic/volume \
\
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-static-volume.claimName=OnDemand \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-static-volume.accessModes=ReadWriteOnce,ReadOnlyMany \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-static-volume.sizeLimit=512Gi \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-static-volume.volumeMode=Block \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-static-volume.path=path/to/mount/static/volume \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-static-volume.subPath=sub/path/to/mount/static/volume \
\
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-shared-volume.claimName=requested-claim-by-user \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-shared-volume.path=path/to/mount/shared/volume \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-shared-volume.subPath=sub/path/to/mount/shared/volume \
\
--config-property heron.kubernetes.manager.volumes.emptyDir.manager-empty-dir.medium="Memory" \
--config-property heron.kubernetes.manager.volumes.emptyDir.manager-empty-dir.sizeLimit="50Mi" \
--config-property heron.kubernetes.manager.volumes.emptyDir.manager-empty-dir.path="empty/dir/path" \
--config-property heron.kubernetes.manager.volumes.emptyDir.manager-empty-dir.subPath="empty/dir/sub/path" \
--config-property heron.kubernetes.manager.volumes.emptyDir.manager-empty-dir.readOnly="true" \
\
--config-property heron.kubernetes.manager.volumes.hostPath.manager-host-path.type="File" \
--config-property heron.kubernetes.manager.volumes.hostPath.manager-host-path.pathOnHost="/dev/null" \
--config-property heron.kubernetes.manager.volumes.hostPath.manager-host-path.path="host/path/path" \
--config-property heron.kubernetes.manager.volumes.hostPath.manager-host-path.subPath="host/path/sub/path" \
--config-property heron.kubernetes.manager.volumes.hostPath.manager-host-path.readOnly="true" \
\
--config-property heron.kubernetes.manager.volumes.nfs.manager-nfs.server="nfs-server.address" \
--config-property heron.kubernetes.manager.volumes.nfs.manager-nfs.readOnly="true" \
--config-property heron.kubernetes.manager.volumes.nfs.manager-nfs.pathOnNFS="/dev/null" \
--config-property heron.kubernetes.manager.volumes.nfs.manager-nfs.path="nfs/path" \
--config-property heron.kubernetes.manager.volumes.nfs.manager-nfs.subPath="nfs/sub/path" \
--config-property heron.kubernetes.manager.volumes.nfs.manager-nfs.readOnly="true" \
\
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.claimName=OnDemand \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.storageClassName=storage-class-name-executor \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.accessModes=ReadWriteOnce,ReadOnlyMany \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.sizeLimit=256Gi \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.volumeMode=Block \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.path=path/to/mount/dynamic/volume \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.subPath=sub/path/to/mount/dynamic/volume \
\
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-static-volume.claimName=OnDemand \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-static-volume.accessModes=ReadWriteOnce,ReadOnlyMany \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-static-volume.sizeLimit=512Gi \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-static-volume.volumeMode=Block \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-static-volume.path=path/to/mount/static/volume \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-static-volume.subPath=sub/path/to/mount/static/volume \
\
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-shared-volume.claimName=requested-claim-by-user \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-shared-volume.path=path/to/mount/shared/volume \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-shared-volume.subPath=sub/path/to/mount/shared/volume
```

</details>

<details><summary>Manager StatefulSet YAML</summary>

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  creationTimestamp: "2021-12-08T21:38:06Z"
  generation: 1
  labels:
    app: heron
    topology: acking
  name: acking-manager
  namespace: default
  resourceVersion: "2147"
  uid: e3ef4c56-50b6-4a4f-9b0f-fc637dbdceba
spec:
  podManagementPolicy: Parallel
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: heron
      topology: acking
  serviceName: acking
  template:
    metadata:
      annotations:
        prometheus.io/port: "8080"
        prometheus.io/scrape: "true"
      creationTimestamp: null
      labels:
        app: heron
        topology: acking
    spec:
      containers:
      - command:
        - sh
        - -c
        - './heron-core/bin/heron-downloader-config kubernetes && ./heron-core/bin/heron-downloader
          distributedlog://zookeeper:2181/heronbkdl/acking-saad-tag-0--7412350634992464132.tar.gz
          . && SHARD_ID=${POD_NAME##*-} && echo shardId=${SHARD_ID} && ./heron-core/bin/heron-executor
          --topology-name=acking --topology-id=ackinga54c5c18-7bb1-485a-a4eb-9e16783d2eba
          --topology-defn-file=acking.defn --state-manager-connection=zookeeper:2181
          --state-manager-root=/heron --state-manager-config-file=./heron-conf/statemgr.yaml
          --tmanager-binary=./heron-core/bin/heron-tmanager --stmgr-binary=./heron-core/bin/heron-stmgr
          --metrics-manager-classpath=./heron-core/lib/metricsmgr/* --instance-jvm-opts="LVhYOitIZWFwRHVtcE9uT3V0T2ZNZW1vcnlFcnJvcg(61)(61)"
          --classpath=heron-api-examples.jar --heron-internals-config-file=./heron-conf/heron_internals.yaml
          --override-config-file=./heron-conf/override.yaml --component-ram-map=exclaim1:1073741824,word:1073741824
          --component-jvm-opts="" --pkg-type=jar --topology-binary-file=heron-api-examples.jar
          --heron-java-home=$JAVA_HOME --heron-shell-binary=./heron-core/bin/heron-shell
          --cluster=kubernetes --role=saad --environment=default --instance-classpath=./heron-core/lib/instance/*
          --metrics-sinks-config-file=./heron-conf/metrics_sinks.yaml --scheduler-classpath=./heron-core/lib/scheduler/*:./heron-core/lib/packing/*:./heron-core/lib/statemgr/*
          --python-instance-binary=./heron-core/bin/heron-python-instance --cpp-instance-binary=./heron-core/bin/heron-cpp-instance
          --metricscache-manager-classpath=./heron-core/lib/metricscachemgr/* --metricscache-manager-mode=disabled
          --is-stateful=false --checkpoint-manager-classpath=./heron-core/lib/ckptmgr/*:./heron-core/lib/statefulstorage/*:
          --stateful-config-file=./heron-conf/stateful.yaml --checkpoint-manager-ram=1073741824
          --health-manager-mode=disabled --health-manager-classpath=./heron-core/lib/healthmgr/*
          --shard=$SHARD_ID --server-port=6001 --tmanager-controller-port=6002 --tmanager-stats-port=6003
          --shell-port=6004 --metrics-manager-port=6005 --scheduler-port=6006 --metricscache-manager-server-port=6007
          --metricscache-manager-stats-port=6008 --checkpoint-manager-port=6009'
        env:
        - name: HOST
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: POD_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.name
        - name: var_one_manager
          value: variable one on manager
        - name: var_three_manager
          value: variable three on manager
        - name: var_two_manager
          value: variable two on manager
        image: apache/heron:testbuild
        imagePullPolicy: IfNotPresent
        name: manager
        ports:
        - containerPort: 6001
          name: server
          protocol: TCP
        - containerPort: 6002
          name: tmanager-ctl
          protocol: TCP
        - containerPort: 6003
          name: tmanager-stats
          protocol: TCP
        - containerPort: 6004
          name: shell-port
          protocol: TCP
        - containerPort: 6005
          name: metrics-mgr
          protocol: TCP
        - containerPort: 6006
          name: scheduler
          protocol: TCP
        - containerPort: 6007
          name: metrics-cache-m
          protocol: TCP
        - containerPort: 6008
          name: metrics-cache-s
          protocol: TCP
        - containerPort: 6009
          name: ckptmgr
          protocol: TCP
        - containerPort: 7775
          name: tcp-port-kept
          protocol: TCP
        - containerPort: 7776
          name: udp-port-kept
          protocol: UDP
        resources:
          limits:
            cpu: "2"
            memory: "3"
          requests:
            cpu: "1"
            memory: "2"
        securityContext:
          allowPrivilegeEscalation: false
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: path/to/mount/dynamic/volume
          name: manager-dynamic-volume
          subPath: sub/path/to/mount/dynamic/volume
        - mountPath: empty/dir/path
          name: manager-empty-dir
          readOnly: true
          subPath: empty/dir/sub/path
        - mountPath: host/path/path
          name: manager-host-path
          readOnly: true
          subPath: host/path/sub/path
        - mountPath: nfs/path
          name: manager-nfs
          readOnly: true
          subPath: nfs/sub/path
        - mountPath: path/to/mount/shared/volume
          name: manager-shared-volume
          subPath: sub/path/to/mount/shared/volume
        - mountPath: path/to/mount/static/volume
          name: manager-static-volume
          subPath: sub/path/to/mount/static/volume
        - mountPath: /shared_volume/manager
          name: shared-volume-manager
      - image: alpine
        imagePullPolicy: Always
        name: manager-sidecar-container
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /shared_volume/manager
          name: shared-volume-manager
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 0
      tolerations:
      - effect: NoExecute
        key: node.kubernetes.io/not-ready
        operator: Exists
        tolerationSeconds: 10
      - effect: NoExecute
        key: node.kubernetes.io/unreachable
        operator: Exists
        tolerationSeconds: 10
      volumes:
      - emptyDir:
          medium: Memory
          sizeLimit: 50Mi
        name: manager-empty-dir
      - hostPath:
          path: /dev/null
          type: File
        name: manager-host-path
      - name: manager-nfs
        nfs:
          path: /dev/null
          readOnly: true
          server: nfs-server.address
      - name: manager-shared-volume
        persistentVolumeClaim:
          claimName: requested-claim-by-user
      - emptyDir: {}
        name: shared-volume-manager
  updateStrategy:
    rollingUpdate:
      partition: 0
    type: RollingUpdate
  volumeClaimTemplates:
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      creationTimestamp: null
      labels:
        onDemand: "true"
        topology: acking
      name: manager-static-volume
    spec:
      accessModes:
      - ReadWriteOnce
      - ReadOnlyMany
      resources:
        requests:
          storage: 512Gi
      storageClassName: ""
      volumeMode: Block
    status:
      phase: Pending
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      creationTimestamp: null
      labels:
        onDemand: "true"
        topology: acking
      name: manager-dynamic-volume
    spec:
      accessModes:
      - ReadWriteOnce
      - ReadOnlyMany
      resources:
        requests:
          storage: 256Gi
      storageClassName: storage-class-name-manager
      volumeMode: Block
    status:
      phase: Pending
status:
  collisionCount: 0
  currentReplicas: 1
  currentRevision: acking-manager-7fd976b458
  observedGeneration: 1
  replicas: 1
  updateRevision: acking-manager-7fd976b458
  updatedReplicas: 1
```

</details>

<details><summary>Executor StatefulSet YAML</summary>

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  creationTimestamp: "2021-12-08T21:38:06Z"
  generation: 1
  labels:
    app: heron
    topology: acking
  name: acking-executors
  namespace: default
  resourceVersion: "2152"
  uid: e63998b2-cfb1-42e5-bc2e-0dfde936b7af
spec:
  podManagementPolicy: Parallel
  replicas: 2
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: heron
      topology: acking
  serviceName: acking
  template:
    metadata:
      annotations:
        prometheus.io/port: "8080"
        prometheus.io/scrape: "true"
      creationTimestamp: null
      labels:
        app: heron
        topology: acking
    spec:
      containers:
      - command:
        - sh
        - -c
        - './heron-core/bin/heron-downloader-config kubernetes && ./heron-core/bin/heron-downloader
          distributedlog://zookeeper:2181/heronbkdl/acking-saad-tag-0--7412350634992464132.tar.gz
          . && SHARD_ID=$((${POD_NAME##*-} + 1)) && echo shardId=${SHARD_ID} && ./heron-core/bin/heron-executor
          --topology-name=acking --topology-id=ackinga54c5c18-7bb1-485a-a4eb-9e16783d2eba
          --topology-defn-file=acking.defn --state-manager-connection=zookeeper:2181
          --state-manager-root=/heron --state-manager-config-file=./heron-conf/statemgr.yaml
          --tmanager-binary=./heron-core/bin/heron-tmanager --stmgr-binary=./heron-core/bin/heron-stmgr
          --metrics-manager-classpath=./heron-core/lib/metricsmgr/* --instance-jvm-opts="LVhYOitIZWFwRHVtcE9uT3V0T2ZNZW1vcnlFcnJvcg(61)(61)"
          --classpath=heron-api-examples.jar --heron-internals-config-file=./heron-conf/heron_internals.yaml
          --override-config-file=./heron-conf/override.yaml --component-ram-map=exclaim1:1073741824,word:1073741824
          --component-jvm-opts="" --pkg-type=jar --topology-binary-file=heron-api-examples.jar
          --heron-java-home=$JAVA_HOME --heron-shell-binary=./heron-core/bin/heron-shell
          --cluster=kubernetes --role=saad --environment=default --instance-classpath=./heron-core/lib/instance/*
          --metrics-sinks-config-file=./heron-conf/metrics_sinks.yaml --scheduler-classpath=./heron-core/lib/scheduler/*:./heron-core/lib/packing/*:./heron-core/lib/statemgr/*
          --python-instance-binary=./heron-core/bin/heron-python-instance --cpp-instance-binary=./heron-core/bin/heron-cpp-instance
          --metricscache-manager-classpath=./heron-core/lib/metricscachemgr/* --metricscache-manager-mode=disabled
          --is-stateful=false --checkpoint-manager-classpath=./heron-core/lib/ckptmgr/*:./heron-core/lib/statefulstorage/*:
          --stateful-config-file=./heron-conf/stateful.yaml --checkpoint-manager-ram=1073741824
          --health-manager-mode=disabled --health-manager-classpath=./heron-core/lib/healthmgr/*
          --shard=$SHARD_ID --server-port=6001 --tmanager-controller-port=6002 --tmanager-stats-port=6003
          --shell-port=6004 --metrics-manager-port=6005 --scheduler-port=6006 --metricscache-manager-server-port=6007
          --metricscache-manager-stats-port=6008 --checkpoint-manager-port=6009'
        env:
        - name: HOST
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: POD_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.name
        - name: var_one
          value: variable one
        - name: var_three
          value: variable three
        - name: var_two
          value: variable two
        image: apache/heron:testbuild
        imagePullPolicy: IfNotPresent
        name: executor
        ports:
        - containerPort: 5555
          name: tcp-port-kept
          protocol: TCP
        - containerPort: 5556
          name: udp-port-kept
          protocol: UDP
        - containerPort: 6001
          name: server
          protocol: TCP
        - containerPort: 6002
          name: tmanager-ctl
          protocol: TCP
        - containerPort: 6003
          name: tmanager-stats
          protocol: TCP
        - containerPort: 6004
          name: shell-port
          protocol: TCP
        - containerPort: 6005
          name: metrics-mgr
          protocol: TCP
        - containerPort: 6006
          name: scheduler
          protocol: TCP
        - containerPort: 6007
          name: metrics-cache-m
          protocol: TCP
        - containerPort: 6008
          name: metrics-cache-s
          protocol: TCP
        - containerPort: 6009
          name: ckptmgr
          protocol: TCP
        resources:
          limits:
            cpu: "3"
            memory: 4Gi
          requests:
            cpu: "3"
            memory: 4Gi
        securityContext:
          allowPrivilegeEscalation: false
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: path/to/mount/dynamic/volume
          name: executor-dynamic-volume
          subPath: sub/path/to/mount/dynamic/volume
        - mountPath: path/to/mount/shared/volume
          name: executor-shared-volume
          subPath: sub/path/to/mount/shared/volume
        - mountPath: path/to/mount/static/volume
          name: executor-static-volume
          subPath: sub/path/to/mount/static/volume
        - mountPath: /shared_volume
          name: shared-volume
      - image: alpine
        imagePullPolicy: Always
        name: sidecar-container
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /shared_volume
          name: shared-volume
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 0
      tolerations:
      - effect: NoExecute
        key: node.kubernetes.io/not-ready
        operator: Exists
        tolerationSeconds: 10
      - effect: NoExecute
        key: node.kubernetes.io/unreachable
        operator: Exists
        tolerationSeconds: 10
      volumes:
      - name: executor-shared-volume
        persistentVolumeClaim:
          claimName: requested-claim-by-user
      - emptyDir: {}
        name: shared-volume
  updateStrategy:
    rollingUpdate:
      partition: 0
    type: RollingUpdate
  volumeClaimTemplates:
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      creationTimestamp: null
      labels:
        onDemand: "true"
        topology: acking
      name: executor-dynamic-volume
    spec:
      accessModes:
      - ReadWriteOnce
      - ReadOnlyMany
      resources:
        requests:
          storage: 256Gi
      storageClassName: storage-class-name-executor
      volumeMode: Block
    status:
      phase: Pending
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      creationTimestamp: null
      labels:
        onDemand: "true"
        topology: acking
      name: executor-static-volume
    spec:
      accessModes:
      - ReadWriteOnce
      - ReadOnlyMany
      resources:
        requests:
          storage: 512Gi
      storageClassName: ""
      volumeMode: Block
    status:
      phase: Pending
status:
  collisionCount: 0
  currentReplicas: 2
  currentRevision: acking-executors-786f58c8f
  observedGeneration: 1
  replicas: 2
  updateRevision: acking-executors-786f58c8f
  updatedReplicas: 2
```

</details>