### PR TITLE
Removed random long in filename which caused leaking in upload storage

### DIFF
--- a/deploy/kubernetes/helm/templates/bookie.yaml
+++ b/deploy/kubernetes/helm/templates/bookie.yaml
@@ -43,9 +43,6 @@ data:
   BK_indexDirectories: "/bookkeeper/data/ledgers" 
   BK_zkServers: {{ .Release.Name }}-zookeeper:{{ .Values.zookeeper.clientPort }}
   BK_autoRecoveryDaemonEnabled: "true"
-  BK_journalMaxBackups: "{{ .Values.bookkeeper.journal.maxBackups }}"
-  BK_journalMaxSizeMB: "{{ .Values.bookkeeper.journal.maxSizeMB }}"
-  BK_logSizeLimit: "{{ int64 .Values.bookkeeper.logSizeLimit }}"
   {{- if .Values.bookkeeper.useHostNameAsBookieID }}
   BK_useHostNameAsBookieID: "true"
   {{- end }}

--- a/deploy/kubernetes/helm/values.yaml.template
+++ b/deploy/kubernetes/helm/values.yaml.template
@@ -89,8 +89,6 @@ bookkeeper:
   useStatefulSet: true
   affinityPods: false
   useVolumeClaimTemplate: true
-
-  logSizeLimit: 10000000
   useHostNameAsBookieID: true
   tolerateUnreadyEndpoints: true
 
@@ -108,8 +106,6 @@ bookkeeper:
   useHostPath: false
   journal:
     capacity: 5G
-    maxBackups: 3
-    maxSizeMB: 300
     hostPath: '/opt/bookkeeper/joural-disk'
   ledgers:
     capacity: 15G

--- a/heron/spi/src/java/org/apache/heron/spi/utils/UploaderUtils.java
+++ b/heron/spi/src/java/org/apache/heron/spi/utils/UploaderUtils.java
@@ -23,7 +23,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Random;
 
 /**
  * Utility used by Uploader

--- a/heron/spi/src/java/org/apache/heron/spi/utils/UploaderUtils.java
+++ b/heron/spi/src/java/org/apache/heron/spi/utils/UploaderUtils.java
@@ -65,8 +65,8 @@ public final class UploaderUtils {
       String tag,
       int version,
       String extension) {
-    return String.format("%s-%s-%s-%d-%d%s",
-        topologyName, role, tag, version, new Random().nextLong(), extension);
+    return String.format("%s-%s-%s-%d%s",
+        topologyName, role, tag, version, extension);
   }
 
   public static void copyToOutputStream(String inFile,

--- a/heron/spi/tests/java/org/apache/heron/spi/utils/UploaderUtilsTest.java
+++ b/heron/spi/tests/java/org/apache/heron/spi/utils/UploaderUtilsTest.java
@@ -37,19 +37,26 @@ public class UploaderUtilsTest {
 
   @Test
   public void testGenerateFilename() throws Exception {
-    int expectedUniqueFilename = 10000;
+    int requestsForFilename = 2;
     String topologyName = "topologyName";
     String role = "role";
     String tag = "";
     int version = -1;
     Set<String> filenames = new HashSet<>();
-    for (int i = 0; i < expectedUniqueFilename; i++) {
+    for (int i = 0; i < requestsForFilename; i++) {
       filenames.add(UploaderUtils.generateFilename(
           topologyName, role, tag, version, ""));
     }
 
-    // All filenames should be unique
-    Assert.assertEquals(expectedUniqueFilename, filenames.size());
+    // There should not be multiple entries
+    Assert.assertEquals(1, filenames.size());
+
+    int newVersion = 1;
+    filenames.add(UploaderUtils.generateFilename(
+        topologyName, role, tag, newVersion, ""));
+
+    // Each version should provide a unique filename
+    Assert.assertEquals(2, filenames.size());
   }
 
   @Test


### PR DESCRIPTION
Fixes #3769 

If you exec into the Bookkeeper pod, you can run the following command in `/opt/bookkeeper/bin`
`./dlog tool watch -u distributedlog://heron-zookeeper:2181/heron`

When I upload the same package, I can see it deleting the old one, and then uploading the new one
```
Old streams :
acking-root-tag-0.tar.gz
New streams :

Old streams :
New streams :
acking-root-tag-0.tar.gz
```

Without this fix, this [bit of code](https://github.com/apache/incubator-heron/blob/f3762f65cd101459d32a431977e980b69155f4ad/heron/uploaders/src/java/org/apache/heron/uploader/dlog/DLUploader.java#L181) is never executed. The package name never matches, so it never deletes the old package.