### PR TITLE
Ubuntu 22.04 Support

### DIFF
--- a/docker/compile/Dockerfile.ubuntu22.04
+++ b/docker/compile/Dockerfile.ubuntu22.04
@@ -1,0 +1,55 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+FROM ubuntu:22.04
+
+# This is passed to the heron build command via the --config flag
+ENV TARGET_PLATFORM ubuntu
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get -y install \
+      ant \
+      g++ \
+      cmake \
+      automake \
+      libtool-bin \
+      libunwind8 \
+      patch \
+      python-is-python3 \
+      python3-dev \
+      python3-venv \
+      pkg-config \
+      wget \
+      zip \
+      unzip \
+      git \
+      curl \
+      tree \
+      openjdk-11-jdk-headless
+
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
+
+ENV bazelVersion 4.1.0
+
+RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/$bazelVersion/bazel-$bazelVersion-installer-linux-x86_64.sh \
+      && chmod +x /tmp/bazel.sh \
+      && /tmp/bazel.sh \
+      && rm -rf /tmp/bazel.sh
+
+ADD bazelrc /root/.bazelrc
+ADD scripts/compile-platform.sh /compile-platform.sh

--- a/third_party/gperftools/gperftools.BUILD
+++ b/third_party/gperftools/gperftools.BUILD
@@ -36,7 +36,7 @@ mac_script = "\n".join(common_script + [
 
 linux_script = "\n".join(common_script + [
      './configure --prefix=$$INSTALL_DIR --enable-shared=no CPPFLAGS=-I$$UNWIND_DIR/include LDFLAGS="-L$$UNWIND_DIR/lib -lunwind" --enable-frame-pointers',
-     'make install CPPFLAGS=-I$$UNWIND_DIR/include LDFLAGS="-L$$UNWIND_DIR/lib -lunwind"',
+     'make install CPPFLAGS="-I$$UNWIND_DIR/include -std=c++11" LDFLAGS="-L$$UNWIND_DIR/lib -lunwind"',
      'rm -rf $$TMP_DIR',
 ])
 

--- a/third_party/gperftools/gperftools.BUILD
+++ b/third_party/gperftools/gperftools.BUILD
@@ -36,7 +36,7 @@ mac_script = "\n".join(common_script + [
 
 linux_script = "\n".join(common_script + [
      './configure --prefix=$$INSTALL_DIR --enable-shared=no CPPFLAGS=-I$$UNWIND_DIR/include LDFLAGS="-L$$UNWIND_DIR/lib -lunwind" --enable-frame-pointers',
-     'make install CPPFLAGS="-I$$UNWIND_DIR/include -std=c++11" LDFLAGS="-L$$UNWIND_DIR/lib -lunwind"',
+     'make install CPPFLAGS="-I$$UNWIND_DIR/include -std=c++14" LDFLAGS="-L$$UNWIND_DIR/lib -lunwind"',
      'rm -rf $$TMP_DIR',
 ])
 


### PR DESCRIPTION
This PR adds support for Ubuntu 22.04 LTS which is slated for release in Q2 2022 and builds on PR #3760.

The `libunwind` library uses dynamically generated exceptions and the latest C++ standard to support this is C++14. By default `g++ 11.2` will use C++17 and this will cause compiler errors. To remedy this I have added the standard specification flag to the compiling and linking of `libunwind`.