### PR TITLE
Update rules-scala of Scala

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -474,27 +474,44 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
 # scala integration
-rules_scala_version = "358ab829626c6c2d34ec27f856485d3121e299c7"  # Jan 15 2020 - update this as needed
-
 http_archive(
     name = "io_bazel_rules_scala",
-    sha256 = "5abd638278de10ccccb0b4d614158f394278b828708ba990461334ecc01529a6",
-    strip_prefix = "rules_scala-%s" % rules_scala_version,
+    sha256 = "77a3b9308a8780fff3f10cdbbe36d55164b85a48123033f5e970fdae262e8eb2",
+    strip_prefix = "rules_scala-20220201",
     type = "zip",
-    url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip" % rules_scala_version,
+    url = "https://github.com/bazelbuild/rules_scala/releases/download/20220201/rules_scala-20220201.zip",
 )
+
+skylib_version = "1.0.3"
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+    type = "tar.gz",
+    url = "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
+)
+
+load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+
+scala_config(scala_version = "2.12.15")
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 
-scala_repositories((
-    "2.12.8",
-    {
-        "scala_compiler": "f34e9119f45abd41e85b9e121ba19dd9288b3b4af7f7047e86dc70236708d170",
-        "scala_library": "321fb55685635c931eba4bc0d7668349da3f2c09aee2de93a70566066ff25c28",
-        "scala_reflect": "4d6405395c4599ce04cea08ba082339e3e42135de9aae2923c9f5367e957315a",
-    },
-))
+scala_repositories()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 
 scala_register_toolchains()
+
+# optional: setup ScalaTest toolchain and dependencies
+load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
+
+scalatest_repositories()
+
+scalatest_toolchain()

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -21,6 +21,8 @@ build --host_force_python=PY3
 build --ignore_unsupported_sandboxing
 build --spawn_strategy=standalone
 build --workspace_status_command scripts/release/status.sh
+build --strategy=Scalac=worker
+build --worker_sandboxing
 
 # To enable stylecheck
 # To use it: bazel build --config=stylecheck


### PR DESCRIPTION
Update rules-scala of Scala

https://github.com/bazelbuild/rules_scala#getting-started

The following error has been resolved in the JDK higher version.
```
ERROR: /Users/thinker0/opensource/heron/heron/api/tests/scala/BUILD:1:11: scala //heron/api/tests/scala:api-scala-test failed: (Exit 1): scalac failed: error executing command bazel-out/darwin-fastbuild/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac @bazel-out/darwin-fastbuild/bin/heron/api/tests/scala/api-scala-test_scalac_worker_input
error: java.io.IOError: java.lang.RuntimeException: /packages cannot be represented as URI
	at java.base/jdk.internal.jrtfs.JrtPath.toUri(JrtPath.java:175)
	at scala.tools.nsc.classpath.JrtClassPath.asURLs(DirectoryClassPath.scala:213)
...
	at scala.tools.nsc.Driver.process(Driver.scala:67)
	at io.bazel.rulesscala.scalac.ScalacProcessor.compileScalaSources(ScalacProcessor.java:219)
	at io.bazel.rulesscala.scalac.ScalacProcessor.processRequest(ScalacProcessor.java:69)
	at io.bazel.rulesscala.worker.GenericWorker.run(GenericWorker.java:114)
	at io.bazel.rulesscala.scalac.ScalaCInvoker.main(ScalaCInvoker.java:41)
Caused by: java.lang.RuntimeException: /packages cannot be represented as URI
	... 125 more
Exception in thread "main" java.io.IOError: java.lang.RuntimeException: /packages cannot be represented as URI
	at java.base/jdk.internal.jrtfs.JrtPath.toUri(JrtPath.java:175)
	at scala.tools.nsc.classpath.JrtClassPath.asURLs(DirectoryClassPath.scala:213)
	at scala.tools.nsc.MainClass.doCompile(Main.scala:32)
	at scala.tools.nsc.Driver.process(Driver.scala:67)
	at io.bazel.rulesscala.scalac.ScalacProcessor.compileScalaSources(ScalacProcessor.java:219)
	at io.bazel.rulesscala.scalac.ScalacProcessor.processRequest(ScalacProcessor.java:69)
	at io.bazel.rulesscala.worker.GenericWorker.run(GenericWorker.java:114)
	at io.bazel.rulesscala.scalac.ScalaCInvoker.main(ScalaCInvoker.java:41)
Caused by: java.lang.RuntimeException: /packages cannot be represented as URI
	... 125 more

```