### PR TITLE
Helm chart cleanup

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -359,17 +359,17 @@ http_archive(
 http_archive(
     name = "helm_mac",
     build_file = "@//:third_party/helm/helm.BUILD",
-    sha256 = "3a9efe337c61a61b3e160da919ac7af8cded8945b75706e401f3655a89d53ef5",
+    sha256 = "5a0738afb1e194853aab00258453be8624e0a1d34fcc3c779989ac8dbcd59436",
     strip_prefix = "darwin-amd64",
-    urls = ["https://get.helm.sh/helm-v3.7.1-darwin-amd64.tar.gz"],
+    urls = ["https://get.helm.sh/helm-v3.7.2-darwin-amd64.tar.gz"],
 )
 
 http_archive(
     name = "helm_linux",
     build_file = "@//:third_party/helm/helm.BUILD",
-    sha256 = "6cd6cad4b97e10c33c978ff3ac97bb42b68f79766f1d2284cfd62ec04cd177f4",
+    sha256 = "4ae30e48966aba5f807a4e140dad6736ee1a392940101e4d79ffb4ee86200a9e",
     strip_prefix = "linux-amd64",
-    urls = ["https://get.helm.sh/helm-v3.7.1-linux-amd64.tar.gz"],
+    urls = ["https://get.helm.sh/helm-v3.7.2-linux-amd64.tar.gz"],
 )
 # end helm
 

--- a/deploy/kubernetes/helm/BUILD
+++ b/deploy/kubernetes/helm/BUILD
@@ -4,5 +4,5 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "chart",
-    srcs = glob(["templates/*.yaml"] + ["templates/*.txt"] + ["templates/*.tpl"] + ["*.lock"] + ["*.yaml"] + ["*.template"]),
+    srcs = glob(["templates/*.yaml"] + ["templates/*.txt"] + ["templates/*.tpl"] + ["*.lock"] + ["*.yaml"] + ["*.template"]) + ["//:disclaimers"],
 )

--- a/deploy/kubernetes/helm/Chart.yaml.template
+++ b/deploy/kubernetes/helm/Chart.yaml.template
@@ -14,16 +14,30 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-
-apiVersion: v1
-description: Heron is a fast distributed streaming engine for processing large data volumes with velocity
+---
+apiVersion: v2
 name: heron
 version: VERSION
+kubeVersion: 1.16
 appVersion: VERSION
-icon: https://apache.github.io/incubator-heron/img/HeronTextLogo-small.png
-home: http://heron.io
+description: Heron is a fast distributed streaming engine for processing large data volumes with velocity
+type: application
+keywords:
+  - apache
+  - streaming
+  - analytics
+  - heron
+  - heronpy
+  - apache-heron
+  - heron-helm
+home: https://heron.apache.org/
+icon: https://heron.apache.org/img/HeronTextLogo-small.png
 sources:
-  - https://github.com/apache/incubator-heron.git
+  - https://github.com/apache/incubator-heron/
+  - https://github.com/apache/incubator-heron/tree/master/deploy/kubernetes/helm/
+dependencies:
 maintainers:
-  - name: Karthik Ramasamy
-    email: kramasamy@gmail.com
+  - name: Apache Heron Developers
+    email: dev@heron.apache.org
+    url: https://heron.apache.org/
+annotations:

--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -687,7 +687,6 @@ genrule(
         "export HERON_VERSION=$$(grep version $$RELEASE_FILE_DIR/$(location :release.yaml) | awk '{print $$3}')",
         'export HERON_VERSION=$$(echo $$HERON_VERSION | sed -e "s/^\'//" -e "s/\'$$//")',
         "export HERON_VERSION=$$(echo $$HERON_VERSION | grep \"[0-9]*\\.[0-9]*\\.[0-9]*\")",
-        'export HERON_VERSION=$$([[ ! -z $$HERON_VERSION_EXT ]] && echo $$HERON_VERSION_EXT || echo $$HERON_VERSION)',
         'export HERON_VERSION=$$([[ -z $$HERON_VERSION ]] && echo "0.0.0" || echo $$HERON_VERSION)',
         "mkdir -p $$TMP_DIR $$HELM_DIR heron-charts",
         "cp $(SRCS) $$HELM_DIR",


### PR DESCRIPTION
1. Updated Helm to 3.7.2.
2. Added LICENSE, NOTICE and DISCLAIMER files to Helm chart
3. Updated the Helm chart.yaml `apiVersion` to `v2` (Helm 3.x)

Helm v2 is necessary to make the Helm chart discoverable in the apache.jfrog.org Helm repo.

I tried to find a way to instruct Helm to leave the commented LICENSE header in the Chart.yaml, but it seems the Chart.yaml is always processed to a final form with no comments.