### PR TITLE
Remove stray space characters between \ and \n

### DIFF
--- a/website2/docs/getting-started-docker.md
+++ b/website2/docs/getting-started-docker.md
@@ -30,16 +30,16 @@ The official Apache Heron Docker image is located at the link below
 In one terminal execute to start Heron in a container
 
 ```bash
-$ docker run -it  --rm \ 
-   -p 8889:8889 \ 
-   -p 8888:8888 \ 
-   --name local-heron \ 
+$ docker run -it  --rm \
+   -p 8889:8889 \
+   -p 8888:8888 \
+   --name local-heron \
    apache/heron:0.20.4-incubating supervisord --nodaemon
 ```
 In another terminal execute the following to deploy a job:
 ```bash
-$ docker exec -it \ 
-   local-heron \ 
+$ docker exec -it \
+   local-heron \
    bash -c "heron submit sandbox  /heron/examples/heron-eco-examples.jar org.apache.heron.eco.Eco --eco-config-file /heron/examples/heron_wordcount.yaml"
 ```
 


### PR DESCRIPTION
The example bash shell commands in this document are wrapped onto multiple lines with
backslashes for legibility. However, there are space characters inserted after the backslash
escapes, breaking the commands: the spaces are being escaped, not the newlines. An
attempt to copy and paste the commands directly from the documentation will fail.

Remove the spaces to fix the commands.