### PR TITLE
Fixing an incorrect use of KubeVersion in the Helm Chart.yml

### DIFF
--- a/deploy/kubernetes/helm/Chart.yaml.template
+++ b/deploy/kubernetes/helm/Chart.yaml.template
@@ -18,7 +18,7 @@
 apiVersion: v2
 name: heron
 version: VERSION
-kubeVersion: 1.16
+kubeVersion: >= 1.16
 appVersion: VERSION
 description: Heron is a fast distributed streaming engine for processing large data volumes with velocity
 type: application


### PR DESCRIPTION
When I added `kubeVersion` I mistakenly made the Helm chart only work for Kubernetes 1.16. This PR corrects the behavior to the original intention. Kubernetes 1.16 as a minimum version.