### PR TITLE
Replace Helm chart's generic Bookkeeper platform property with specific properties

### DIFF
--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -45,7 +45,7 @@ data:
   BK_journalMaxBackups: "{{ .Values.bookieJournalMaxBackups }}"
   BK_journalMaxSizeMB: "{{ .Values.bookieJournalMaxSizeMB }}"
   BK_logSizeLimit: "{{ int64 .Values.bookieLogSizeLimit }}"
-  {{- if or (eq .Values.platform "gke") (eq .Values.platform "minikube") }}
+  {{- if .Values.useHostNameAsBookieID }}
   BK_useHostNameAsBookieID: "true"
   {{- end }}
   # TODO: Issue 458: https://github.com/apache/bookkeeper/issues/458
@@ -60,7 +60,7 @@ data:
 ## cannot be moved across different nodes.
 ## For this reason, we run BK as a daemon set, one for each node in the
 ## cluster, unless restricted by label selectors
-{{- if or (eq .Values.platform "gke") (eq .Values.platform "minikube") }}
+{{- if .Values.useStatefulSet }}
 apiVersion: apps/v1
 kind: StatefulSet
 {{- else }}
@@ -79,7 +79,7 @@ spec:
       app: {{ .Release.Name }}-bookkeeper
       component: {{ .Release.Name }}-bookie
       cluster: {{ .Release.Name }}-bookkeeper
-{{- if or (eq .Values.platform "gke") (eq .Values.platform "minikube") }}
+{{- if .Values.createReplicas }}
   serviceName: {{ .Release.Name }}-bookie
   replicas: {{ $bookieReplicas }}
 {{- end }}
@@ -97,7 +97,7 @@ spec:
         prometheus.io/port: "8000"
 
     spec:
-{{- if eq .Values.platform "gke" }}
+{{- if .Values.affinityPods }}
       # Make sure multiple pods of bookkeeper don't get scheduled on the
       # same node, unless there are no other available nodes
       affinity:
@@ -154,7 +154,7 @@ spec:
             - name: ledgers-disk
               mountPath: /bookkeeper/data/ledgers
 
-{{- if or (eq .Values.platform "aws") (eq .Values.platform "baremetal") }}
+{{- if .Values.mountLocalDisk }}
       volumes:
           # Mount local disks
         - name: journal-disk
@@ -165,7 +165,7 @@ spec:
             path: /bookkeeper/data/ledgers
 {{- end }}
 
-{{- if or (eq .Values.platform "gke") (eq .Values.platform "minikube") }}
+{{- if .Values.formatDisks }}
   volumeClaimTemplates:
     - metadata:
         name: journal-disk
@@ -206,7 +206,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if or (eq .Values.platform "gke") (eq .Values.platform "minikube") }}
+  {{- if .Values.tolerateUnreadyEndpoints }}
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   {{- end }}

--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -45,7 +45,7 @@ data:
   BK_journalMaxBackups: "{{ .Values.bookieJournalMaxBackups }}"
   BK_journalMaxSizeMB: "{{ .Values.bookieJournalMaxSizeMB }}"
   BK_logSizeLimit: "{{ int64 .Values.bookieLogSizeLimit }}"
-  {{- if .Values.useHostNameAsBookieID }}
+  {{- if .Values.bookkeeper.useHostNameAsBookieID }}
   BK_useHostNameAsBookieID: "true"
   {{- end }}
   # TODO: Issue 458: https://github.com/apache/bookkeeper/issues/458
@@ -60,7 +60,7 @@ data:
 ## cannot be moved across different nodes.
 ## For this reason, we run BK as a daemon set, one for each node in the
 ## cluster, unless restricted by label selectors
-{{- if .Values.useStatefulSet }}
+{{- if .Values.bookkeeper.useStatefulSet }}
 apiVersion: apps/v1
 kind: StatefulSet
 {{- else }}
@@ -79,7 +79,7 @@ spec:
       app: {{ .Release.Name }}-bookkeeper
       component: {{ .Release.Name }}-bookie
       cluster: {{ .Release.Name }}-bookkeeper
-{{- if .Values.createReplicas }}
+{{- if .Values.bookkeeper.createReplicas }}
   serviceName: {{ .Release.Name }}-bookie
   replicas: {{ $bookieReplicas }}
 {{- end }}
@@ -97,7 +97,7 @@ spec:
         prometheus.io/port: "8000"
 
     spec:
-{{- if .Values.affinityPods }}
+{{- if .Values.bookkeeper.affinityPods }}
       # Make sure multiple pods of bookkeeper don't get scheduled on the
       # same node, unless there are no other available nodes
       affinity:
@@ -154,7 +154,7 @@ spec:
             - name: ledgers-disk
               mountPath: /bookkeeper/data/ledgers
 
-{{- if .Values.mountLocalDisk }}
+{{- if .Values.bookkeeper.useHostPath }}
       volumes:
           # Mount local disks
         - name: journal-disk
@@ -165,7 +165,7 @@ spec:
             path: /bookkeeper/data/ledgers
 {{- end }}
 
-{{- if .Values.formatDisks }}
+{{- if .Values.bookkeeper.useVolumeClaimTemplate }}
   volumeClaimTemplates:
     - metadata:
         name: journal-disk
@@ -206,7 +206,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.tolerateUnreadyEndpoints }}
+  {{- if .Values.bookkeeper.tolerateUnreadyEndpoints }}
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   {{- end }}

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -19,28 +19,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# The environment where Heron will be running
-# The following values are valid:
-# "aws" - Amazon Web Services
-# "gke" - Google Kubernetes Engine
-# "minikube" - Kubernetes on a single local node
-# "baremetal" - On-premise cluster
-platform: minikube
-
 # Heron image to use
 image: apache/heron:VERSION
 
 # Heron image pull policy
 imagePullPolicy: IfNotPresent
-
-# Optional Variables
-useHostNameAsBookieID: true
-useStatefulSet: true
-createReplicas: true
-affinityPods: false
-mountLocalDisk: false
-formatDisks: true
-tolerateUnreadyEndpoints: true
 
 # Number of replicas for the job binary in bookkeeper
 jobReplicas: 1
@@ -114,6 +97,14 @@ bookkeeper:
   storageClassName: "none"
   prometheus:
     enabled: false
+  # Optional Variables
+  useHostNameAsBookieID: true
+  useStatefulSet: true
+  createReplicas: true
+  affinityPods: false
+  useHostPath: false
+  useVolumeClaimTemplate: true
+  tolerateUnreadyEndpoints: true
 
 zookeeper:
   enabled: true

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -33,6 +33,15 @@ image: apache/heron:VERSION
 # Heron image pull policy
 imagePullPolicy: IfNotPresent
 
+# Optional Variables
+useHostNameAsBookieID: true
+useStatefulSet: true
+createReplicas: true
+affinityPods: false
+mountLocalDisk: false
+formatDisks: true
+tolerateUnreadyEndpoints: true
+
 # Number of replicas for the job binary in bookkeeper
 jobReplicas: 1
 


### PR DESCRIPTION
This pull request removes the antiquated use of `platform` property which assumed certain combinations of Bookkeeper settings based on early incarnations of Kubernetes. This PR will create unique configurable settings for each of the features. This will allow greater flexibility for Heron users choosing to create clusters in Kubernetes.

Fixes #3770 