### PR TITLE
Added missing epel-release repo in Rocky8 Dist image Dockerfile

### DIFF
--- a/docker/dist/Dockerfile.dist.centos7
+++ b/docker/dist/Dockerfile.dist.centos7
@@ -21,8 +21,9 @@ FROM centos:centos7
 ENV TARGET_PLATFORM linux
 ENV LC_ALL en_US.utf8
 
-RUN yum -y upgrade && yum -y install centos-release-scl-rh
-RUN yum -y install epel-release \
+RUN yum -y upgrade \
+    && yum -y install centos-release-scl-rh \
+    && yum -y install epel-release \
     && yum -y install \
     curl \
     java-11-openjdk-headless \

--- a/docker/dist/Dockerfile.dist.rocky8
+++ b/docker/dist/Dockerfile.dist.rocky8
@@ -19,6 +19,7 @@
 FROM rockylinux:8.5
 
 RUN yum -y upgrade \
+    && yum -y install epel-release \
     && yum -y install \
     curl \
     java-11-openjdk-headless \


### PR DESCRIPTION
The `supervisor` package is not available unless `epel-release` repo is installed.