### PR TITLE
[Heron-3723] Add support for Empty Dir, Host Path, and NFS via CLI

### DIFF
--- a/deploy/kubernetes/general/apiserver.yaml
+++ b/deploy/kubernetes/general/apiserver.yaml
@@ -92,7 +92,7 @@ spec:
               -D heron.statefulstorage.classname=org.apache.heron.statefulstorage.dlog.DlogStorage
               -D heron.statefulstorage.dlog.namespace.uri=distributedlog://zookeeper:2181/heron
               -D heron.kubernetes.pod.template.disabled=false
-              -D heron.kubernetes.persistent.volume.claims.cli.disabled=false
+              -D heron.kubernetes.volume.from.cli.disabled=false
 
 ---
 apiVersion: v1

--- a/deploy/kubernetes/helm/templates/tools.yaml
+++ b/deploy/kubernetes/helm/templates/tools.yaml
@@ -159,7 +159,7 @@ spec:
               {{- end }}
               -D heron.kubernetes.resource.request.mode={{ .Values.topologyResourceRequestMode }}
               -D heron.kubernetes.pod.template.disabled={{ .Values.disablePodTemplates }}
-              -D heron.kubernetes.persistent.volume.claims.cli.disabled={{ .Values.disablePersistentVolumeMountsCLI }}
+              -D heron.kubernetes.volume.from.cli.disabled={{ .Values.disableVolumesFromCLI }}
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-tools-config

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -77,8 +77,8 @@ packing: RoundRobin # ResourceCompliantRR, FirstFitDecreasing
 # Support for ConfigMap mounted PodTemplates
 disablePodTemplates: false
 
-# Support for Dynamic Persistent Volume Mounts from CLI input
-disablePersistentVolumeMountsCLI: false
+# Support for Voume specification from CLI input
+disableVolumesFromCLI: false
 
 # Number of replicas for storage bookies, memory and storage requirements
 bookieReplicas: 3

--- a/deploy/kubernetes/minikube/apiserver.yaml
+++ b/deploy/kubernetes/minikube/apiserver.yaml
@@ -83,7 +83,7 @@ spec:
               -D heron.statefulstorage.classname=org.apache.heron.statefulstorage.dlog.DlogStorage
               -D heron.statefulstorage.dlog.namespace.uri=distributedlog://zookeeper:2181/heronbkdl
               -D heron.kubernetes.pod.template.disabled=false
-              -D heron.kubernetes.persistent.volume.claims.cli.disabled=false
+              -D heron.kubernetes.volume.from.cli.disabled=false
 
 ---
 apiVersion: v1

--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -22,8 +22,10 @@ package org.apache.heron.scheduler.kubernetes;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.apache.heron.scheduler.utils.SchedulerUtils.ExecutorPort;
@@ -115,13 +117,34 @@ public final class KubernetesConstants {
       )
   );
 
-  enum VolumeClaimTemplateConfigKeys {
+  protected enum VolumeConfigKeys {
     claimName,
     storageClassName,
     sizeLimit,
     accessModes,
     volumeMode,
-    path,               // Added to container.
+    medium,
+    type,
+    readOnly,
+    server,
+    pathOnHost,
+    pathOnNFS,
+    path,               // Added to container, nfsVolume, hostPath.
     subPath,            // Added to container.
   }
+
+  protected static final Set<String> VALID_VOLUME_HOSTPATH_TYPES = Collections.unmodifiableSet(
+      new HashSet<String>() {
+        {
+          add("");
+          add("DirectoryOrCreate");
+          add("Directory");
+          add("FileOrCreate");
+          add("File");
+          add("Socket");
+          add("CharDevice");
+          add("BlockDevice");
+        }
+      }
+  );
 }

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/KubernetesContextTest.java
@@ -20,9 +20,12 @@
 package org.apache.heron.scheduler.kubernetes;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,7 +35,7 @@ import org.apache.heron.scheduler.TopologySubmissionException;
 import org.apache.heron.scheduler.kubernetes.KubernetesUtils.TestTuple;
 import org.apache.heron.spi.common.Config;
 
-import static org.apache.heron.scheduler.kubernetes.KubernetesConstants.VolumeClaimTemplateConfigKeys;
+import static org.apache.heron.scheduler.kubernetes.KubernetesConstants.VolumeConfigKeys;
 
 public class KubernetesContextTest {
 
@@ -82,40 +85,42 @@ public class KubernetesContextTest {
   }
 
   @Test
-  public void testPersistentVolumeClaimDisabled() {
-    Assert.assertFalse(KubernetesContext.getPersistentVolumeClaimDisabled(config));
+  public void testVolumesFromCLIDisabled() {
+    Assert.assertFalse(KubernetesContext.getVolumesFromCLIDisabled(config));
     Assert.assertFalse(KubernetesContext
-        .getPersistentVolumeClaimDisabled(configWithPodTemplateConfigMap));
+        .getVolumesFromCLIDisabled(configWithPodTemplateConfigMap));
 
     final Config configWithPodTemplateConfigMapOff = Config.newBuilder()
         .put(KubernetesContext.KUBERNETES_POD_TEMPLATE_LOCATION,
             POD_TEMPLATE_CONFIGMAP_NAME)
-        .put(KubernetesContext.KUBERNETES_PERSISTENT_VOLUME_CLAIMS_CLI_DISABLED, "TRUE")
+        .put(KubernetesContext.KUBERNETES_VOLUME_FROM_CLI_DISABLED, "TRUE")
         .build();
     Assert.assertTrue(KubernetesContext
-        .getPersistentVolumeClaimDisabled(configWithPodTemplateConfigMapOff));
+        .getVolumesFromCLIDisabled(configWithPodTemplateConfigMapOff));
   }
 
