### PR TITLE
Rearrange values.yaml to better style

### DIFF
--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -20,14 +20,15 @@
 ## A reference of https://github.com/apache/incubator-pulsar/blob/master/kubernetes/google-container-engine/bookie.yaml
 
 {{- $platform := .Values.platform }}
-{{- $bookieReplicas := .Values.bookieReplicas }}
-{{- $bookieCpuMin := .Values.bookieCpuMin }}
-{{- $bookieCpuMax := .Values.bookieCpuMax }}
-{{- $bookieHeapMemory := .Values.bookieHeapMemory }}
-{{- $bookieDirectMemory := .Values.bookieDirectMemory }}
-{{- $bookieJournalCapacity := .Values.bookieJournalCapacity }}
-{{- $bookieStorageCapacity := .Values.bookieStorageCapacity }}
-{{- $bookieStorageHostPath := .Values.bookieStorageHostPath }}
+{{- $bookieReplicas := .Values.bookkeeper.replicas }}
+{{- $bookieCpuMin := .Values.bookkeeper.resources.cpuMin }}
+{{- $bookieCpuMax := .Values.bookkeeper.resources.cpuMax }}
+{{- $bookieHeapMemory := .Values.bookkeeper.resources.heapMemory }}
+{{- $bookieDirectMemory := .Values.bookkeeper.resources.directMemory }}
+{{- $bookieJournalCapacity := .Values.bookkeeper.journal.capacity }}
+{{- $bookieJournalHostPath := .Values.bookkeeper.journal.hostPath }}
+{{- $bookieLedgersCapacity := .Values.bookkeeper.ledgers.capacity }}
+{{- $bookieLedgersHostPath := .Values.bookkeeper.ledgers.hostPath }}
 
 apiVersion: v1
 kind: ConfigMap
@@ -42,9 +43,9 @@ data:
   BK_indexDirectories: "/bookkeeper/data/ledgers" 
   BK_zkServers: {{ .Release.Name }}-zookeeper:{{ .Values.zookeeper.clientPort }}
   BK_autoRecoveryDaemonEnabled: "true"
-  BK_journalMaxBackups: "{{ .Values.bookieJournalMaxBackups }}"
-  BK_journalMaxSizeMB: "{{ .Values.bookieJournalMaxSizeMB }}"
-  BK_logSizeLimit: "{{ int64 .Values.bookieLogSizeLimit }}"
+  BK_journalMaxBackups: "{{ .Values.bookkeeper.journal.maxBackups }}"
+  BK_journalMaxSizeMB: "{{ .Values.bookkeeper.journal.maxSizeMB }}"
+  BK_logSizeLimit: "{{ int64 .Values.bookkeeper.logSizeLimit }}"
   {{- if .Values.bookkeeper.useHostNameAsBookieID }}
   BK_useHostNameAsBookieID: "true"
   {{- end }}
@@ -159,10 +160,10 @@ spec:
           # Mount local disks
         - name: journal-disk
           hostPath:
-            path: /bookkeeper/data/journal
+            path: {{ $bookieJournalHostPath }}
         - name: ledgers-disk
           hostPath:
-            path: /bookkeeper/data/ledgers
+            path: {{ $bookieLedgersHostPath }}
 {{- end }}
 
 {{- if .Values.bookkeeper.useVolumeClaimTemplate }}
@@ -194,7 +195,7 @@ spec:
         {{- end }}
         resources:
           requests:
-            storage: {{ $bookieStorageCapacity }}
+            storage: {{ $bookieLedgersCapacity }}
 {{- end }}
 
 ---

--- a/deploy/kubernetes/helm/templates/zookeeper.yaml
+++ b/deploy/kubernetes/helm/templates/zookeeper.yaml
@@ -16,7 +16,7 @@
 #  under the License.
 
 {{- $platform := .Values.platform }}
-{{- $zkReplicas := .Values.zkReplicas }}
+{{- $zkReplicas := .Values.zookeeper.replicas }}
 
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -72,43 +72,54 @@ disablePodTemplates: false
 # Support for Voume specification from CLI input
 disableVolumesFromCLI: false
 
-# Number of replicas for storage bookies, memory and storage requirements
-bookieReplicas: 3
-bookieCpuMin: 100m
-bookieCpuMax: 250m
-bookieHeapMemory: 512M
-bookieDirectMemory: 256M
-bookieReadCacheSize: 32
-bookieWriteCacheSize: 32
-bookieJournalCapacity: 5G
-bookieStorageCapacity: 15G
-bookieJournalMaxBackups: 3
-bookieJournalMaxSizeMB: 300
-bookieLogSizeLimit: 10000000
 
 # Number of replicas for zookeeper
 zkReplicas: 3
 
+
 bookkeeper:
   image: apache/bookkeeper:4.13.0
   imagePullPolicy: IfNotPresent
-  
+
   # set storageClassName to "none" to not use storageClassName
   storageClassName: "none"
+
+  replicas: 3
+  createReplicas: true
+  useStatefulSet: true
+  affinityPods: false
+  useVolumeClaimTemplate: true
+
+  logSizeLimit: 10000000
+  useHostNameAsBookieID: true
+  tolerateUnreadyEndpoints: true
+
   prometheus:
     enabled: false
-  # Optional Variables
-  useHostNameAsBookieID: true
-  useStatefulSet: true
-  createReplicas: true
-  affinityPods: false
+
+  resources:
+    cpuMin: 100m
+    cpuMax: 250m
+    heapMemory: 512M
+    directMemory: 256M
+    readCacheSize: 32
+    writeCacheSize: 32
+
   useHostPath: false
-  useVolumeClaimTemplate: true
-  tolerateUnreadyEndpoints: true
+  journal:
+    capacity: 5G
+    maxBackups: 3
+    maxSizeMB: 300
+    hostPath: '/opt/bookkeeper/joural-disk'
+  ledgers:
+    capacity: 15G
+    hostPath: '/opt/bookkeeper/ledgers-disk'
+
 
 zookeeper:
   enabled: true
   minAvailable: 1
+  replicas: 3
   resources:
     requests:
       cpu: 500m


### PR DESCRIPTION
bookkeeper now uses hostpath to control the path instead of default /bookkeeper/
Renaming storage -> ledgers