### PR TITLE
Updated Docker rules to 0.22.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -373,13 +373,11 @@ http_archive(
 # end helm
 
 # for docker image building
-DOCKER_RULES_VERSION = "0.14.4"
-
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
-    strip_prefix = "rules_docker-%s" % DOCKER_RULES_VERSION,
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v%s.tar.gz" % DOCKER_RULES_VERSION],
+    sha256 = "59536e6ae64359b716ba9c46c39183403b01eabfbd57578e84398b4829ca499a",
+    strip_prefix = "rules_docker-0.22.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.22.0/rules_docker-v0.22.0.tar.gz"],
 )
 
 load(

--- a/scripts/images/BUILD
+++ b/scripts/images/BUILD
@@ -8,7 +8,7 @@ container_image(
         "-n",
     ],
     directory = "/heron",
-    stamp = 1,
+    stamp = "@io_bazel_rules_docker//stamp:always",
     symlinks = {
         "/usr/local/bin/heron": "/heron/heron-tools/bin/heron",
         "/usr/local/bin/heron-explorer": "/heron/heron-tools/bin/heron-explorer",


### PR DESCRIPTION
Updated to newer Bazel docker rules.

https://github.com/bazelbuild/rules_docker/releases/tag/v0.22.0