-  @Test
-  public void testGetVolumeClaimTemplates() {
-    final String volumeNameOne = "volume-name-one";
-    final String volumeNameTwo = "volume-name-two";
-    final String claimName = "OnDeMaNd";
-    final String keyPattern = KubernetesContext.KUBERNETES_VOLUME_CLAIM_PREFIX + "%%s.%%s";
+  /**
+   * Generate <code>Volume</code> Configs for testing.
+   * @param testCases Test case container.
+   *                  Input: [0] Config, [1] Boolean to indicate Manager/Executor.
+   *                  Output: [0] expectedKeys, [1] expectedOptionsKeys, [2] expectedOptionsValues.
+   * @param prefix Configuration prefix key to use in lookup.
+   */
+  private void createVolumeConfigs(List<TestTuple<Pair<Config, Boolean>, Object[]>> testCases,
+                                   String prefix) {
+    final String keyPattern = prefix + "%%s.%%s";
     final String keyExecutor = String.format(keyPattern, KubernetesConstants.EXECUTOR_NAME);
     final String keyManager = String.format(keyPattern, KubernetesConstants.MANAGER_NAME);
 
-    final String storageClassField = VolumeClaimTemplateConfigKeys.storageClassName.name();
-    final String pathField = VolumeClaimTemplateConfigKeys.path.name();
-    final String claimNameField = VolumeClaimTemplateConfigKeys.claimName.name();
+    final String volumeNameOne = "volume-name-one";
+    final String volumeNameTwo = "volume-name-two";
+    final String claimName = "OnDeMaNd";
+
+    final String storageClassField = VolumeConfigKeys.storageClassName.name();
+    final String pathField = VolumeConfigKeys.path.name();
+    final String claimNameField = VolumeConfigKeys.claimName.name();
     final String expectedStorageClass = "expected-storage-class";
     final String expectedPath = "/path/for/volume/expected";
-
-
-    // Test case container.
-    // Input: Config to extract options from, Boolean to indicate Manager/Executor.
-    // Output: [0] expectedKeys, [1] expectedOptionsKeys, [2] expectedOptionsValues.
-    final List<TestTuple<Pair<Config, Boolean>, Object[]>> testCases = new LinkedList<>();
 
     // Create test cases for Executor/Manager on even/odd indices respectively.
     for (int idx = 0; idx < 2; ++idx) {
@@ -149,28 +154,54 @@ public class KubernetesContextTest {
           .build();
 
       final List<String> expectedKeys = Arrays.asList(volumeNameOne, volumeNameTwo);
-      final List<VolumeClaimTemplateConfigKeys> expectedOptionsKeys =
-          Arrays.asList(VolumeClaimTemplateConfigKeys.path,
-              VolumeClaimTemplateConfigKeys.storageClassName,
-              VolumeClaimTemplateConfigKeys.claimName);
+      final List<VolumeConfigKeys> expectedOptionsKeys =
+          Arrays.asList(VolumeConfigKeys.path,
+              VolumeConfigKeys.storageClassName,
+              VolumeConfigKeys.claimName);
       final List<String> expectedOptionsValues =
           Arrays.asList(expectedPath, expectedStorageClass, claimName);
 
       testCases.add(new TestTuple<>(description,
           new Pair<>(configPVC, isExecutor),
           new Object[]{expectedKeys, expectedOptionsKeys, expectedOptionsValues}));
+
+      final Config configPVCDisabled = Config.newBuilder()
+          .put(KubernetesContext.KUBERNETES_VOLUME_FROM_CLI_DISABLED, "true")
+          .put(pathKeyOne, expectedPath)
+          .put(pathKeyTwo, expectedPath)
+          .put(claimNameKeyOne, claimName)
+          .put(claimNameKeyTwo, claimName)
+          .put(storageClassKeyOne, expectedStorageClass)
+          .put(storageClassKeyTwo, expectedStorageClass)
+          .build();
+
+      testCases.add(new TestTuple<>(description + " Disabled should not error",
+          new Pair<>(configPVCDisabled, !isExecutor),
+          new Object[]{new LinkedList<String>(), new LinkedList<VolumeConfigKeys>(),
+              new LinkedList<String>()}));
     }
+  }
+
+  @Test
+  public void testGetVolumeConfigs() {
+    final String prefix = KubernetesContext.KUBERNETES_VOLUME_CLAIM_PREFIX;
+
+    // Test case container.
+    // Input: [0] Config, [1] Boolean to indicate Manager/Executor.
+    // Output: [0] expectedKeys, [1] expectedOptionsKeys, [2] expectedOptionsValues.
+    final List<TestTuple<Pair<Config, Boolean>, Object[]>> testCases = new LinkedList<>();
+    createVolumeConfigs(testCases, prefix);
 
     // Test loop.
     for (TestTuple<Pair<Config, Boolean>, Object[]> testCase : testCases) {
-      final Map<String, Map<VolumeClaimTemplateConfigKeys, String>> mapOfPVC =
-          KubernetesContext.getVolumeClaimTemplates(testCase.input.first, testCase.input.second);
+      final Map<String, Map<VolumeConfigKeys, String>> mapOfPVC =
+          KubernetesContext.getVolumeConfigs(testCase.input.first, prefix, testCase.input.second);
 
       Assert.assertTrue(testCase.description + ": Contains all provided Volumes",
           mapOfPVC.keySet().containsAll((List<String>) testCase.expected[0]));
-      for (Map<VolumeClaimTemplateConfigKeys, String> items : mapOfPVC.values()) {
+      for (Map<VolumeConfigKeys, String> items : mapOfPVC.values()) {
         Assert.assertTrue(testCase.description + ": Contains all provided option keys",
-            items.keySet().containsAll((List<VolumeClaimTemplateConfigKeys>) testCase.expected[1]));
+            items.keySet().containsAll((List<VolumeConfigKeys>) testCase.expected[1]));
         Assert.assertTrue(testCase.description + ": Contains all provided option values",
             items.values().containsAll((List<String>) testCase.expected[2]));
       }
@@ -179,35 +210,41 @@ public class KubernetesContextTest {
     // Empty PVC.
     final Boolean[] emptyPVCTestCases = new Boolean[] {true, false};
     for (boolean testCase : emptyPVCTestCases) {
-      final Map<String, Map<VolumeClaimTemplateConfigKeys, String>> emptyPVC =
+      final Map<String, Map<VolumeConfigKeys, String>> emptyPVC =
           KubernetesContext.getVolumeClaimTemplates(Config.newBuilder().build(), testCase);
       Assert.assertTrue("Empty PVC is returned when no options provided", emptyPVC.isEmpty());
     }
   }
 
   @Test
-  public void testGetPersistentVolumeClaimsErrors() {
+  public void testGetVolumeConfigsErrors() {
+    final String prefix = KubernetesContext.KUBERNETES_VOLUME_CLAIM_PREFIX;
     final String volumeNameValid = "volume-name-valid";
     final String volumeNameInvalid = "volume-Name-Invalid";
+    final String passingValue = "should-pass";
     final String failureValue = "Should-Fail";
-    final String generalFailureMessage = "Invalid Persistent Volume";
+    final String generalFailureMessage = "Invalid Volume configuration";
     final String keyPattern = String.format(KubernetesContext.KUBERNETES_VOLUME_CLAIM_PREFIX
         + "%%s.%%s", KubernetesConstants.EXECUTOR_NAME);
     final List<TestTuple<Config, String>> testCases = new LinkedList<>();
 
     // Invalid option key test.
     final Config configInvalidOption = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "claimName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "storageClassName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "volumeMode"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "server"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "type"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "medium"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "NonExistentKey"), failureValue)
         .build();
     testCases.add(new TestTuple<>("Invalid option key should trigger exception",
         configInvalidOption, generalFailureMessage));
-
-    // Just the prefix.
-    final Config configJustPrefix = Config.newBuilder()
-        .put(KubernetesContext.KUBERNETES_VOLUME_CLAIM_PREFIX, failureValue)
-        .build();
-    testCases.add(new TestTuple<>("Only a key prefix should trigger exception",
-        configJustPrefix, generalFailureMessage));
 
     // Invalid Volume Name.
     final Config configInvalidVolumeName = Config.newBuilder()
@@ -216,31 +253,729 @@ public class KubernetesContextTest {
     testCases.add(new TestTuple<>("Invalid Volume Name should trigger exception",
         configInvalidVolumeName, "lowercase RFC-1123"));
 
+    // Required Path.
+    final Config configRequiredPath = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "claimName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "storageClassName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "volumeMode"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "server"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "type"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "medium"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>("Missing path should trigger exception",
+        configRequiredPath, "All Volumes require a 'path'."));
+
+    // Disabled.
+    final Config configDisabled = Config.newBuilder()
+        .put(KubernetesContext.KUBERNETES_VOLUME_FROM_CLI_DISABLED, "true")
+        .put(String.format(keyPattern, volumeNameValid, "claimName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "storageClassName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "volumeMode"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "server"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "type"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "medium"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>("Disabled functionality should trigger exception",
+        configDisabled, "Configuring Volumes from the CLI is disabled."));
+
+    // Testing loop.
+    for (TestTuple<Config, String> testCase : testCases) {
+      String message = "";
+      try {
+        KubernetesContext.getVolumeConfigs(testCase.input, prefix, true);
+      } catch (TopologySubmissionException e) {
+        message = e.getMessage();
+      }
+      Assert.assertTrue(testCase.description, message.contains(testCase.expected));
+    }
+  }
+
+  /**
+   * Create test cases for <code>Volume Claim Templates</code>.
+   * @param testCases Test case container.
+   *                  Input: [0] Config, [1] Boolean to indicate Manager/Executor.
+   *                  Output: <code>Map<String, Map<VolumeConfigKeys, String></code>
+   * @param isExecutor Boolean to indicate Manager/Executor test case generation.
+   */
+  private void createVolumeClaimTemplates(
+      List<TestTuple<Pair<Config, Boolean>, Map<String, Map<VolumeConfigKeys, String>>>> testCases,
+      boolean isExecutor) {
+    final String volumeNameValid = "volume-name-valid";
+    final String passingValue = "should-pass";
+    final String processName = isExecutor ? KubernetesConstants.EXECUTOR_NAME
+        : KubernetesConstants.MANAGER_NAME;
+    final String keyPattern = String.format(KubernetesContext.KUBERNETES_VOLUME_CLAIM_PREFIX
+        + "%%s.%%s", processName);
+
+    // With Storage Class Name.
+    final Map<String, Map<VolumeConfigKeys, String>> expectedWithStorageClassName =
+        ImmutableMap.of(volumeNameValid, new HashMap<VolumeConfigKeys, String>() {
+          {
+            put(VolumeConfigKeys.claimName, passingValue);
+            put(VolumeConfigKeys.storageClassName, passingValue);
+            put(VolumeConfigKeys.sizeLimit, passingValue);
+            put(VolumeConfigKeys.accessModes, passingValue);
+            put(VolumeConfigKeys.volumeMode, passingValue);
+            put(VolumeConfigKeys.path, passingValue);
+            put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
+          }
+        });
+    final Config configWithStorageClass = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "claimName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "storageClassName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "volumeMode"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": PVC with Storage Class name",
+        new Pair<>(configWithStorageClass, isExecutor), expectedWithStorageClassName));
+
+    // Without Storage Class Name.
+    final Map<String, Map<VolumeConfigKeys, String>> expectedWithoutStorageClassName =
+        ImmutableMap.of(volumeNameValid, new HashMap<VolumeConfigKeys, String>() {
+          {
+            put(VolumeConfigKeys.claimName, passingValue);
+            put(VolumeConfigKeys.sizeLimit, passingValue);
+            put(VolumeConfigKeys.accessModes, passingValue);
+            put(VolumeConfigKeys.volumeMode, passingValue);
+            put(VolumeConfigKeys.path, passingValue);
+            put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
+          }
+        });
+    final Config configWithoutStorageClass = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "claimName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "volumeMode"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": PVC with Storage Class name",
+        new Pair<>(configWithoutStorageClass, isExecutor), expectedWithoutStorageClassName));
+
+    // Ignored.
+    final Config configIgnored = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "claimName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "storageClassName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "volumeMode"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": PVC with ignored keys",
+        new Pair<>(configIgnored, !isExecutor), new HashMap<>()));
+  }
+
+  @Test
+  public void testGetVolumeClaimTemplates() {
+    final List<TestTuple<Pair<Config, Boolean>, Map<String, Map<VolumeConfigKeys, String>>>>
+        testCases = new LinkedList<>();
+    createVolumeClaimTemplates(testCases, true);
+    createVolumeClaimTemplates(testCases, false);
+
+    // Testing loop.
+    for (TestTuple<Pair<Config, Boolean>, Map<String, Map<VolumeConfigKeys, String>>> testCase
+        : testCases) {
+      Map<String, Map<VolumeConfigKeys, String>> actual =
+          KubernetesContext.getVolumeClaimTemplates(testCase.input.first, testCase.input.second);
+      Assert.assertEquals(testCase.description, testCase.expected, actual);
+    }
+  }
+
+  /**
+   * Create test cases for <code>Volume Claim Templates</code> errors.
+   * @param testCases Test case container.
+   *                  Input: [0] Config, [1] Boolean to indicate Manager/Executor.
+   *                  Output: Error message
+   * @param isExecutor Boolean to indicate Manager/Executor test case generation.
+   */
+  private void createVolumeClaimTemplatesErrors(
+      List<TestTuple<Pair<Config, Boolean>, String>> testCases, boolean isExecutor) {
+    final String volumeNameValid = "volume-name-valid";
+    final String passingValue = "should-pass";
+    final String failureValue = "Should-Fail";
+    final String processName = isExecutor ? KubernetesConstants.EXECUTOR_NAME
+        : KubernetesConstants.MANAGER_NAME;
+    final String keyPattern = String.format(KubernetesContext.KUBERNETES_VOLUME_CLAIM_PREFIX
+        + "%%s.%%s", processName);
+
+    // Required Claim Name.
+    final Config configRequiredClaimName = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": Missing Claim Name should trigger exception",
+        new Pair<>(configRequiredClaimName, isExecutor), "require a `claimName`"));
+
     // Invalid Claim Name.
     final Config configInvalidClaimName = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "claimName"), failureValue)
         .build();
