### PR TITLE
Kubernetes V1Controller Cleanup

### DIFF
--- a/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesUtils.java
+++ b/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/KubernetesUtils.java
@@ -90,6 +90,11 @@ final class KubernetesUtils {
     return String.format("%sMi", Long.toString(amount.asMegabytes()));
   }
 
+  static double roundDecimal(double value, int places) {
+    double scale = Math.pow(10, places);
+    return Math.round(value * scale) / scale;
+  }
+
   static class V1ControllerUtils<T> {
     private static final Logger LOG = Logger.getLogger(V1Controller.class.getName());
 

--- a/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
+++ b/heron/schedulers/tests/java/org/apache/heron/scheduler/kubernetes/V1ControllerTest.java
@@ -566,11 +566,11 @@ public class V1ControllerTest {
     final Quantity defaultRAM = Quantity.fromString(
         KubernetesUtils.Megabytes(resourceDefault.getRam()));
     final Quantity defaultCPU = Quantity.fromString(
-        Double.toString(V1Controller.roundDecimal(resourceDefault.getCpu(), 3)));
+        Double.toString(KubernetesUtils.roundDecimal(resourceDefault.getCpu(), 3)));
     final Quantity customRAM = Quantity.fromString(
         KubernetesUtils.Megabytes(resourceCustom.getRam()));
     final Quantity customCPU = Quantity.fromString(
-        Double.toString(V1Controller.roundDecimal(resourceCustom.getCpu(), 3)));
+        Double.toString(KubernetesUtils.roundDecimal(resourceCustom.getCpu(), 3)));
     final Quantity customDisk = Quantity.fromString(
         KubernetesUtils.Megabytes(resourceCustom.getDisk()));
 


### PR DESCRIPTION
There are no functional changes in this PR. I have added all the outstanding Javadocs to the methods in the `V1Controller` and relocated

https://github.com/apache/incubator-heron/blob/fd30626d70e3cc3284dcc527f9d0883f42ff1157/heron/schedulers/src/java/org/apache/heron/scheduler/kubernetes/V1Controller.java#L933-L936

to the more appropriate `KubernetesUtils` class.

Resolves #3707, #3723, #3747.