### PR TITLE
Fix git url

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -163,7 +163,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "com_github_johnynek_bazel_jar_jar",
     commit = "171f268569384c57c19474b04aebe574d85fde0d", # Latest commit SHA as at 2019/02/13
-    remote = "git://github.com/johnynek/bazel_jar_jar.git",
+    remote = "https://github.com/johnynek/bazel_jar_jar.git",
     shallow_since = "1594234634 -1000",
 )
 


### PR DESCRIPTION

```
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
ERROR: Error fetching repository: Traceback (most recent call last):
	File "/private/var/tmp/_bazel_thinker0/1db3221e319a1f6b3420bd0c6f4d8d08/external/bazel_tools/tools/build_defs/repo/git.bzl", line 181, column 30, in _git_repository_implementation
		update = _clone_or_update(ctx)
	File "/private/var/tmp/_bazel_thinker0/1db3221e319a1f6b3420bd0c6f4d8d08/external/bazel_tools/tools/build_defs/repo/git.bzl", line 36, column 20, in _clone_or_update
		git_ = git_repo(ctx, directory)
	File "/private/var/tmp/_bazel_thinker0/1db3221e319a1f6b3420bd0c6f4d8d08/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 91, column 12, in git_repo
		_update(ctx, git_repo)
	File "/private/var/tmp/_bazel_thinker0/1db3221e319a1f6b3420bd0c6f4d8d08/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 103, column 10, in _update
		fetch(ctx, git_repo)
	File "/private/var/tmp/_bazel_thinker0/1db3221e319a1f6b3420bd0c6f4d8d08/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 136, column 13, in fetch
		_git(
	File "/private/var/tmp/_bazel_thinker0/1db3221e319a1f6b3420bd0c6f4d8d08/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 169, column 15, in _git
		_error(ctx.name, start + list(args), st.stderr)
	File "/private/var/tmp/_bazel_thinker0/1db3221e319a1f6b3420bd0c6f4d8d08/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 190, column 9, in _error
		fail("error running '%s' while working with @%s:\n%s" % (command_text, name, stderr))
Error in fail: error running 'git fetch origin refs/heads/*:refs/remotes/origin/* refs/tags/*:refs/tags/*' while working with @com_github_johnynek_bazel_jar_jar:
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
ERROR: no such package '@com_github_johnynek_bazel_jar_jar//': error running 'git fetch origin refs/heads/*:refs/remotes/origin/* refs/tags/*:refs/tags/*' while working with @com_github_johnynek_bazel_jar_jar:
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
```