-    testCases.add(new TestTuple<>("Invalid Claim Name should trigger exception",
-        configInvalidClaimName, "Option `claimName`"));
+    testCases.add(new TestTuple<>(processName + ": Invalid Claim Name should trigger exception",
+        new Pair<>(configInvalidClaimName, isExecutor),
+        String.format("Volume `%s`: `claimName`", volumeNameValid)));
 
     // Invalid Storage Class Name.
     final Config configInvalidStorageClassName = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "claimName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
         .put(String.format(keyPattern, volumeNameValid, "storageClassName"), failureValue)
         .build();
-    testCases.add(new TestTuple<>("Invalid Storage Class Name should trigger exception",
-        configInvalidStorageClassName, "Option `storageClassName`"));
+    testCases.add(new TestTuple<>(processName
+        + ": Invalid Storage Class Name should trigger exception",
+        new Pair<>(configInvalidStorageClassName, isExecutor),
+        String.format("Volume `%s`: `storageClassName`", volumeNameValid)));
+
+    // Invalid Storage Class Name.
+    final Config configInvalidOption = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "claimName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "storageClassName"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "volumeMode"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "server"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": Invalid option should trigger exception",
+        new Pair<>(configInvalidOption, isExecutor),
+        String.format("Volume `%s`: Invalid Persistent", volumeNameValid)));
+  }
+
+  @Test
+  public void testGetVolumeClaimTemplatesErrors() {
+    final List<TestTuple<Pair<Config, Boolean>, String>> testCases = new LinkedList<>();
+    createVolumeClaimTemplatesErrors(testCases, true);
+    createVolumeClaimTemplatesErrors(testCases, false);
 
     // Testing loop.
-    final Boolean[] executorFlags = new Boolean[] {true, false};
-    for (TestTuple<Config, String> testCase : testCases) {
-      // Test for both Executor and Manager.
-      for (boolean isExecutor : executorFlags) {
-        try {
-          KubernetesContext.getVolumeClaimTemplates(testCase.input, isExecutor);
-        } catch (TopologySubmissionException e) {
-          Assert.assertTrue(testCase.description, e.getMessage().contains(testCase.expected));
-        }
+    for (TestTuple<Pair<Config, Boolean>, String> testCase : testCases) {
+      String message = "";
+      try {
+        KubernetesContext.getVolumeClaimTemplates(testCase.input.first, testCase.input.second);
+      } catch (TopologySubmissionException e) {
+        message = e.getMessage();
       }
+      Assert.assertTrue(testCase.description, message.contains(testCase.expected));
+    }
+  }
+
+  /**
+   * Create test cases for <code>Empty Directory</code>.
+   * @param testCases Test case container.
+   *                  Input: [0] Config, [1] Boolean to indicate Manager/Executor.
+   *                  Output: <code>Map<String, Map<VolumeConfigKeys, String></code>
+   * @param isExecutor Boolean to indicate Manager/Executor test case generation.
+   */
+  private void createVolumeEmptyDir(
+      List<TestTuple<Pair<Config, Boolean>, Map<String, Map<VolumeConfigKeys, String>>>> testCases,
+      boolean isExecutor) {
+    final String volumeNameValid = "volume-name-valid";
+    final String passingValue = "should-pass";
+    final String processName = isExecutor ? KubernetesConstants.EXECUTOR_NAME
+        : KubernetesConstants.MANAGER_NAME;
+    final String keyPattern = String.format(KubernetesContext.KUBERNETES_VOLUME_EMPTYDIR_PREFIX
+        + "%%s.%%s", processName);
+
+    // With Medium.
+    final Map<String, Map<VolumeConfigKeys, String>> expectedWithMedium =
+        ImmutableMap.of(volumeNameValid, new HashMap<VolumeConfigKeys, String>() {
+          {
+            put(VolumeConfigKeys.sizeLimit, passingValue);
+            put(VolumeConfigKeys.medium, "Memory");
+            put(VolumeConfigKeys.path, passingValue);
+            put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
+          }
+        });
+    final Config configWithMedium = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "medium"), "Memory")
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": `emptyDir` with `medium`",
+        new Pair<>(configWithMedium, isExecutor), expectedWithMedium));
+
+    // With empty Medium.
+    final Map<String, Map<VolumeConfigKeys, String>> expectedEmptyMedium =
+        ImmutableMap.of(volumeNameValid, new HashMap<VolumeConfigKeys, String>() {
+          {
+            put(VolumeConfigKeys.sizeLimit, passingValue);
+            put(VolumeConfigKeys.medium, "");
+            put(VolumeConfigKeys.path, passingValue);
+            put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
+          }
+        });
+    final Config configEmptyMedium = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "medium"), "")
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": `emptyDir` with empty `medium`",
+        new Pair<>(configEmptyMedium, isExecutor), expectedEmptyMedium));
+
+    // Without Medium.
+    final Map<String, Map<VolumeConfigKeys, String>> expectedNoMedium =
+        ImmutableMap.of(volumeNameValid, new HashMap<VolumeConfigKeys, String>() {
+          {
+            put(VolumeConfigKeys.sizeLimit, passingValue);
+            put(VolumeConfigKeys.path, passingValue);
+            put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
+          }
+        });
+    final Config configNoMedium = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": `emptyDir` without `medium`",
+        new Pair<>(configNoMedium, isExecutor), expectedNoMedium));
+
+    // Ignored.
+    final Config configIgnored = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "medium"), "")
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": `emptyDir` ignored",
+        new Pair<>(configIgnored, !isExecutor), new HashMap<>()));
+  }
+
+  @Test
+  public void testGetVolumeEmptyDir() {
+    final List<TestTuple<Pair<Config, Boolean>, Map<String, Map<VolumeConfigKeys, String>>>>
+        testCases = new LinkedList<>();
+    createVolumeEmptyDir(testCases, true);
+    createVolumeEmptyDir(testCases, false);
+
+    // Testing loop.
+    for (TestTuple<Pair<Config, Boolean>, Map<String, Map<VolumeConfigKeys, String>>> testCase
+        : testCases) {
+      Map<String, Map<VolumeConfigKeys, String>> actual =
+          KubernetesContext.getVolumeEmptyDir(testCase.input.first, testCase.input.second);
+      Assert.assertEquals(testCase.description, testCase.expected, actual);
+    }
+  }
+
+  /**
+   * Create test cases for <code>Empty Directory</code> errors.
+   * @param testCases Test case container.
+   *                  Input: [0] Config, [1] Boolean to indicate Manager/Executor.
+   *                  Output: Error message
+   * @param isExecutor Boolean to indicate Manager/Executor test case generation.
+   */
+  private void createVolumeEmptyDirError(
+      List<TestTuple<Pair<Config, Boolean>, String>> testCases, boolean isExecutor) {
+    final String volumeNameValid = "volume-name-valid";
+    final String passingValue = "should-pass";
+    final String failureValue = "Should-Fail";
+    final String processName = isExecutor ? KubernetesConstants.EXECUTOR_NAME
+        : KubernetesConstants.MANAGER_NAME;
+    final String keyPattern = String.format(KubernetesContext.KUBERNETES_VOLUME_EMPTYDIR_PREFIX
+        + "%%s.%%s", processName);
+
+    // Medium is invalid.
+    final Config configInvalidMedium = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "medium"), failureValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": Invalid 'medium' should trigger exception",
+        new Pair<>(configInvalidMedium, isExecutor), "must be 'Memory' or empty."));
+
+    // Invalid option.
+    final Config configInvalidOption = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "sizeLimit"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "medium"), "Memory")
+        .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": Invalid option should trigger exception",
+        new Pair<>(configInvalidOption, isExecutor), "Directory type option"));
+  }
+
+  @Test
+  public void testGetVolumeEmptyDirErrors() {
+    final List<TestTuple<Pair<Config, Boolean>, String>> testCases = new LinkedList<>();
+    createVolumeEmptyDirError(testCases, true);
+    createVolumeEmptyDirError(testCases, false);
+
+    // Testing loop.
+    for (TestTuple<Pair<Config, Boolean>, String> testCase : testCases) {
+      String message = "";
+      try {
+        KubernetesContext.getVolumeEmptyDir(testCase.input.first, testCase.input.second);
+      } catch (TopologySubmissionException e) {
+        message = e.getMessage();
+      }
+      Assert.assertTrue(testCase.description, message.contains(testCase.expected));
+    }
+  }
+
+  /**
+   * Create test cases for <code>Host Path</code>.
+   * @param testCases Test case container.
+   *                  Input: [0] Config, [1] Boolean to indicate Manager/Executor.
+   *                  Output: <code>Map<String, Map<VolumeConfigKeys, String></code>
+   * @param isExecutor Boolean to indicate Manager/Executor test case generation.
+   */
+  private void createVolumeHostPath(
+      List<TestTuple<Pair<Config, Boolean>, Map<String, Map<VolumeConfigKeys, String>>>> testCases,
+      boolean isExecutor) {
+    final String volumeNameValid = "volume-name-valid";
+    final String passingValue = "should-pass";
+    final String processName = isExecutor ? KubernetesConstants.EXECUTOR_NAME
+        : KubernetesConstants.MANAGER_NAME;
+    final String keyPattern = String.format(KubernetesContext.KUBERNETES_VOLUME_HOSTPATH_PREFIX
+        + "%%s.%%s", processName);
+
+    // With type.
+    final Map<String, Map<VolumeConfigKeys, String>> expectedWithType =
+        ImmutableMap.of(volumeNameValid, new HashMap<VolumeConfigKeys, String>() {
+          {
+            put(VolumeConfigKeys.type, "DirectoryOrCreate");
+            put(VolumeConfigKeys.path, passingValue);
+            put(VolumeConfigKeys.pathOnHost, passingValue);
+            put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
+          }
+        });
+    final Config configWithType = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "type"), "DirectoryOrCreate")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": 'hostPath' with 'type'",
+        new Pair<>(configWithType, isExecutor), expectedWithType));
+
+    // Without type.
+    final Map<String, Map<VolumeConfigKeys, String>> expectedWithoutType =
+        ImmutableMap.of(volumeNameValid, new HashMap<VolumeConfigKeys, String>() {
+          {
+            put(VolumeConfigKeys.pathOnHost, passingValue);
+            put(VolumeConfigKeys.path, passingValue);
+            put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
+          }
+        });
+    final Config configWithoutType = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": 'hostPath' without 'type'",
+        new Pair<>(configWithoutType, isExecutor), expectedWithoutType));
+
+    // Ignored.
+    final Config configIgnored = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "type"), "BlockDevice")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": 'hostPath' ignored",
+        new Pair<>(configIgnored, !isExecutor), new HashMap<>()));
+  }
+
+  @Test
+  public void testGetVolumeHostPath() {
+    final List<TestTuple<Pair<Config, Boolean>, Map<String, Map<VolumeConfigKeys, String>>>>
+        testCases = new LinkedList<>();
+    createVolumeHostPath(testCases, true);
+    createVolumeHostPath(testCases, false);
+
+    // Testing loop.
+    for (TestTuple<Pair<Config, Boolean>, Map<String, Map<VolumeConfigKeys, String>>> testCase
+        : testCases) {
+      Map<String, Map<VolumeConfigKeys, String>> actual =
+          KubernetesContext.getVolumeHostPath(testCase.input.first, testCase.input.second);
+      Assert.assertEquals(testCase.description, testCase.expected, actual);
+    }
+  }
+
+  /**
+   * Create test cases for <code>Host Path</code> errors.
+   * @param testCases Test case container.
+   *                  Input: [0] Config, [1] Boolean to indicate Manager/Executor.
+   *                  Output: Error message
+   * @param isExecutor Boolean to indicate Manager/Executor test case generation.
+   */
+  private void createVolumeHostPathError(
+      List<TestTuple<Pair<Config, Boolean>, String>> testCases, boolean isExecutor) {
+    final String volumeNameValid = "volume-name-valid";
+    final String passingValue = "should-pass";
+    final String failureValue = "Should-Fail";
+    final String processName = isExecutor ? KubernetesConstants.EXECUTOR_NAME
+        : KubernetesConstants.MANAGER_NAME;
+    final String keyPattern = String.format(KubernetesContext.KUBERNETES_VOLUME_HOSTPATH_PREFIX
+        + "%%s.%%s", processName);
+
+    // Type is invalid.
+    final Config configInvalidMedium = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "type"), failureValue)
+        .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": Invalid 'type' should trigger exception",
+        new Pair<>(configInvalidMedium, isExecutor), "Host Path 'type' of"));
+
+    // Path on Host is missing.
+    final Config configNoHostOnPath = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "type"), "BlockDevice")
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": No 'hostOnPath' should trigger exception",
+        new Pair<>(configNoHostOnPath, isExecutor), "requires a path on the host"));
+
+    // Path on Host is empty.
+    final Config configEmptyHostOnPath = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "type"), "BlockDevice")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), "")
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": Empty 'hostOnPath' should trigger exception",
+        new Pair<>(configEmptyHostOnPath, isExecutor), "requires a path on the host"));
+
+    // Invalid option.
+    final Config configInvalidOption = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "type"), "BlockDevice")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnHost"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": Invalid option should trigger exception",
+        new Pair<>(configInvalidOption, isExecutor), "Invalid Host Path option for"));
+  }
+
+  @Test
+  public void testGetVolumeHostPathErrors() {
+    final List<TestTuple<Pair<Config, Boolean>, String>> testCases = new LinkedList<>();
+    createVolumeHostPathError(testCases, true);
+    createVolumeHostPathError(testCases, false);
+
+    // Testing loop.
+    for (TestTuple<Pair<Config, Boolean>, String> testCase : testCases) {
+      String message = "";
+      try {
+        KubernetesContext.getVolumeHostPath(testCase.input.first, testCase.input.second);
+      } catch (TopologySubmissionException e) {
+        message = e.getMessage();
+      }
+      Assert.assertTrue(testCase.description, message.contains(testCase.expected));
+    }
+  }
+
+  /**
+   * Create test cases for <code>NFS</code>.
+   * @param testCases Test case container.
+   *                  Input: [0] Config, [1] Boolean to indicate Manager/Executor.
+   *                  Output: <code>Map<String, Map<VolumeConfigKeys, String></code>
+   * @param isExecutor Boolean to indicate Manager/Executor test case generation.
+   */
+  private void createVolumeNFS(
+      List<TestTuple<Pair<Config, Boolean>, Map<String, Map<VolumeConfigKeys, String>>>> testCases,
+      boolean isExecutor) {
+    final String volumeNameValid = "volume-name-valid";
+    final String passingValue = "should-pass";
+    final String processName = isExecutor ? KubernetesConstants.EXECUTOR_NAME
+        : KubernetesConstants.MANAGER_NAME;
+    final String keyPattern = String.format(KubernetesContext.KUBERNETES_VOLUME_NFS_PREFIX
+        + "%%s.%%s", processName);
+
+    // With readOnly.
+    final Map<String, Map<VolumeConfigKeys, String>> expectedWithReadOnly =
+        ImmutableMap.of(volumeNameValid, new HashMap<VolumeConfigKeys, String>() {
+          {
+            put(VolumeConfigKeys.server, "nfs-server.default.local");
+            put(VolumeConfigKeys.readOnly, "true");
+            put(VolumeConfigKeys.pathOnNFS, passingValue);
+            put(VolumeConfigKeys.path, passingValue);
+            put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
+          }
+        });
+    final Config configWithReadOnly = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "server"), "nfs-server.default.local")
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), "true")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": `NFS` with `readOnly`",
+        new Pair<>(configWithReadOnly, isExecutor), expectedWithReadOnly));
+
+    // With readOnly.
+    final Map<String, Map<VolumeConfigKeys, String>> expectedWithoutReadOnly =
+        ImmutableMap.of(volumeNameValid, new HashMap<VolumeConfigKeys, String>() {
+          {
+            put(VolumeConfigKeys.server, "nfs-server.default.local");
+            put(VolumeConfigKeys.pathOnNFS, passingValue);
+            put(VolumeConfigKeys.path, passingValue);
+            put(VolumeConfigKeys.subPath, passingValue);
+            put(VolumeConfigKeys.readOnly, passingValue);
+          }
+        });
+    final Config configWithoutReadOnly = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "server"), "nfs-server.default.local")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": `NFS` without `readOnly`",
+        new Pair<>(configWithoutReadOnly, isExecutor), expectedWithoutReadOnly));
+
+    // Ignored.
+    final Config configIgnored = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "server"), "nfs-server.default.local")
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), "true")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": `NFS` ignored",
+        new Pair<>(configIgnored, !isExecutor), new HashMap<>()));
+  }
+
+  @Test
+  public void testGetVolumeNFS() {
+    final List<TestTuple<Pair<Config, Boolean>, Map<String, Map<VolumeConfigKeys, String>>>>
+        testCases = new LinkedList<>();
+    createVolumeNFS(testCases, true);
+    createVolumeNFS(testCases, false);
+
+    // Testing loop.
+    for (TestTuple<Pair<Config, Boolean>, Map<String, Map<VolumeConfigKeys, String>>> testCase
+        : testCases) {
+      Map<String, Map<VolumeConfigKeys, String>> actual =
+          KubernetesContext.getVolumeNFS(testCase.input.first, testCase.input.second);
+      Assert.assertEquals(testCase.description, testCase.expected, actual);
+    }
+  }
+  /**
+   * Create test cases for <code>NFS</code> errors.
+   * @param testCases Test case container.
+   *                  Input: [0] Config, [1] Boolean to indicate Manager/Executor.
+   *                  Output: Error message
+   * @param isExecutor Boolean to indicate Manager/Executor test case generation.
+   */
+  private void createVolumeNFSError(
+      List<TestTuple<Pair<Config, Boolean>, String>> testCases, boolean isExecutor) {
+    final String volumeNameValid = "volume-name-valid";
+    final String passingValue = "should-pass";
+    final String failureValue = "Should-Fail";
+    final String processName = isExecutor ? KubernetesConstants.EXECUTOR_NAME
+        : KubernetesConstants.MANAGER_NAME;
+    final String keyPattern = String.format(KubernetesContext.KUBERNETES_VOLUME_NFS_PREFIX
+        + "%%s.%%s", processName);
+
+    // Server is missing.
+    final Config configNoServer = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), "false")
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": No `server` should trigger exception",
+        new Pair<>(configNoServer, isExecutor), "`NFS` volumes require a"));
+
+    // Server is invalid.
+    final Config configInvalidServer = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "server"), "")
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), "false")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": Invalid `server` should trigger exception",
+        new Pair<>(configInvalidServer, isExecutor), "`NFS` volumes require a"));
+
+    // Path on NFS missing.
+    final Config configNoNFSPath = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "server"), "nfs-server.default.local")
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), "false")
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": No path on NFS should trigger exception",
+        new Pair<>(configNoNFSPath, isExecutor), "NFS requires a path on"));
+
+    // Path on NFS is empty.
+    final Config configEmptyNFSPath = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "server"), "nfs-server.default.local")
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), "false")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), "")
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": No path on NFS should trigger exception",
+        new Pair<>(configEmptyNFSPath, isExecutor), "NFS requires a path on"));
+
+    // Invalid option.
+    final Config configInvalidOption = Config.newBuilder()
+        .put(String.format(keyPattern, volumeNameValid, "server"), "nfs-server.default.local")
+        .put(String.format(keyPattern, volumeNameValid, "readOnly"), "false")
+        .put(String.format(keyPattern, volumeNameValid, "pathOnNFS"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "path"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "subPath"), passingValue)
+        .put(String.format(keyPattern, volumeNameValid, "accessModes"), passingValue)
+        .build();
+    testCases.add(new TestTuple<>(processName + ": Invalid option should trigger exception",
+        new Pair<>(configInvalidOption, isExecutor), "Invalid NFS option"));
+  }
+
+  @Test
+  public void testGetVolumeNFSErrors() {
+    final List<TestTuple<Pair<Config, Boolean>, String>> testCases = new LinkedList<>();
+    createVolumeNFSError(testCases, true);
+    createVolumeNFSError(testCases, false);
+
+    // Testing loop.
+    for (TestTuple<Pair<Config, Boolean>, String> testCase : testCases) {
+      String message = "";
+      try {
+        KubernetesContext.getVolumeNFS(testCase.input.first, testCase.input.second);
+      } catch (TopologySubmissionException e) {
+        message = e.getMessage();
+      }
+      Assert.assertTrue(testCase.description, message.contains(testCase.expected));
     }
   }
 }

