### PR TITLE
Remove fixed young generation heap space of instance

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -612,13 +612,8 @@ class HeronExecutor:
       java_metasize_param = 'PermSize'
     xmn_param = '-Xmn%dM' % xmn_size
     if self._get_java_major_version() >= 11:
-        # For Java 11 and above.
-        # The Xmx value is 25% of the available memory with a maximum of 25 GB.
-        # However, where there is 2 GB or less of physical memory,
-        # the value set is 50% of available memory with a minimum value of 16 MB and a maximum value of 512 MB.
-        # For Java 8
-        # The Xmx value is half the available memory with a minimum of 16 MB and a maximum of 512 MB.
-        xmn_param = None
+      # Remove '-Xmn'
+      xmn_param = None
 
     instance_options = [
         '-Xmx%dM' % heap_size_mb,

--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -146,7 +146,7 @@ class HeronExecutorTest(unittest.TestCase):
 
   def get_expected_instance_command(component_name, instance_id, container_id):
     instance_name = "container_%d_%s_%d" % (container_id, component_name, instance_id)
-    return "heron_java_home/bin/java -Xmx320M -Xms320M -Xmn160M -XX:MaxMetaspaceSize=128M " \
+    return "heron_java_home/bin/java -Xmx320M -Xms320M -XX:MaxMetaspaceSize=128M " \
            "-XX:MetaspaceSize=128M -XX:ReservedCodeCacheSize=64M -XX:+PrintCommandLineFlags " \
            "-Djava.net.preferIPv4Stack=true " \
            "-XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication " \


### PR DESCRIPTION
It seems that it is not suitable for JVM 11 or higher to statically allocate 50% heap.

Ref: 
```
For Java 11 and above
The Xmx value is 25% of the available memory with a maximum of 25 GB. 
However, where there is 2 GB or less of physical memory, the value set is 50% of available memory with 
a minimum value of 16 MB and a maximum value of 512 MB.
For Java 8
The Xmx value is half the available memory with a minimum of 16 MB and a maximum of 512 MB.
```

https://blog.openj9.org/2020/04/30/default-java-maximum-heap-size-is-changed-for-java-8/

