### PR TITLE
Updated to fix missing anticrlf dependency

### DIFF
--- a/heron/shell/src/python/BUILD
+++ b/heron/shell/src/python/BUILD
@@ -6,6 +6,7 @@ pex_library(
         ["**/*.py"],
     ),
     reqs = [
+        "logging-formatter-anticrlf==1.2",
         "requests==2.12.3",
         "tornado==4.5.3",
     ],

--- a/heron/shell/src/python/handlers/downloadhandler.py
+++ b/heron/shell/src/python/handlers/downloadhandler.py
@@ -23,6 +23,7 @@
 import os
 import logging
 import tornado.web
+import anticrlf
 
 from heron.shell.src.python import utils
 
@@ -35,7 +36,7 @@ class DownloadHandler(tornado.web.RequestHandler):
     """ get method """
 
     handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter('%(levelname)s:%(name)s:%(message)s'))
+    handler.setFormatter(anticrlf.LogFormatter('%(levelname)s:%(name)s:%(message)s'))
     logger = logging.getLogger(__name__)
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
It looks like we added anticrlf to heron-shell for security reasons in this PR. https://github.com/apache/incubator-heron/pull/3718

But then removed it here 10 days ago: https://github.com/apache/incubator-heron/pull/3746

This PR fixes the issue by adding the `anticrlf` dependency.