--- a/website2/docs/schedulers-k8s-execution-environment.md
+++ b/website2/docs/schedulers-k8s-execution-environment.md
@@ -485,7 +485,7 @@ It is possible to allocate and configure Volumes with Pod Templates but the CLI 
 > ***System Administrators:***
 >
 > * You may wish to disable the ability to configure Volume configurations specified via the CLI. To achieve this, you must pass the define option `-D heron.kubernetes.volume.from.cli.disabled=true`to the Heron API Server on the command line when launching. This command has been added to the Kubernetes configuration files to deploy the Heron API Server and is set to `false` by default.
-> * &#x26a0; ***WARNING*** &#x26a0; `Host Path` volumes have inherent [security concerns](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath). `Host Path`s can breach the containment provided by containerisation and should be exclusively used with volume mounts set to `read-only`, with usage limited to testing and development environments.
+> * &#x26a0; ***WARNING*** &#x26a0; `Host Path` volumes have inherent [security concerns](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath). `Host Path`s can breach the containment provided by containerization and should be exclusively used with volume mounts set to `read-only`, with usage limited to testing and development environments.
 
 <br>
 

--- a/website2/docs/schedulers-k8s-execution-environment.md
+++ b/website2/docs/schedulers-k8s-execution-environment.md
@@ -485,7 +485,7 @@ It is possible to allocate and configure Volumes with Pod Templates but the CLI 
 > ***System Administrators:***
 >
 > * You may wish to disable the ability to configure Volume configurations specified via the CLI. To achieve this, you must pass the define option `-D heron.kubernetes.volume.from.cli.disabled=true`to the Heron API Server on the command line when launching. This command has been added to the Kubernetes configuration files to deploy the Heron API Server and is set to `false` by default.
