### PR TITLE
Updated to fix MacOS stylecheck RuntimeError

### DIFF
--- a/tools/java/src/org/apache/bazel/cppcheck/CppCheck.java
+++ b/tools/java/src/org/apache/bazel/cppcheck/CppCheck.java
@@ -135,6 +135,7 @@ public final class CppCheck {
                     Predicates.not(Predicates.containsPattern("external/")),
                     Predicates.not(Predicates.containsPattern("third_party/")),
                     Predicates.not(Predicates.containsPattern("config/heron-config.h")),
+                    Predicates.not(Predicates.containsPattern(".*cppmap")),
                     Predicates.not(Predicates.containsPattern(".*pb.h$")),
                     Predicates.not(Predicates.containsPattern(".*cc_wrapper.sh$")),
                     Predicates.not(Predicates.containsPattern(".*pb.cc$"))


### PR DESCRIPTION
Style check worked on Linux, but when I tested on MacOS it failed. This PR helps resolve the issue.

The build was hitting on an error parsing a "crosstool" line. This filter helped ignore the cppmap which was referencing protobuf generated source.