### PR TITLE
libunwind 1.5.0 Upgrade

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -272,9 +272,9 @@ http_archive(
 http_archive(
     name = "org_nongnu_libunwind",
     build_file = "@//:third_party/libunwind/libunwind.BUILD",
-    sha256 = "4a6aec666991fb45d0889c44aede8ad6eb108071c3554fcdff671f9c94794976",
-    strip_prefix = "libunwind-1.6.2",
-    urls = ["https://github.com/libunwind/libunwind/releases/download/v1.6.2/libunwind-1.6.2.tar.gz"],
+    sha256 = "90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017",
+    strip_prefix = "libunwind-1.5.0",
+    urls = ["https://github.com/libunwind/libunwind/releases/download/v1.5/libunwind-1.5.0.tar.gz"],
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -272,9 +272,9 @@ http_archive(
 http_archive(
     name = "org_nongnu_libunwind",
     build_file = "@//:third_party/libunwind/libunwind.BUILD",
-    sha256 = "0a4b5a78d8c0418dfa610245f75fa03ad45d8e5e4cc091915d2dbed34c01178e",
-    strip_prefix = "libunwind-1.3.2",
-    urls = ["https://github.com/libunwind/libunwind/releases/download/v1.3.2/libunwind-1.3.2.tar.gz"],
+    sha256 = "4a6aec666991fb45d0889c44aede8ad6eb108071c3554fcdff671f9c94794976",
+    strip_prefix = "libunwind-1.6.2",
+    urls = ["https://github.com/libunwind/libunwind/releases/download/v1.6.2/libunwind-1.6.2.tar.gz"],
 )
 
 http_archive(


### PR DESCRIPTION
[libunwind](https://github.com/libunwind/libunwind) is used by C++ components to maintain function call history ([details](https://www.nongnu.org/libunwind/man/libunwind(3).html)). An upgrade is required to support newer Linux kernels.

Changes to this library are non-breaking and the changelog can be found [here](https://github.com/libunwind/libunwind/commits/master). Tests are all passing locally on Ubuntu 18.04.