-> * &#x26a0; ***WARNING*** &#x26a0; `Host Path` Volumes have inherent [security concerns](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath).
+> * &#x26a0; ***WARNING*** &#x26a0; `Host Path` volumes have inherent [security concerns](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath). `Host Path`s can breach the containment provided by containerisation and should be exclusively used with volume mounts set to `read-only`, with usage limited to testing and development environments.
 
 <br>
 


### PR DESCRIPTION
**_Feature #3723: Add support for Empty Dir, Host Path, and NFS via CLI_**

Closes #3723, Resolves #3723. The duplicate PR is closed #3744 due to tracking the wrong branch (`-dev`).

This PR adds support for specifying `Empty Dir`, `Host Path`, and `NFS` via CLI commands.

For further details please see the [documentation](https://github.com/apache/incubator-heron/blob/aae2f0f3fb346149fe6e4ac3deee46ded8efedf4/website2/docs/schedulers-k8s-execution-environment.md) and the [relevant section](https://github.com/apache/incubator-heron/blob/aae2f0f3fb346149fe6e4ac3deee46ded8efedf4/website2/docs/schedulers-k8s-execution-environment.md#adding-empty-directory-host-path-and-nework-file-system-volumes-via-the-command-line-interface). Please note that the Helm charts and the commands to disable Volumes configuration specification via the CLI has been updated as well.

<details><summary>Commands</summary>

```bash
~/bin/heron submit kubernetes ~/.heron/examples/heron-api-examples.jar \
org.apache.heron.examples.api.AckingTopology acking \
--verbose \
\
--config-property heron.kubernetes.executor.pod.template=pod-templ-executor.pod-template-executor.yaml \
--config-property heron.kubernetes.manager.pod.template=pod-templ-manager.pod-template-manager.yaml \
\
--config-property heron.kubernetes.manager.limits.cpu=2 \
--config-property heron.kubernetes.manager.limits.memory=3 \
--config-property heron.kubernetes.manager.requests.cpu=1 \
--config-property heron.kubernetes.manager.requests.memory=2 \
\
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.claimName=OnDemand \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.storageClassName=storage-class-name-manager \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.accessModes=ReadWriteOnce,ReadOnlyMany \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.sizeLimit=256Gi \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.volumeMode=Block \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.path=path/to/mount/dynamic/volume \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-dynamic-volume.subPath=sub/path/to/mount/dynamic/volume \
\
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-static-volume.claimName=OnDemand \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-static-volume.accessModes=ReadWriteOnce,ReadOnlyMany \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-static-volume.sizeLimit=512Gi \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-static-volume.volumeMode=Block \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-static-volume.path=path/to/mount/static/volume \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-static-volume.subPath=sub/path/to/mount/static/volume \
\
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-shared-volume.claimName=requested-claim-by-user \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-shared-volume.path=path/to/mount/shared/volume \
--config-property heron.kubernetes.manager.volumes.persistentVolumeClaim.manager-shared-volume.subPath=sub/path/to/mount/shared/volume \
\
--config-property heron.kubernetes.manager.volumes.emptyDir.manager-empty-dir.medium="Memory" \
--config-property heron.kubernetes.manager.volumes.emptyDir.manager-empty-dir.sizeLimit="50Mi" \
--config-property heron.kubernetes.manager.volumes.emptyDir.manager-empty-dir.path="empty/dir/path" \
--config-property heron.kubernetes.manager.volumes.emptyDir.manager-empty-dir.subPath="empty/dir/sub/path" \
--config-property heron.kubernetes.manager.volumes.emptyDir.manager-empty-dir.readOnly="true" \
\
--config-property heron.kubernetes.manager.volumes.hostPath.manager-host-path.type="File" \
--config-property heron.kubernetes.manager.volumes.hostPath.manager-host-path.pathOnHost="/dev/null" \
--config-property heron.kubernetes.manager.volumes.hostPath.manager-host-path.path="host/path/path" \
--config-property heron.kubernetes.manager.volumes.hostPath.manager-host-path.subPath="host/path/sub/path" \
--config-property heron.kubernetes.manager.volumes.hostPath.manager-host-path.readOnly="true" \
\
--config-property heron.kubernetes.manager.volumes.nfs.manager-nfs.server="nfs-server.address" \
--config-property heron.kubernetes.manager.volumes.nfs.manager-nfs.readOnly="true" \
--config-property heron.kubernetes.manager.volumes.nfs.manager-nfs.pathOnNFS="/dev/null" \
--config-property heron.kubernetes.manager.volumes.nfs.manager-nfs.path="nfs/path" \
--config-property heron.kubernetes.manager.volumes.nfs.manager-nfs.subPath="nfs/sub/path" \
--config-property heron.kubernetes.manager.volumes.nfs.manager-nfs.readOnly="true" \
\
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.claimName=OnDemand \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.storageClassName=storage-class-name-executor \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.accessModes=ReadWriteOnce,ReadOnlyMany \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.sizeLimit=256Gi \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.volumeMode=Block \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.path=path/to/mount/dynamic/volume \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-dynamic-volume.subPath=sub/path/to/mount/dynamic/volume \
\
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-static-volume.claimName=OnDemand \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-static-volume.accessModes=ReadWriteOnce,ReadOnlyMany \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-static-volume.sizeLimit=512Gi \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-static-volume.volumeMode=Block \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-static-volume.path=path/to/mount/static/volume \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-static-volume.subPath=sub/path/to/mount/static/volume \
\
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-shared-volume.claimName=requested-claim-by-user \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-shared-volume.path=path/to/mount/shared/volume \
--config-property heron.kubernetes.executor.volumes.persistentVolumeClaim.executor-shared-volume.subPath=sub/path/to/mount/shared/volume
```

</details>

<details><summary>Manager StatefulSet YAML</summary>

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  creationTimestamp: "2021-12-08T21:38:06Z"
  generation: 1
  labels:
    app: heron
    topology: acking
  name: acking-manager
  namespace: default
  resourceVersion: "2147"
  uid: e3ef4c56-50b6-4a4f-9b0f-fc637dbdceba
spec:
  podManagementPolicy: Parallel
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: heron
      topology: acking
  serviceName: acking
  template:
    metadata:
      annotations:
        prometheus.io/port: "8080"
        prometheus.io/scrape: "true"
      creationTimestamp: null
      labels:
        app: heron
        topology: acking
    spec:
      containers:
      - command:
        - sh
        - -c
        - './heron-core/bin/heron-downloader-config kubernetes && ./heron-core/bin/heron-downloader
          distributedlog://zookeeper:2181/heronbkdl/acking-saad-tag-0--7412350634992464132.tar.gz
          . && SHARD_ID=${POD_NAME##*-} && echo shardId=${SHARD_ID} && ./heron-core/bin/heron-executor
          --topology-name=acking --topology-id=ackinga54c5c18-7bb1-485a-a4eb-9e16783d2eba
          --topology-defn-file=acking.defn --state-manager-connection=zookeeper:2181
          --state-manager-root=/heron --state-manager-config-file=./heron-conf/statemgr.yaml
          --tmanager-binary=./heron-core/bin/heron-tmanager --stmgr-binary=./heron-core/bin/heron-stmgr
          --metrics-manager-classpath=./heron-core/lib/metricsmgr/* --instance-jvm-opts="LVhYOitIZWFwRHVtcE9uT3V0T2ZNZW1vcnlFcnJvcg(61)(61)"
          --classpath=heron-api-examples.jar --heron-internals-config-file=./heron-conf/heron_internals.yaml
          --override-config-file=./heron-conf/override.yaml --component-ram-map=exclaim1:1073741824,word:1073741824
          --component-jvm-opts="" --pkg-type=jar --topology-binary-file=heron-api-examples.jar
          --heron-java-home=$JAVA_HOME --heron-shell-binary=./heron-core/bin/heron-shell
          --cluster=kubernetes --role=saad --environment=default --instance-classpath=./heron-core/lib/instance/*
          --metrics-sinks-config-file=./heron-conf/metrics_sinks.yaml --scheduler-classpath=./heron-core/lib/scheduler/*:./heron-core/lib/packing/*:./heron-core/lib/statemgr/*
          --python-instance-binary=./heron-core/bin/heron-python-instance --cpp-instance-binary=./heron-core/bin/heron-cpp-instance
          --metricscache-manager-classpath=./heron-core/lib/metricscachemgr/* --metricscache-manager-mode=disabled
          --is-stateful=false --checkpoint-manager-classpath=./heron-core/lib/ckptmgr/*:./heron-core/lib/statefulstorage/*:
          --stateful-config-file=./heron-conf/stateful.yaml --checkpoint-manager-ram=1073741824
          --health-manager-mode=disabled --health-manager-classpath=./heron-core/lib/healthmgr/*
          --shard=$SHARD_ID --server-port=6001 --tmanager-controller-port=6002 --tmanager-stats-port=6003
          --shell-port=6004 --metrics-manager-port=6005 --scheduler-port=6006 --metricscache-manager-server-port=6007
          --metricscache-manager-stats-port=6008 --checkpoint-manager-port=6009'
        env:
        - name: HOST
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: POD_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.name
        - name: var_one_manager
          value: variable one on manager
        - name: var_three_manager
          value: variable three on manager
        - name: var_two_manager
          value: variable two on manager
        image: apache/heron:testbuild
        imagePullPolicy: IfNotPresent
        name: manager
        ports:
        - containerPort: 6001
          name: server
          protocol: TCP
        - containerPort: 6002
          name: tmanager-ctl
          protocol: TCP
        - containerPort: 6003
          name: tmanager-stats
          protocol: TCP
        - containerPort: 6004
          name: shell-port
          protocol: TCP
        - containerPort: 6005
          name: metrics-mgr
          protocol: TCP
        - containerPort: 6006
          name: scheduler
          protocol: TCP
        - containerPort: 6007
          name: metrics-cache-m
          protocol: TCP
        - containerPort: 6008
          name: metrics-cache-s
          protocol: TCP
        - containerPort: 6009
          name: ckptmgr
          protocol: TCP
        - containerPort: 7775
          name: tcp-port-kept
          protocol: TCP
        - containerPort: 7776
          name: udp-port-kept
          protocol: UDP
        resources:
          limits:
            cpu: "2"
            memory: "3"
          requests:
            cpu: "1"
            memory: "2"
        securityContext:
          allowPrivilegeEscalation: false
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: path/to/mount/dynamic/volume
          name: manager-dynamic-volume
          subPath: sub/path/to/mount/dynamic/volume
        - mountPath: empty/dir/path
          name: manager-empty-dir
          readOnly: true
          subPath: empty/dir/sub/path
        - mountPath: host/path/path
          name: manager-host-path
          readOnly: true
          subPath: host/path/sub/path
        - mountPath: nfs/path
          name: manager-nfs
          readOnly: true
          subPath: nfs/sub/path
        - mountPath: path/to/mount/shared/volume
          name: manager-shared-volume
          subPath: sub/path/to/mount/shared/volume
        - mountPath: path/to/mount/static/volume
          name: manager-static-volume
          subPath: sub/path/to/mount/static/volume
        - mountPath: /shared_volume/manager
          name: shared-volume-manager
      - image: alpine
        imagePullPolicy: Always
        name: manager-sidecar-container
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /shared_volume/manager
          name: shared-volume-manager
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 0
      tolerations:
      - effect: NoExecute
        key: node.kubernetes.io/not-ready
        operator: Exists
        tolerationSeconds: 10
      - effect: NoExecute
        key: node.kubernetes.io/unreachable
        operator: Exists
        tolerationSeconds: 10
      volumes:
      - emptyDir:
          medium: Memory
          sizeLimit: 50Mi
        name: manager-empty-dir
      - hostPath:
          path: /dev/null
          type: File
        name: manager-host-path
      - name: manager-nfs
        nfs:
          path: /dev/null
          readOnly: true
          server: nfs-server.address
      - name: manager-shared-volume
        persistentVolumeClaim:
          claimName: requested-claim-by-user
      - emptyDir: {}
        name: shared-volume-manager
  updateStrategy:
    rollingUpdate:
      partition: 0
    type: RollingUpdate
  volumeClaimTemplates:
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      creationTimestamp: null
      labels:
        onDemand: "true"
        topology: acking
      name: manager-static-volume
    spec:
      accessModes:
      - ReadWriteOnce
      - ReadOnlyMany
      resources:
        requests:
          storage: 512Gi
      storageClassName: ""
      volumeMode: Block
    status:
      phase: Pending
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      creationTimestamp: null
      labels:
        onDemand: "true"
        topology: acking
      name: manager-dynamic-volume
    spec:
      accessModes:
      - ReadWriteOnce
      - ReadOnlyMany
      resources:
        requests:
          storage: 256Gi
      storageClassName: storage-class-name-manager
      volumeMode: Block
    status:
      phase: Pending
status:
  collisionCount: 0
  currentReplicas: 1
  currentRevision: acking-manager-7fd976b458
  observedGeneration: 1
  replicas: 1
  updateRevision: acking-manager-7fd976b458
  updatedReplicas: 1
```

</details>

<details><summary>Executor StatefulSet YAML</summary>

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  creationTimestamp: "2021-12-08T21:38:06Z"
  generation: 1
  labels:
    app: heron
    topology: acking
  name: acking-executors
  namespace: default
  resourceVersion: "2152"
  uid: e63998b2-cfb1-42e5-bc2e-0dfde936b7af
spec:
  podManagementPolicy: Parallel
  replicas: 2
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: heron
      topology: acking
  serviceName: acking
  template:
    metadata:
      annotations:
        prometheus.io/port: "8080"
        prometheus.io/scrape: "true"
      creationTimestamp: null
      labels:
        app: heron
        topology: acking
    spec:
      containers:
      - command:
        - sh
        - -c
        - './heron-core/bin/heron-downloader-config kubernetes && ./heron-core/bin/heron-downloader
          distributedlog://zookeeper:2181/heronbkdl/acking-saad-tag-0--7412350634992464132.tar.gz
          . && SHARD_ID=$((${POD_NAME##*-} + 1)) && echo shardId=${SHARD_ID} && ./heron-core/bin/heron-executor
          --topology-name=acking --topology-id=ackinga54c5c18-7bb1-485a-a4eb-9e16783d2eba
          --topology-defn-file=acking.defn --state-manager-connection=zookeeper:2181
          --state-manager-root=/heron --state-manager-config-file=./heron-conf/statemgr.yaml
          --tmanager-binary=./heron-core/bin/heron-tmanager --stmgr-binary=./heron-core/bin/heron-stmgr
          --metrics-manager-classpath=./heron-core/lib/metricsmgr/* --instance-jvm-opts="LVhYOitIZWFwRHVtcE9uT3V0T2ZNZW1vcnlFcnJvcg(61)(61)"
          --classpath=heron-api-examples.jar --heron-internals-config-file=./heron-conf/heron_internals.yaml
          --override-config-file=./heron-conf/override.yaml --component-ram-map=exclaim1:1073741824,word:1073741824
          --component-jvm-opts="" --pkg-type=jar --topology-binary-file=heron-api-examples.jar
          --heron-java-home=$JAVA_HOME --heron-shell-binary=./heron-core/bin/heron-shell
          --cluster=kubernetes --role=saad --environment=default --instance-classpath=./heron-core/lib/instance/*
          --metrics-sinks-config-file=./heron-conf/metrics_sinks.yaml --scheduler-classpath=./heron-core/lib/scheduler/*:./heron-core/lib/packing/*:./heron-core/lib/statemgr/*
          --python-instance-binary=./heron-core/bin/heron-python-instance --cpp-instance-binary=./heron-core/bin/heron-cpp-instance
          --metricscache-manager-classpath=./heron-core/lib/metricscachemgr/* --metricscache-manager-mode=disabled
          --is-stateful=false --checkpoint-manager-classpath=./heron-core/lib/ckptmgr/*:./heron-core/lib/statefulstorage/*:
          --stateful-config-file=./heron-conf/stateful.yaml --checkpoint-manager-ram=1073741824
          --health-manager-mode=disabled --health-manager-classpath=./heron-core/lib/healthmgr/*
          --shard=$SHARD_ID --server-port=6001 --tmanager-controller-port=6002 --tmanager-stats-port=6003
          --shell-port=6004 --metrics-manager-port=6005 --scheduler-port=6006 --metricscache-manager-server-port=6007
          --metricscache-manager-stats-port=6008 --checkpoint-manager-port=6009'
        env:
        - name: HOST
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: POD_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.name
        - name: var_one
          value: variable one
        - name: var_three
          value: variable three
        - name: var_two
          value: variable two
        image: apache/heron:testbuild
        imagePullPolicy: IfNotPresent
        name: executor
        ports:
        - containerPort: 5555
          name: tcp-port-kept
          protocol: TCP
        - containerPort: 5556
          name: udp-port-kept
          protocol: UDP
        - containerPort: 6001
          name: server
          protocol: TCP
        - containerPort: 6002
          name: tmanager-ctl
          protocol: TCP
        - containerPort: 6003
          name: tmanager-stats
          protocol: TCP
        - containerPort: 6004
          name: shell-port
          protocol: TCP
        - containerPort: 6005
          name: metrics-mgr
          protocol: TCP
        - containerPort: 6006
          name: scheduler
          protocol: TCP
        - containerPort: 6007
          name: metrics-cache-m
          protocol: TCP
        - containerPort: 6008
          name: metrics-cache-s
          protocol: TCP
        - containerPort: 6009
          name: ckptmgr
          protocol: TCP
        resources:
          limits:
            cpu: "3"
            memory: 4Gi
          requests:
            cpu: "3"
            memory: 4Gi
        securityContext:
          allowPrivilegeEscalation: false
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: path/to/mount/dynamic/volume
          name: executor-dynamic-volume
          subPath: sub/path/to/mount/dynamic/volume
        - mountPath: path/to/mount/shared/volume
          name: executor-shared-volume
          subPath: sub/path/to/mount/shared/volume
        - mountPath: path/to/mount/static/volume
          name: executor-static-volume
          subPath: sub/path/to/mount/static/volume
        - mountPath: /shared_volume
          name: shared-volume
      - image: alpine
        imagePullPolicy: Always
        name: sidecar-container
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /shared_volume
          name: shared-volume
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 0
      tolerations:
      - effect: NoExecute
        key: node.kubernetes.io/not-ready
        operator: Exists
        tolerationSeconds: 10
      - effect: NoExecute
        key: node.kubernetes.io/unreachable
        operator: Exists
        tolerationSeconds: 10
      volumes:
      - name: executor-shared-volume
        persistentVolumeClaim:
          claimName: requested-claim-by-user
      - emptyDir: {}
        name: shared-volume
  updateStrategy:
    rollingUpdate:
      partition: 0
    type: RollingUpdate
  volumeClaimTemplates:
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      creationTimestamp: null
      labels:
        onDemand: "true"
        topology: acking
      name: executor-dynamic-volume
    spec:
      accessModes:
      - ReadWriteOnce
      - ReadOnlyMany
      resources:
        requests:
          storage: 256Gi
      storageClassName: storage-class-name-executor
      volumeMode: Block
    status:
      phase: Pending
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      creationTimestamp: null
      labels:
        onDemand: "true"
        topology: acking
      name: executor-static-volume
    spec:
      accessModes:
      - ReadWriteOnce
      - ReadOnlyMany
      resources:
        requests:
          storage: 512Gi
      storageClassName: ""
      volumeMode: Block
    status:
      phase: Pending
status:
  collisionCount: 0
  currentReplicas: 2
  currentRevision: acking-executors-786f58c8f
  observedGeneration: 1
  replicas: 2
  updateRevision: acking-executors-786f58c8f
  updatedReplicas: 2
```

</details>