### PR TITLE
Fixed stmgr unittest segfault issue on macOS

### DIFF
--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -682,9 +682,7 @@ void TearCommonResources(CommonResources& common) {
 
   common.ss_list_.clear();
 
-  for (auto itr = common.instanceid_instance_.begin();
-       itr != common.instanceid_instance_.end(); ++itr)
-      common.instanceid_instance_.erase(itr->first);
+  common.instanceid_instance_.clear();
 
   // Clean up the local filesystem state
   FileUtils::removeRecursive(common.dpath_, true);


### PR DESCRIPTION
This fixes an issue in which we deleted an item in a loop which invalidated the iterator. An example can be found here: https://stackoverflow.com/a/4636230

Could update to use the returned `itr` as shown below:
```
  for (auto itr = common.instanceid_instance_.begin();
       itr != common.instanceid_instance_.end(); ++itr)
      itr = common.instanceid_instance_.erase(itr);
```
But I instead opted for the `map.clear()` because the map values are of type `shared_ptr`.